### PR TITLE
Support Eclipselink

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ dependencies {
 }
 ```
 
+### Eclipselink
+Add Hibernate Kotlin JDSL and Eclipselink to dependencies
+
+```kotlin
+dependencies {
+    implementation("com.linecorp.kotlin-jdsl:eclipselink-kotlin-jdsl:x.y.z")
+    implementation("org.eclipse.persistence:org.eclipse.persistence.jpa:x.y.z")
+}
+```
+
 Create QueryFactory using EntityManager
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ dependencies {
 ```
 
 ### Eclipselink
-Add Hibernate Kotlin JDSL and Eclipselink to dependencies
+Add Eclipselink Kotlin JDSL and Eclipselink to dependencies
 
 ```kotlin
 dependencies {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -17,7 +17,7 @@ object Dependencies {
     const val slf4j = "org.slf4j:slf4j-api:1.7.32"
     const val logback = "ch.qos.logback:logback-classic:1.2.6"
     const val hibernate = "org.hibernate:hibernate-core:5.6.3.Final"
-    const val eclipse = "org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.9"
+    const val eclipselink = "org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.10"
     const val jacksonKotlinModule = "com.fasterxml.jackson.module:jackson-module-kotlin"
 
     // SpringBoot

--- a/buildSrc/src/main/kotlin/Modules.kt
+++ b/buildSrc/src/main/kotlin/Modules.kt
@@ -10,6 +10,7 @@ data class Module(
 object Modules {
     val core = module(":kotlin-jdsl-core")
     val hibernate = module(":hibernate-kotlin-jdsl")
+    val eclipselink = module(":eclipselink-kotlin-jdsl")
 
     val springDataCore = module(":spring-data-kotlin-jdsl-core")
     val springBatchInfrastructure = module(":spring-batch-kotlin-jdsl-infrastructure")

--- a/eclipselink/build.gradle.kts
+++ b/eclipselink/build.gradle.kts
@@ -1,0 +1,15 @@
+apply<PublishPlugin>()
+
+dependencies {
+    api(Modules.core)
+
+    compileOnly(Dependencies.eclipselink)
+    compileOnly(Dependencies.javaPersistenceApi)
+    compileOnly(Dependencies.slf4j)
+
+    testImplementation(Modules.core)
+    testImplementation(Modules.testFixtureIntegration)
+    testImplementation(Dependencies.eclipselink)
+    testImplementation(Dependencies.javaPersistenceApi)
+    testImplementation(Dependencies.h2)
+}

--- a/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/hint/EclipselinkSqlQueryHintClause.kt
+++ b/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/hint/EclipselinkSqlQueryHintClause.kt
@@ -1,0 +1,28 @@
+package com.linecorp.kotlinjdsl.query.clause.hint
+
+import org.eclipse.persistence.queries.DatabaseQuery
+import org.slf4j.LoggerFactory
+import javax.persistence.Query
+
+data class EclipselinkSqlQueryHintClause(
+    val queryHints: List<String>
+) : SqlQueryHintClause {
+    companion object {
+        private val log = LoggerFactory.getLogger(EclipselinkSqlQueryHintClause::class.java)
+    }
+
+    override fun apply(query: Query) {
+        if (queryHints.isEmpty()) return
+
+        val unwrappedQuery = try {
+            query.unwrap(DatabaseQuery::class.java)
+        } catch (e: Exception) {
+            log.error("This query does not support eclipselink query hint", e)
+            null
+        }
+
+        unwrappedQuery?.run {
+            queryHints.forEach { hintString = it }
+        }
+    }
+}

--- a/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/hint/eclipselink/EclipselinkSqlQueryHintClauseFactoryProvider.kt
+++ b/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/hint/eclipselink/EclipselinkSqlQueryHintClauseFactoryProvider.kt
@@ -1,0 +1,9 @@
+package com.linecorp.kotlinjdsl.querydsl.hint.eclipselink
+
+import com.linecorp.kotlinjdsl.query.clause.hint.EclipselinkSqlQueryHintClause
+import com.linecorp.kotlinjdsl.query.clause.hint.SqlQueryHintClause
+import com.linecorp.kotlinjdsl.querydsl.hint.SqlQueryHintClauseFactoryProvider
+
+class EclipselinkSqlQueryHintClauseFactoryProvider : SqlQueryHintClauseFactoryProvider {
+    override fun factory(): (List<String>) -> SqlQueryHintClause = { EclipselinkSqlQueryHintClause(it) }
+}

--- a/eclipselink/src/main/resources/META-INF/services/com.linecorp.kotlinjdsl.querydsl.hint.SqlQueryHintClauseFactoryProvider
+++ b/eclipselink/src/main/resources/META-INF/services/com.linecorp.kotlinjdsl.querydsl.hint.SqlQueryHintClauseFactoryProvider
@@ -1,0 +1,1 @@
+com.linecorp.kotlinjdsl.querydsl.hint.eclipselink.EclipselinkSqlQueryHintClauseFactoryProvider

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/expression/EclipselinkCriteriaQueryDslExpressionIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/expression/EclipselinkCriteriaQueryDslExpressionIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.expression
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.querydsl.expression.AbstractCriteriaQueryDslExpressionIntegrationTest
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+internal class EclipselinkCriteriaQueryDslExpressionIntegrationTest : AbstractCriteriaQueryDslExpressionIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/from/EclipselinkCriteriaQueryDslFromIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/from/EclipselinkCriteriaQueryDslFromIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.from
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.querydsl.from.AbstractCriteriaQueryDslFromIntegrationTest
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+internal class EclipselinkCriteriaQueryDslFromIntegrationTest : AbstractCriteriaQueryDslFromIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/groupby/EclipselinkCriteriaQueryDslGroupByIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/groupby/EclipselinkCriteriaQueryDslGroupByIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.groupby
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.querydsl.groupby.AbstractCriteriaQueryDslGroupByIntegrationTest
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+internal class EclipselinkCriteriaQueryDslGroupByIntegrationTest : AbstractCriteriaQueryDslGroupByIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/having/EclipselinkCriteriaQueryDslHavingIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/having/EclipselinkCriteriaQueryDslHavingIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.having
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.querydsl.having.AbstractCriteriaQueryDslHavingIntegrationTest
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+internal class EclipselinkCriteriaQueryDslHavingIntegrationTest : AbstractCriteriaQueryDslHavingIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/hint/EclipselinkCriteriaQueryDslHintIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/hint/EclipselinkCriteriaQueryDslHintIntegrationTest.kt
@@ -1,0 +1,59 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.hint
+
+import com.linecorp.kotlinjdsl.listQuery
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.querydsl.expression.min
+import com.linecorp.kotlinjdsl.test.entity.order.Order
+import com.linecorp.kotlinjdsl.test.integration.AbstractCriteriaQueryDslIntegrationTest
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import org.eclipse.persistence.config.CacheUsage
+import org.eclipse.persistence.config.HintValues
+import org.eclipse.persistence.config.PessimisticLock
+import org.eclipse.persistence.config.QueryHints
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+internal class EclipselinkCriteriaQueryDslHintIntegrationTest : AbstractCriteriaQueryDslIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+
+    private val order1 = order { purchaserId = 1000 }
+    private val order2 = order { purchaserId = 1000 }
+    private val order3 = order { purchaserId = 2000 }
+
+    @BeforeEach
+    fun setUp() {
+        entityManager.persistAll(order1, order2, order3)
+        entityManager.flushAndClear()
+    }
+
+    @Test
+    fun sqlHint() {
+        // when
+        val purchaserIds = queryFactory.listQuery<Long> {
+            select(min(Order::purchaserId))
+            from(entity(Order::class))
+            where(col(Order::id).`in`(order1.id, order2.id, order3.id))
+            // Since eclipselink does not put /*+ */ comments in SQL hints, users must put all comments in hints.
+            sqlHints("/*+ idx1 */")
+        }
+
+        // then
+        assertThat(purchaserIds).containsOnly(1000)
+    }
+
+    @Test
+    fun jpaHint() {
+        // when
+        val purchaserIds = queryFactory.listQuery<Long> {
+            select(col(Order::purchaserId))
+            from(entity(Order::class))
+            hints(QueryHints.PESSIMISTIC_LOCK to PessimisticLock.LockNoWait)
+        }
+
+        // then
+        assertThat(purchaserIds).containsOnly(1000, 2000)
+    }
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/hint/EclipselinkCriteriaQueryDslHintIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/hint/EclipselinkCriteriaQueryDslHintIntegrationTest.kt
@@ -36,7 +36,7 @@ internal class EclipselinkCriteriaQueryDslHintIntegrationTest : AbstractCriteria
             select(min(Order::purchaserId))
             from(entity(Order::class))
             where(col(Order::id).`in`(order1.id, order2.id, order3.id))
-            // Since eclipselink does not put /*+ */ comments in SQL hints, users must put all comments in hints.
+            // Since eclipselink does not put /*+ */ comments automatically in SQL hints, users must put all comments in hints.
             sqlHints("/*+ idx1 */")
         }
 

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/limit/EclipselinkCriteriaQueryDslLimitIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/limit/EclipselinkCriteriaQueryDslLimitIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.limit
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.querydsl.limit.AbstractCriteriaQueryDslLimitIntegrationTest
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+internal class EclipselinkCriteriaQueryDslLimitIntegrationTest : AbstractCriteriaQueryDslLimitIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/orderby/EclipselinkCriteriaQueryDslOrderByIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/orderby/EclipselinkCriteriaQueryDslOrderByIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.orderby
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.querydsl.orderby.AbstractCriteriaQueryDslOrderByIntegrationTest
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+internal class EclipselinkCriteriaQueryDslOrderByIntegrationTest : AbstractCriteriaQueryDslOrderByIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/predicate/EclipselinkCriteriaQueryDslPredicateIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/predicate/EclipselinkCriteriaQueryDslPredicateIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.predicate
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.querydsl.predicate.AbstractCriteriaQueryDslPredicateIntegrationTest
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+internal class EclipselinkCriteriaQueryDslPredicateIntegrationTest : AbstractCriteriaQueryDslPredicateIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
@@ -2,6 +2,8 @@ package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.select
 
 import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
 import com.linecorp.kotlinjdsl.test.integration.querydsl.select.AbstractCriteriaQueryDslSelectIntegrationTest
+import org.eclipse.persistence.internal.jpa.querydef.SelectionImpl
+import org.eclipse.persistence.internal.jpa.querydef.SubQueryImpl
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import javax.persistence.EntityManager
@@ -10,10 +12,19 @@ import javax.persistence.EntityManager
 class EclipselinkCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQueryDslSelectIntegrationTest() {
     override lateinit var entityManager: EntityManager
 
+    /**
+     * https://wiki.eclipse.org/EclipseLink/UserGuide/JPA/Basic_JPA_Development/Querying/JPQL#Sub-selects_in_FROM_clause
+     * eclipselink does not support subquery in select and jpa criteria does not support from subquery
+     * so kotlin-jdsl's eclipselink does not support subquery in select
+     */
     @Test
     override fun `listQuery - subquery in select, subquery in from`() {
-        // https://wiki.eclipse.org/EclipseLink/UserGuide/JPA/Basic_JPA_Development/Querying/JPQL#Sub-selects_in_FROM_clause
-        // eclipselink does not support subquery in select and jpa criteria does not support from subquery
-        // so kotlin-jdsl's eclipselink does not support subquery in select
+        // when
+        val exception =
+            catchThrowable(ClassCastException::class) { super.`listQuery - subquery in select, subquery in from`() }
+
+        // then
+        assertThat(exception)
+            .hasMessage("${SubQueryImpl::class.qualifiedName} cannot be cast to ${SelectionImpl::class.qualifiedName}")
     }
 }

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
@@ -13,7 +13,7 @@ class EclipselinkCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQueryDs
     @Test
     override fun `listQuery - subquery in select, subquery in from`() {
         // https://wiki.eclipse.org/EclipseLink/UserGuide/JPA/Basic_JPA_Development/Querying/JPQL#Sub-selects_in_FROM_clause
-        // eclipselink does not support select subquery and jpa criteria does not support from subquery
-        // so kotlin-jdsl's eclipselink does not support select subquery column
+        // eclipselink does not support subquery in select and jpa criteria does not support from subquery
+        // so kotlin-jdsl's eclipselink does not support subquery in select
     }
 }

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
@@ -11,7 +11,7 @@ class EclipselinkCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQueryDs
     override lateinit var entityManager: EntityManager
 
     @Test
-    override fun `listQuery - select single subquery`() {
+    override fun `listQuery - subquery in select, subquery in from`() {
         // https://wiki.eclipse.org/EclipseLink/UserGuide/JPA/Basic_JPA_Development/Querying/JPQL#Sub-selects_in_FROM_clause
         // eclipselink does not support select subquery and jpa criteria does not support from subquery
         // so kotlin-jdsl's eclipselink does not support select subquery column

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
@@ -1,0 +1,19 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.select
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.querydsl.select.AbstractCriteriaQueryDslSelectIntegrationTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+class EclipselinkCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQueryDslSelectIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+
+    @Test
+    override fun `listQuery - select single subquery`() {
+        // https://wiki.eclipse.org/EclipseLink/UserGuide/JPA/Basic_JPA_Development/Querying/JPQL#Sub-selects_in_FROM_clause
+        // eclipselink does not support select subquery and jpa criteria does not support from subquery
+        // so kotlin-jdsl's eclipselink does not support select subquery column
+    }
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/where/EclipselinkCriteriaQueryDslWhereIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/where/EclipselinkCriteriaQueryDslWhereIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.where
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.querydsl.where.AbstractCriteriaQueryDslWhereIntegrationTest
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+internal class EclipselinkCriteriaQueryDslWhereIntegrationTest : AbstractCriteriaQueryDslWhereIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/hint/eclipselink/EclipseSqlQueryHintClauseFactoryProviderTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/hint/eclipselink/EclipseSqlQueryHintClauseFactoryProviderTest.kt
@@ -1,4 +1,4 @@
-package com.linecorp.kotlinjdsl.querydsl.hint.hibernate
+package com.linecorp.kotlinjdsl.querydsl.hint.eclipselink
 
 import com.linecorp.kotlinjdsl.query.clause.hint.EclipselinkSqlQueryHintClause
 import com.linecorp.kotlinjdsl.querydsl.hint.SqlQueryHintClauseFactoryProvider

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/hint/hibernate/EclipseSqlQueryHintClauseFactoryProviderTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/hint/hibernate/EclipseSqlQueryHintClauseFactoryProviderTest.kt
@@ -1,0 +1,16 @@
+package com.linecorp.kotlinjdsl.querydsl.hint.hibernate
+
+import com.linecorp.kotlinjdsl.query.clause.hint.EclipselinkSqlQueryHintClause
+import com.linecorp.kotlinjdsl.querydsl.hint.SqlQueryHintClauseFactoryProvider
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+internal class EclipseSqlQueryHintClauseFactoryProviderTest : WithAssertions {
+
+    @Test
+    fun test() {
+        assertThat(SqlQueryHintClauseFactoryProvider.loadedFactory?.invoke(listOf("test"))).isInstanceOf(
+            EclipselinkSqlQueryHintClause::class.java
+        )
+    }
+}

--- a/eclipselink/src/test/resources/META-INF/persistence.xml
+++ b/eclipselink/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+
+    <persistence-unit name="order">
+        <class>com.linecorp.kotlinjdsl.test.entity.Address</class>
+
+        <class>com.linecorp.kotlinjdsl.test.entity.order.Order</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.order.OrderGroup</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.order.OrderItem</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.order.OrderAddress</class>
+
+        <class>com.linecorp.kotlinjdsl.test.entity.delivery.Delivery</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.delivery.DeliveryItem</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.delivery.DeliveryAddress</class>
+
+        <properties>
+            <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:test;MODE=MYSQL"/>
+            <property name="javax.persistence.jdbc.user" value="sa"/>
+            <property name="javax.persistence.jdbc.password" value=""/>
+            <property name="javax.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/examples/eclipselink/build.gradle.kts
+++ b/examples/eclipselink/build.gradle.kts
@@ -1,0 +1,9 @@
+dependencies {
+    implementation(Modules.eclipselink)
+    implementation(Dependencies.eclipselink)
+    implementation(Dependencies.javaPersistenceApi)
+    implementation(Dependencies.logback)
+    implementation(Dependencies.h2)
+
+    testImplementation(Modules.testFixtureCore)
+}

--- a/examples/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/eclipselink/example/Main.kt
+++ b/examples/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/eclipselink/example/Main.kt
@@ -1,8 +1,8 @@
-package com.linecorp.kotlinjdsl.hibernate.example
+package com.linecorp.kotlinjdsl.eclipselink.example
 
 import com.linecorp.kotlinjdsl.QueryFactory
 import com.linecorp.kotlinjdsl.QueryFactoryImpl
-import com.linecorp.kotlinjdsl.hibernate.example.entity.Book
+import com.linecorp.kotlinjdsl.eclipselink.example.entity.Book
 import com.linecorp.kotlinjdsl.listQuery
 import com.linecorp.kotlinjdsl.query.creator.CriteriaQueryCreatorImpl
 import com.linecorp.kotlinjdsl.query.creator.SubqueryCreatorImpl

--- a/examples/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/eclipselink/example/entity/Book.kt
+++ b/examples/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/eclipselink/example/entity/Book.kt
@@ -1,4 +1,4 @@
-package com.linecorp.kotlinjdsl.hibernate.example.entity
+package com.linecorp.kotlinjdsl.eclipselink.example.entity
 
 import javax.persistence.*
 

--- a/examples/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/hibernate/example/Main.kt
+++ b/examples/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/hibernate/example/Main.kt
@@ -1,0 +1,43 @@
+package com.linecorp.kotlinjdsl.hibernate.example
+
+import com.linecorp.kotlinjdsl.QueryFactory
+import com.linecorp.kotlinjdsl.QueryFactoryImpl
+import com.linecorp.kotlinjdsl.hibernate.example.entity.Book
+import com.linecorp.kotlinjdsl.listQuery
+import com.linecorp.kotlinjdsl.query.creator.CriteriaQueryCreatorImpl
+import com.linecorp.kotlinjdsl.query.creator.SubqueryCreatorImpl
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import javax.persistence.EntityManager
+import javax.persistence.Persistence
+
+private val entityManagerFactory = Persistence.createEntityManagerFactory("example")
+
+fun main(args: Array<String>) {
+    val entityManager = entityManagerFactory.createEntityManager().also {
+        it.initializeData()
+    }
+
+    val queryFactory: QueryFactory = QueryFactoryImpl(
+        criteriaQueryCreator = CriteriaQueryCreatorImpl(entityManager),
+        subqueryCreator = SubqueryCreatorImpl()
+    )
+
+    val books: List<Book> = queryFactory.listQuery {
+        select(entity(Book::class))
+        from(entity(Book::class))
+        where(or(args.map { col(Book::name).like("%${it}%") }))
+    }
+
+    println(books)
+}
+
+private fun EntityManager.initializeData() {
+    transaction.run {
+        begin()
+        persist(Book(name = "Hamlet"))
+        persist(Book(name = "King Lear"))
+        persist(Book(name = "Romeo and Juliet"))
+        persist(Book(name = "Macbeth"))
+        commit()
+    }
+}

--- a/examples/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/hibernate/example/entity/Book.kt
+++ b/examples/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/hibernate/example/entity/Book.kt
@@ -1,0 +1,15 @@
+package com.linecorp.kotlinjdsl.hibernate.example.entity
+
+import javax.persistence.*
+
+@Entity
+@Table(name = "book")
+data class Book(
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column
+    val name: String,
+)

--- a/examples/eclipselink/src/main/resources/META-INF/persistence.xml
+++ b/examples/eclipselink/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+
+    <persistence-unit name="example">
+        <class>com.linecorp.kotlinjdsl.hibernate.example.entity.Book</class>
+
+        <properties>
+            <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:test;MODE=MYSQL"/>
+            <property name="javax.persistence.jdbc.user" value="sa"/>
+            <property name="javax.persistence.jdbc.password" value=""/>
+            <property name="javax.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/examples/eclipselink/src/main/resources/META-INF/persistence.xml
+++ b/examples/eclipselink/src/main/resources/META-INF/persistence.xml
@@ -5,7 +5,7 @@
         http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
 
     <persistence-unit name="example">
-        <class>com.linecorp.kotlinjdsl.hibernate.example.entity.Book</class>
+        <class>com.linecorp.kotlinjdsl.eclipselink.example.entity.Book</class>
 
         <properties>
             <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:test;MODE=MYSQL"/>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ data class Module(
 // CORE
 module(name = ":kotlin-jdsl-core", path = "core")
 module(name = ":hibernate-kotlin-jdsl", path = "hibernate")
+module(name = ":eclipselink-kotlin-jdsl", path = "eclipselink")
 
 // SPRING
 module(name = ":spring", path = "spring")
@@ -30,6 +31,7 @@ module(name = ":test-fixture-integration", path = "test-fixture/integration")
 
 // EXAMPLES
 module(name = ":hibernate-example", path = "examples/hibernate")
+module(name = ":eclipselink-example", path = "examples/eclipselink")
 module(name = ":spring-data-boot-2.6-example", path = "examples/spring-boot-2.6")
 module(name = ":spring-data-boot-2.5-example", path = "examples/spring-boot-2.5")
 module(name = ":spring-data-boot-2.4-example", path = "examples/spring-boot-2.4")

--- a/spring/README.md
+++ b/spring/README.md
@@ -13,6 +13,18 @@ dependencies {
 }
 ```
 
+kotlin-jdsl's spring boot starter is adopted hibernate as the default implementation of kotlin-jdsl, so to use eclipselink, you need to modify the build script as follows.
+
+```kotlin
+dependencies {
+    implementation("com.linecorp.kotlin-jdsl:spring-data-kotlin-jdsl-starter:x.y.z") {
+        exclude(group = "com.linecorp.kotlin-jdsl", module = "hibernate-kotlin-jdsl")
+    }
+    implementation("com.linecorp.kotlin-jdsl:eclipselink-kotlin-jdsl:x.y.z")
+    implementation("org.eclipse.persistence:org.eclipse.persistence.jpa:x.y.z")
+}
+```
+
 Inject SpringDataQueryFactory in your service and query using it
 
 ```kotlin

--- a/test-fixture/entity/src/main/kotlin/com/linecorp/kotlinjdsl/test/entity/EntityDsl.kt
+++ b/test-fixture/entity/src/main/kotlin/com/linecorp/kotlinjdsl/test/entity/EntityDsl.kt
@@ -12,11 +12,6 @@ import javax.persistence.EntityManager
 abstract class EntityDsl {
     fun EntityManager.persistAll(vararg entities: Any) = persistAll(entities.toList())
     fun EntityManager.persistAll(entities: Collection<Any>) = entities.forEach { persist(it) }
-    fun EntityManager.persistAllFlushAndClearEach(vararg entities: Any) = persistAllFlushAndClearEach(entities.toList())
-    fun EntityManager.persistAllFlushAndClearEach(entities: Collection<Any>) = entities.forEach {
-        persist(it)
-        flushAndClear()
-    }
     fun EntityManager.removeAll(vararg entities: Any) = removeAll(entities.toList())
     fun EntityManager.removeAll(entities: Collection<Any>) = entities.forEach {
         if (contains(it)) {

--- a/test-fixture/entity/src/main/kotlin/com/linecorp/kotlinjdsl/test/entity/EntityDsl.kt
+++ b/test-fixture/entity/src/main/kotlin/com/linecorp/kotlinjdsl/test/entity/EntityDsl.kt
@@ -12,6 +12,11 @@ import javax.persistence.EntityManager
 abstract class EntityDsl {
     fun EntityManager.persistAll(vararg entities: Any) = persistAll(entities.toList())
     fun EntityManager.persistAll(entities: Collection<Any>) = entities.forEach { persist(it) }
+    fun EntityManager.persistAllFlushAndClearEach(vararg entities: Any) = persistAllFlushAndClearEach(entities.toList())
+    fun EntityManager.persistAllFlushAndClearEach(entities: Collection<Any>) = entities.forEach {
+        persist(it)
+        flushAndClear()
+    }
     fun EntityManager.removeAll(vararg entities: Any) = removeAll(entities.toList())
     fun EntityManager.removeAll(entities: Collection<Any>) = entities.forEach {
         if (contains(it)) {

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/expression/AbstractCriteriaQueryDslExpressionIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/expression/AbstractCriteriaQueryDslExpressionIntegrationTest.kt
@@ -94,7 +94,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
         }
 
         // then
-        assertThat(max).isEqualTo(50.toBigDecimal().setScale(2))
+        assertThat(max).isEqualByComparingTo(50.toString())
     }
 
     @Test
@@ -106,7 +106,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
         }
 
         // then
-        assertThat(min).isEqualTo(10.toBigDecimal().setScale(2))
+        assertThat(min).isEqualByComparingTo(10.toString())
     }
 
     @Test
@@ -130,7 +130,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
         }
 
         // then
-        assertThat(sum).isEqualTo(110.toBigDecimal().setScale(2))
+        assertThat(sum).isEqualByComparingTo(110.toString())
     }
 
     @Test

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/limit/AbstractCriteriaQueryDslLimitIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/limit/AbstractCriteriaQueryDslLimitIntegrationTest.kt
@@ -14,7 +14,8 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest : AbstractCriteriaQu
 
     @BeforeEach
     fun setUp() {
-        entityManager.persistAllFlushAndClearEach(order1, order2, order3)
+        entityManager.persistAll(order1, order2, order3)
+        entityManager.flushAndClear()
     }
 
     @Test
@@ -28,7 +29,7 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest : AbstractCriteriaQu
         }
 
         // then
-        assertThat(orderIds).containsOnly(order2.id, order3.id)
+        assertThat(orderIds).isEqualTo(listOf(order1.id, order2.id, order3.id).sorted().drop(1))
     }
 
     @Test
@@ -42,7 +43,7 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest : AbstractCriteriaQu
         }
 
         // then
-        assertThat(orderIds).containsOnly(order1.id)
+        assertThat(orderIds).containsOnly(listOf(order1.id, order2.id, order3.id).minOrNull())
     }
 
     @Test
@@ -56,6 +57,6 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest : AbstractCriteriaQu
         }
 
         // then
-        assertThat(orderIds).containsOnly(order2.id)
+        assertThat(orderIds).containsOnly(listOf(order1.id, order2.id, order3.id).sorted()[1])
     }
 }

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/limit/AbstractCriteriaQueryDslLimitIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/limit/AbstractCriteriaQueryDslLimitIntegrationTest.kt
@@ -14,8 +14,7 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest : AbstractCriteriaQu
 
     @BeforeEach
     fun setUp() {
-        entityManager.persistAll(order1, order2, order3)
-        entityManager.flushAndClear()
+        entityManager.persistAllFlushAndClearEach(order1, order2, order3)
     }
 
     @Test

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/orderby/AbstractCriteriaQueryDslOrderByIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/orderby/AbstractCriteriaQueryDslOrderByIntegrationTest.kt
@@ -13,7 +13,8 @@ abstract class AbstractCriteriaQueryDslOrderByIntegrationTest : AbstractCriteria
 
     @BeforeEach
     fun setUp() {
-        entityManager.persistAllFlushAndClearEach(order1, order2)
+        entityManager.persistAll(order1, order2)
+        entityManager.flushAndClear()
     }
 
     @Test
@@ -26,7 +27,7 @@ abstract class AbstractCriteriaQueryDslOrderByIntegrationTest : AbstractCriteria
         }
 
         // then
-        assertThat(orderIds).isEqualTo(listOf(order1.id, order2.id))
+        assertThat(orderIds).isEqualTo(listOf(order1.id, order2.id).sorted())
     }
 
     @Test
@@ -39,6 +40,6 @@ abstract class AbstractCriteriaQueryDslOrderByIntegrationTest : AbstractCriteria
         }
 
         // then
-        assertThat(orderIds).isEqualTo(listOf(order2.id, order1.id))
+        assertThat(orderIds).isEqualTo(listOf(order2.id, order1.id).sortedDescending())
     }
 }

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/orderby/AbstractCriteriaQueryDslOrderByIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/orderby/AbstractCriteriaQueryDslOrderByIntegrationTest.kt
@@ -13,8 +13,7 @@ abstract class AbstractCriteriaQueryDslOrderByIntegrationTest : AbstractCriteria
 
     @BeforeEach
     fun setUp() {
-        entityManager.persistAll(order1, order2)
-        entityManager.flushAndClear()
+        entityManager.persistAllFlushAndClearEach(order1, order2)
     }
 
     @Test

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -24,7 +24,8 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
 
     @BeforeEach
     fun setUp() {
-        entityManager.persistAllFlushAndClearEach(order1, order2, order3)
+        entityManager.persistAll(order1, order2, order3)
+        entityManager.flushAndClear()
     }
 
     @Test
@@ -36,7 +37,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
         }
 
         // then
-        assertThat(purchaserId).isEqualTo(order3.id)
+        assertThat(purchaserId).isEqualTo(listOf(order1.id, order2.id, order3.id).maxOrNull())
     }
 
     @Test
@@ -62,7 +63,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
         }
 
         // then
-        assertThat(orderIds).isEqualTo(listOf(order1.id, order2.id, order3.id))
+        assertThat(orderIds).isEqualTo(listOf(order1.id, order2.id, order3.id).sorted())
     }
 
     @Test

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -91,6 +91,10 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
         assertThat(purchaserIds).isEqualTo(listOf(1000L, 2000L))
     }
 
+    /**
+     * Currently, in the case of this test, eclipselink does not support it properly,
+     * so for tests that generate an exception like this, open it so that it can be extended with open.
+     */
     @Test
     open fun `listQuery - subquery in select, subquery in from`() {
         val subquery = queryFactory.subquery<Long> {

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -24,8 +24,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
 
     @BeforeEach
     fun setUp() {
-        entityManager.persistAll(order1, order2, order3)
-        entityManager.flushAndClear()
+        entityManager.persistAllFlushAndClearEach(order1, order2, order3)
     }
 
     @Test
@@ -92,7 +91,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
     }
 
     @Test
-    fun `listQuery - select single subquery`() {
+    open fun `listQuery - select single subquery`() {
         val subquery = queryFactory.subquery<Long> {
             val order = entity(Order::class, "o")
 

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -91,7 +91,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
     }
 
     @Test
-    open fun `listQuery - select single subquery`() {
+    open fun `listQuery - subquery in select, subquery in from`() {
         val subquery = queryFactory.subquery<Long> {
             val order = entity(Order::class, "o")
 

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
@@ -29,8 +29,6 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest : AbstractCriteriaQu
             where(col(Order::purchaserId).equal(1000))
         }
 
-        order.groups.forEach { it.items.forEach { it.price } }
-
         // then
         assertThat(order)
             .usingRecursiveComparison()

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
@@ -17,7 +17,8 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest : AbstractCriteriaQu
 
     @BeforeEach
     fun setUp() {
-        entityManager.persistAllFlushAndClearEach(order1, order2, order3)
+        entityManager.persistAll(order1, order2, order3)
+        entityManager.flushAndClear()
     }
 
     @Test

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.test.entity.order.Order
 import com.linecorp.kotlinjdsl.test.integration.AbstractCriteriaQueryDslIntegrationTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 
 abstract class AbstractCriteriaQueryDslWhereIntegrationTest : AbstractCriteriaQueryDslIntegrationTest() {
     private val order1 = order { purchaserId = 1000 }
@@ -16,8 +17,7 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest : AbstractCriteriaQu
 
     @BeforeEach
     fun setUp() {
-        entityManager.persistAll(order1, order2, order3)
-        entityManager.flushAndClear()
+        entityManager.persistAllFlushAndClearEach(order1, order2, order3)
     }
 
     @Test
@@ -29,9 +29,12 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest : AbstractCriteriaQu
             where(col(Order::purchaserId).equal(1000))
         }
 
+        order.groups.forEach { it.items.forEach { it.price } }
+
         // then
         assertThat(order)
             .usingRecursiveComparison()
+            .withComparatorForType(BigDecimal::compareTo, BigDecimal::class.java)
             .isEqualTo(order1)
     }
 


### PR DESCRIPTION
Motivation:
The hint support of Eclipselink, which is one of the implementations of JPA, is required. Also, we need a test and an example to see if it works normally by adding the eclipselink module of kotlin-jdsl.
Refer to #14

-- korean
JPA의 구현체 중 하나인 Eclipselink 의 힌트 지원이 필요합니다. 또한 우리는 kotlin-jdsl의 eclipselink 모듈을 추가함으로써 정상 구동이 되는지에 대한 테스트와 예제가 필요합니다.

Modifications:
Added eclipselink module and added SQL hint provider and hint clause implementation.
I added the query test of the eclipslink module and confirmed that the normal test passed.
Examples/eclipselink was added to confirm eclipselink operation.

-- korean
eclipselink 모듈을 추가하고 SQL힌트 제공자 및 힌트절 구현체를 추가하였습니다.
eclipslink 모듈의 쿼리 테스트를 추가하고 정상 테스트 통과를 확인하였습니다.
examples/eclipselink 를 추가하여 eclipselink 구동을 확인하였습니다.

Result:
Users can use eclipselink as a hint implementation of kotlin-jdsl.
In the case of spring boot starter, hibernate is adopted as the default implementation of kotlin-jdsl, so to use eclipselink, you need to modify the build script as follows.

```kotlin
dependencies {
    implementation("com.linecorp.kotlin-jdsl:spring-data-kotlin-jdsl-starter:x.y.z") {
        exclude(group = "com.linecorp.kotlin-jdsl", module = "hibernate-kotlin-jdsl")
    }
    implementation("com.linecorp.kotlin-jdsl:eclipselink-kotlin-jdsl:x.y.z")
    implementation("org.eclipse.persistence:org.eclipse.persistence.jpa:x.y.z")
}
```

-- korean
사용자는 eclipselink 를 kotlin-jdsl 의 힌트 구현체로 사용할 수 있습니다.
spring boot starter의 경우 kotlin-jdsl의 기본 구현체로 hibernate 를 채택하고 있기 때문에 eclipselink 를 사용하려면 위와 같이 빌드 스크립트를 수정해야 합니다.