### PR TITLE
Support Query Extraction

### DIFF
--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
@@ -1,7 +1,9 @@
 package com.linecorp.kotlinjdsl.querydsl.where
 
 import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
+import com.linecorp.kotlinjdsl.querydsl.expression.ExpressionDsl
+import com.linecorp.kotlinjdsl.querydsl.predicate.PredicateDsl
 
-interface WhereDsl {
+interface WhereDsl : ExpressionDsl, PredicateDsl {
     fun where(predicate: PredicateSpec)
 }

--- a/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryIntegrationTest.kt
+++ b/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryIntegrationTest.kt
@@ -3,6 +3,10 @@ package com.linecorp.kotlinjdsl.spring.data
 import com.linecorp.kotlinjdsl.query.creator.CriteriaQueryCreatorImpl
 import com.linecorp.kotlinjdsl.query.creator.SubqueryCreatorImpl
 import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.querydsl.expression.column
+import com.linecorp.kotlinjdsl.querydsl.where.WhereDsl
+import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataCriteriaQueryDsl
+import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataPageableQueryDsl
 import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
 import com.linecorp.kotlinjdsl.test.entity.EntityDsl
 import com.linecorp.kotlinjdsl.test.entity.order.Order
@@ -11,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import javax.persistence.EntityManager
@@ -53,5 +58,32 @@ internal open class SpringDataQueryFactoryIntegrationTest : EntityDsl(), WithKot
         assertThat(actual.totalElements).isEqualTo(3)
         assertThat(actual.totalPages).isEqualTo(2)
         assertThat(actual.number).isEqualTo(1)
+    }
+
+    @Test
+    fun pageExtractWhereQuery() {
+        // given
+        val pageable = PageRequest.of(0, 10)
+        fun WhereDsl.equalValueSpec() = column(Order::purchaserId).equal(1000L)
+
+        val dsl: SpringDataPageableQueryDsl<Order>.() -> Unit = {
+            select(entity(Order::class))
+            from(entity(Order::class))
+            where(equalValueSpec())
+        }
+
+        val dslCriteria: SpringDataCriteriaQueryDsl<Order>.() -> Unit = {
+            select(entity(Order::class))
+            from(entity(Order::class))
+            where(equalValueSpec())
+        }
+        // when
+        val actual: Page<Order> = queryFactory.pageQuery(pageable, dsl)
+        val actualList: List<Order> = queryFactory.listQuery(dslCriteria)
+
+        // then
+        assertThat(actual.content.size).isEqualTo(3)
+        assertThat(actual.map { it.id }).containsExactlyInAnyOrder(order1.id, order2.id, order3.id)
+        assertThat(actualList.map { it.id }).containsExactlyInAnyOrder(order1.id, order2.id, order3.id)
     }
 }


### PR DESCRIPTION
Motivation:
support query extraction.
Refer to #3

-- korean
쿼리 추출을 지원해야 합니다.

Modifications:
WhereDsl implements ExpressionDsl, PredicateDsl

-- korean
WhereDsl 은 ExpressionDsl 과 PredicateDsl을 구현합니다.

Result:
It is possible to reuse the below where condition by extracting it.
```kotlin
        val pageable = PageRequest.of(0, 10)
        fun WhereDsl.equalValueSpec() = column(Order::purchaserId).equal(1000L)

        val dsl: SpringDataPageableQueryDsl<Order>.() -> Unit = {
            select(entity(Order::class))
            from(entity(Order::class))
            where(equalValueSpec())
        }

        val dslCriteria: SpringDataCriteriaQueryDsl<Order>.() -> Unit = {
            select(entity(Order::class))
            from(entity(Order::class))
            where(equalValueSpec())
        }
        // when
        val actual: Page<Order> = queryFactory.pageQuery(pageable, dsl)
        val actualList: List<Order> = queryFactory.listQuery(dslCriteria)
```

-- korean
위와 같은 where 조건을 추출해서 재사용이 가능해집니다.