### PR TITLE
Support Stream Query

### DIFF
--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensions.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensions.kt
@@ -2,6 +2,7 @@ package com.linecorp.kotlinjdsl
 
 import com.linecorp.kotlinjdsl.querydsl.CriteriaQueryDsl
 import com.linecorp.kotlinjdsl.querydsl.SubqueryDsl
+import java.util.stream.Stream
 
 inline fun <reified T> QueryFactory.singleQuery(
     noinline dsl: CriteriaQueryDsl<T>.() -> Unit
@@ -10,6 +11,11 @@ inline fun <reified T> QueryFactory.singleQuery(
 inline fun <reified T> QueryFactory.listQuery(
     noinline dsl: CriteriaQueryDsl<T>.() -> Unit
 ): List<T> = typedQuery(T::class.java, dsl).resultList
+
+inline fun <reified T> QueryFactory.streamQuery(
+    noinline dsl: CriteriaQueryDsl<T>.() -> Unit
+): Stream<T> = typedQuery(T::class.java, dsl).resultStream
+
 
 inline fun <reified T> QueryFactory.typedQuery(noinline dsl: CriteriaQueryDsl<T>.() -> Unit) =
     typedQuery(T::class.java, dsl)

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensionsTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensionsTest.kt
@@ -11,6 +11,7 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.util.stream.Stream
 import javax.persistence.TypedQuery
 
 @ExtendWith(MockKExtension::class)
@@ -69,6 +70,31 @@ internal class QueryFactoryExtensionsTest : WithKotlinJdslAssertions {
         verify(exactly = 1) {
             queryFactory.typedQuery(Data1::class.java, dsl)
             typedQuery.resultList
+        }
+
+        confirmVerified(queryFactory, typedQuery)
+    }
+
+    @Test
+    fun streamQuery() {
+        // given
+        every { queryFactory.typedQuery<Data1>(any(), any()) } returns typedQuery
+        every { typedQuery.resultStream } returns Stream.of(Data1())
+
+        val dsl: CriteriaQueryDsl<Data1>.() -> Unit = {
+            select(entity(Data1::class))
+            from(entity(Data1::class))
+        }
+
+        // when
+        queryFactory.streamQuery(dsl).use { actual ->
+            // then
+            assertThat(actual).contains(Data1())
+        }
+
+        verify(exactly = 1) {
+            queryFactory.typedQuery(Data1::class.java, dsl)
+            typedQuery.resultStream
         }
 
         confirmVerified(queryFactory, typedQuery)

--- a/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensions.kt
+++ b/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensions.kt
@@ -5,6 +5,7 @@ import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataCriteriaQueryDsl
 import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataPageableQueryDsl
 import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataSubqueryDsl
 import org.springframework.data.domain.Pageable
+import java.util.stream.Stream
 
 inline fun <reified T> SpringDataQueryFactory.singleQuery(
     noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit
@@ -13,6 +14,10 @@ inline fun <reified T> SpringDataQueryFactory.singleQuery(
 inline fun <reified T> SpringDataQueryFactory.listQuery(
     noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit
 ): List<T> = typedQuery(T::class.java, dsl).resultList
+
+inline fun <reified T> SpringDataQueryFactory.streamQuery(
+    noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit
+): Stream<T> = typedQuery(T::class.java, dsl).resultStream
 
 inline fun <reified T> SpringDataQueryFactory.typedQuery(noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit) =
     typedQuery(T::class.java, dsl)

--- a/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
+++ b/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
@@ -2,11 +2,13 @@ package com.linecorp.kotlinjdsl.spring.data
 
 import com.linecorp.kotlinjdsl.query.clause.select.SingleSelectClause
 import com.linecorp.kotlinjdsl.query.spec.expression.SubqueryExpressionSpec
+import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.querydsl.expression.column
 import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataCriteriaQueryDsl
 import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataPageableQueryDsl
 import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataSubqueryDsl
 import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
+import com.linecorp.kotlinjdsl.test.entity.order.Order
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -16,7 +18,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import java.util.stream.Stream
 import javax.persistence.TypedQuery
+import kotlin.streams.toList
 
 @ExtendWith(MockKExtension::class)
 internal class SpringDataQueryFactoryExtensionsTest : WithKotlinJdslAssertions {
@@ -152,6 +156,22 @@ internal class SpringDataQueryFactoryExtensionsTest : WithKotlinJdslAssertions {
 
         confirmVerified(queryFactory)
     }
+
+    @Test
+    fun streamQuery() {
+        // given
+        every { queryFactory.streamQuery<Long>(any()) } returns Stream.of(1L, 2L, 3L)
+
+        // when
+        val actual = queryFactory.streamQuery<Long>() {
+            select(col(Order::id))
+            from(entity(Order::class))
+            where(col(Order::purchaserId).equal(1000))
+        }.toList()
+        // then
+        assertThat(actual).containsExactlyInAnyOrder(3, 2, 1)
+    }
+
 
     @Test
     fun `pageQuery with countProjection`() {


### PR DESCRIPTION
Motivation:
Support Stream queries.
Refer to #5

-- korean
Stream 쿼리를 지원해야 합니다.

Modifications:
Added streamQuery to DSL code

-- korean
DSL 코드에 streamQuery 를 추가하였습니다

Result:
You can use code like below.

```kotlin
val stream: Stream<Long> = queryFactory.streamQuery<Long>() {
            select(col(Order::id))
            from(entity(Order::class))
            where(col(Order::purchaserId).equal(1000))
        }
```

-- korean
위와 같은 코드를 사용할 수 있습니다.