### PR TITLE
Make publishing settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Secret ###
+secring.gpg
+local.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     jacoco
-    `maven-publish`
 
     id("org.jetbrains.kotlin.plugin.noarg") version Dependencies.kotlinVersion
     id("org.jetbrains.kotlin.plugin.allopen") version Dependencies.kotlinVersion
@@ -20,14 +19,12 @@ allprojects {
 }
 
 subprojects {
-    apply {
-        plugin("jacoco")
-        plugin("kotlin")
-        plugin("kotlin-noarg")
-        plugin("kotlin-allopen")
+    apply(plugin = "jacoco")
+    apply(plugin = "kotlin")
+    apply(plugin = "kotlin-noarg")
+    apply(plugin = "kotlin-allopen")
 
-        plugin("maven-publish")
-    }
+    apply<LocalPropertiesPlugin>()
 
     java.sourceCompatibility = JavaVersion.VERSION_1_8
     java.targetCompatibility = JavaVersion.VERSION_1_8
@@ -57,9 +54,5 @@ subprojects {
 
     tasks.withType<Test> {
         useJUnitPlatform()
-    }
-
-    java {
-        withSourcesJar()
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,8 @@
 plugins {
     `kotlin-dsl`
+    `java-gradle-plugin`
+    `maven-publish`
+    signing
 }
 
 repositories {

--- a/buildSrc/src/main/kotlin/LocalPropertiesPlugin.kt
+++ b/buildSrc/src/main/kotlin/LocalPropertiesPlugin.kt
@@ -1,0 +1,17 @@
+import org.gradle.api.Project
+import java.util.*
+
+class LocalPropertiesPlugin : AbstractPlugin() {
+    override fun Project.initialize() {
+        val localProperties = rootProject.file("local.properties").takeIf { it.exists() } ?: return
+
+        localProperties.reader().use {
+            Properties().apply { load(it) }
+        }.forEach { (name, value) ->
+            ext[name.toString()] = value
+        }
+    }
+}
+
+private val Project.ext: org.gradle.api.plugins.ExtraPropertiesExtension
+    get() = (this as org.gradle.api.plugins.ExtensionAware).extensions.getByName("ext") as org.gradle.api.plugins.ExtraPropertiesExtension

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -1,0 +1,10 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+abstract class AbstractPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.initialize()
+    }
+
+    protected abstract fun Project.initialize()
+}

--- a/buildSrc/src/main/kotlin/PublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/PublishPlugin.kt
@@ -1,0 +1,113 @@
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.plugins.signing.SigningExtension
+
+class PublishPlugin : AbstractPlugin() {
+    override fun Project.initialize() {
+        apply(plugin = "signing")
+        apply(plugin = "maven-publish")
+
+        java {
+            withSourcesJar()
+            withJavadocJar()
+        }
+
+        signing {
+            sign(publishing.publications)
+        }
+
+        publishing {
+            repositories {
+                maven {
+                    val releaseRepoUri = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                    val snapshotRepoUri = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+
+                    url = if (version.isSnapshot()) snapshotRepoUri else releaseRepoUri
+
+                    val sonatypeUsername: String? by project
+                    val sonatypePassword: String? by project
+
+                    credentials {
+                        username = sonatypeUsername ?: ""
+                        password = sonatypePassword ?: ""
+                    }
+                }
+            }
+
+            publications {
+                create<MavenPublication>("maven") {
+                    from(components["java"])
+
+                    pom {
+                        name.set(artifactId)
+                        description.set("DSL for JPA Criteria API without generated metamodel and reflection.")
+                        url.set("https://github.com/line/kotlin-jdsl")
+
+                        licenses {
+                            license {
+                                name.set("The Apache License, Version 2.0")
+                                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                name.set("LINE Corporation")
+                                email.set("dl_oss_dev@linecorp.com")
+                                url.set("https://engineering.linecorp.com/en/")
+                            }
+                            developer {
+                                id.set("shouwn")
+                                name.set("jonghyon.s")
+                                email.set("jonghon.s@linecorp.com")
+                            }
+                            developer {
+                                id.set("cj848")
+                                name.set("hyunsik.kang")
+                                email.set("kaka@linecorp.com")
+                            }
+                            developer {
+                                id.set("pickmoment")
+                                name.set("pickmoment")
+                                email.set("moongeun.kim@linecorp.com")
+                            }
+                            developer {
+                                id.set("huisam")
+                                name.set("huisam")
+                                email.set("huijin.hong@linecorp.com")
+                            }
+                        }
+
+                        scm {
+                            connection.set("scm:git@github.com:line/kotlin-jdsl.git")
+                            developerConnection.set("scm:git:ssh://github.com:line/kotlin-jdsl.git")
+                            url.set("https://github.com/line/kotlin-jdsl")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val Project.publishing: PublishingExtension
+    get() = (this as org.gradle.api.plugins.ExtensionAware).extensions.getByName("publishing") as PublishingExtension
+
+private fun Project.java(configure: Action<JavaPluginExtension>): Unit =
+    (this as org.gradle.api.plugins.ExtensionAware).extensions.configure("java", configure)
+
+private fun Project.signing(configure: Action<SigningExtension>): Unit =
+    (this as org.gradle.api.plugins.ExtensionAware).extensions.configure("signing", configure)
+
+private fun Project.publishing(configure: Action<PublishingExtension>): Unit =
+    (this as org.gradle.api.plugins.ExtensionAware).extensions.configure("publishing", configure)
+
+private val Project.ext: org.gradle.api.plugins.ExtraPropertiesExtension
+    get() = (this as org.gradle.api.plugins.ExtensionAware).extensions.getByName("ext") as org.gradle.api.plugins.ExtraPropertiesExtension

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+apply<PublishPlugin>()
+
 dependencies {
     compileOnly(Dependencies.javaPersistenceApi)
     compileOnly(Dependencies.slf4j)

--- a/hibernate/build.gradle.kts
+++ b/hibernate/build.gradle.kts
@@ -1,3 +1,5 @@
+apply<PublishPlugin>()
+
 dependencies {
     api(Modules.core)
 

--- a/spring/batch-infrastructure/build.gradle.kts
+++ b/spring/batch-infrastructure/build.gradle.kts
@@ -1,3 +1,5 @@
+apply<PublishPlugin>()
+
 dependencies {
     compileOnly(Modules.core)
     compileOnly(Modules.springDataCore)

--- a/spring/data-autoconfigure/build.gradle.kts
+++ b/spring/data-autoconfigure/build.gradle.kts
@@ -1,3 +1,5 @@
+apply<PublishPlugin>()
+
 dependencies {
     compileOnly(Modules.core)
     compileOnly(Modules.springDataCore)

--- a/spring/data-core/build.gradle.kts
+++ b/spring/data-core/build.gradle.kts
@@ -1,3 +1,5 @@
+apply<PublishPlugin>()
+
 dependencies {
     compileOnly(Modules.core)
     compileOnly(Dependencies.springJpa)

--- a/spring/data-starter/build.gradle.kts
+++ b/spring/data-starter/build.gradle.kts
@@ -1,3 +1,5 @@
+apply<PublishPlugin>()
+
 dependencies {
     api(Modules.hibernate)
     api(Modules.springDataCore)


### PR DESCRIPTION
Motivation:
Make publishing settings.
Refer to #8 

-- korean
maven 저장소에 배포될 수 있도록 sonatype 저장소에 배포하는 스크립트 작성

-- english
Create scripts to deploy to sonatype so that it can be published to maven.

Result:
-- korean
local.properties에 계정 정보를 적는 것으로 sonatype에 배포할 수 있게 됩니다.

-- english
By writing down account in local.properties, you can publish it to sonatype. 

```properties
signing.keyId={your signing.keyId}
signing.password={your signing.password}
signing.secretKeyRingFile={your signing.secretKeyRingFile}

sonatypeUsername={your sonatype username}
sonatypePassword={your sonatype password}
```