### PR TITLE
Correct typo in developer's email address.

### DIFF
--- a/buildSrc/src/main/kotlin/PublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/PublishPlugin.kt
@@ -66,7 +66,7 @@ class PublishPlugin : AbstractPlugin() {
                             developer {
                                 id.set("shouwn")
                                 name.set("jonghyon.s")
-                                email.set("jonghon.s@linecorp.com")
+                                email.set("jonghyon.s@linecorp.com")
                             }
                             developer {
                                 id.set("cj848")


### PR DESCRIPTION
Motivation:
I found that the wrong email was written in the maven publishing settings.

Modifications:
Modify the developer's email address.

Result:
Users will be able to communicate with the correct email address.