### PR TITLE
Code coverage management is required.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Motivation:
+
+Explain why you're making this change and what problem you're trying to solve.
+
+Modifications:
+
+List the modifications you've made in detail.
+Result:
+
+Closes #. (If this resolves the issue.)
+Describe the consequences that a user will face after this PR is merged.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ Explain why you're making this change and what problem you're trying to solve.
 Modifications:
 
 List the modifications you've made in detail.
+
 Result:
 
 Closes #. (If this resolves the issue.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
-Motivation:
+# Motivation:
 
-Explain why you're making this change and what problem you're trying to solve.
+* Explain why you're making this change and what problem you're trying to solve.
 
-Modifications:
+#Modifications:
 
-List the modifications you've made in detail.
+* List the modifications you've made in detail.
 
-Result:
+#Result:
 
-Closes #. (If this resolves the issue.)
-Describe the consequences that a user will face after this PR is merged.
+#Closes #. (If this resolves the issue.)
+* Describe the consequences that a user will face after this PR is merged.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  # Cancel the previous builds in the same PR.
+  # Allow running concurrently for all non-PR commits.
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          cache: gradle
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: CodeCoverage(with test) with Gradle
+        run: ./gradlew codeCoverageReport
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+      - name: Cleanup Gradle Cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @pickmoment @huisam @cj848 @shouwn
+* @pickmoment @huisam @cj848 @shouwn

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # Kotlin JDSL
+<a href="https://codecov.io/gh/line/kotlin-jdsl">
+  <img src="https://codecov.io/gh/line/kotlin-jdsl/branch/main/graph/badge.svg?token=YWPDKYDARW"/>
+</a>
+<a href="https://github.com/line/kotlin-jdsl/contributors"><img src="https://img.shields.io/github/contributors/line/kotlin-jdsl.svg" /></a>
+<a href="https://search.maven.org/search?q=g:com.linecorp.kotlin-jdsl%20AND%20a:kotlin-jdsl-core"><img src="https://img.shields.io/maven-central/v/com.linecorp.kotlin-jdsl/kotlin-jdsl-core.svg?label=version" /></a>
+<a href="https://github.com/line/kotlin-jdsl/commits"><img src="https://img.shields.io/github/release-date/line/kotlin-jdsl.svg?label=release" /></a>
 
 Kotlin JDSL is DSL for JPA Criteria API without generated metamodel and reflection. It helps you write a JPA query like
 writing an SQL statement.
@@ -267,3 +273,10 @@ If you believe you have discovered a vulnerability or have an issue related to s
    limitations under the License.
 ```
 See [LICENSE](LICENSE) for more details.
+
+# Our Lovely Contrubutors
+See [the complete list of our contributors](https://github.com/line/kotlin-jdsl/contributors).
+
+<a href="https://github.com/line/kotlin-jdsl/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=line/kotlin-jdsl"/>
+</a>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 <a href="https://codecov.io/gh/line/kotlin-jdsl">
   <img src="https://codecov.io/gh/line/kotlin-jdsl/branch/main/graph/badge.svg?token=YWPDKYDARW"/>
 </a>
-<a href="https://github.com/line/kotlin-jdsl/contributors"><img src="https://img.shields.io/github/contributors/line/kotlin-jdsl.svg" /></a>
-<a href="https://search.maven.org/search?q=g:com.linecorp.kotlin-jdsl%20AND%20a:kotlin-jdsl-core"><img src="https://img.shields.io/maven-central/v/com.linecorp.kotlin-jdsl/kotlin-jdsl-core.svg?label=version" /></a>
+&nbsp;<a href="https://github.com/line/kotlin-jdsl/contributors"><img src="https://img.shields.io/github/contributors/line/kotlin-jdsl.svg" /></a>&nbsp;
+<a href="https://search.maven.org/search?q=g:com.linecorp.kotlin-jdsl%20AND%20a:kotlin-jdsl-core"><img src="https://img.shields.io/maven-central/v/com.linecorp.kotlin-jdsl/kotlin-jdsl-core.svg?label=version" /></a>&nbsp;
 <a href="https://github.com/line/kotlin-jdsl/commits"><img src="https://img.shields.io/github/release-date/line/kotlin-jdsl.svg?label=release" /></a>
 
 Kotlin JDSL is DSL for JPA Criteria API without generated metamodel and reflection. It helps you write a JPA query like

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,10 @@ allprojects {
     }
 }
 
+rootProject {
+    apply<JacocoExtensionPlugin>()
+}
+
 subprojects {
     apply(plugin = "jacoco")
     apply(plugin = "kotlin")

--- a/buildSrc/src/main/kotlin/JacocoExtensionPlugin.kt
+++ b/buildSrc/src/main/kotlin/JacocoExtensionPlugin.kt
@@ -1,0 +1,49 @@
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.*
+import org.gradle.testing.jacoco.tasks.JacocoReport
+
+@Suppress("UNUSED_VARIABLE")
+class JacocoExtensionPlugin : AbstractRootPlugin(apply {
+    val coverage = rootProject.extensions.create<CoverageExtension>("coverage")
+    // Task to gather code coverage from multiple subprojects
+    // @see https://gist.github.com/aalmiray/e6f54aa4b3803be0bcac
+    val codeCoverageReport: TaskProvider<JacocoReport> by tasks.registering(JacocoReport::class) {
+        group = "verification"
+        dependsOn(subprojects.map { it.tasks.withType<Test>() })
+
+        val targetProjects = subprojects.filter { it.project !in coverage.excludes }
+        additionalSourceDirs.setFrom(targetProjects.map { it.the<SourceSetContainer>()["main"].allSource.srcDirs })
+        sourceDirectories.setFrom(targetProjects.map { it.the<SourceSetContainer>()["main"].allSource.srcDirs })
+        classDirectories.setFrom(targetProjects.map { it.the<SourceSetContainer>()["main"].output })
+        executionData.setFrom(project.fileTree(".") {
+            include("**/build/jacoco/test.exec")
+        })
+
+        reports {
+            xml.required.set(true)
+            html.required.set(false)
+            csv.required.set(false)
+        }
+    }
+})
+
+
+@Suppress("MemberVisibilityCanBePrivate")
+open class CoverageExtension {
+    private val _excludes: MutableSet<Project> = mutableSetOf()
+
+    val excludes: Set<Project>
+        get() = _excludes
+
+    fun exclude(project: Project) {
+        _excludes.add(project)
+    }
+}
+
+fun Project.coverage(customize: CoverageExtension.() -> Unit) {
+    rootProject.configure(customize)
+}
+

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -8,3 +8,23 @@ abstract class AbstractPlugin : Plugin<Project> {
 
     protected abstract fun Project.initialize()
 }
+
+abstract class AbstractRootPlugin(
+    private val apply: Project.() -> Unit
+) : Plugin<Project> {
+    override fun apply(target: Project) {
+        if (target == target.rootProject) {
+            target.apply()
+        } else {
+            throw IllegalStateException("RootPlugin must be applied in root scope")
+        }
+    }
+}
+
+fun apply(apply: Project.() -> Unit) = apply
+
+fun Project.rootProject(action: Project.() -> Unit) {
+    if (this != rootProject) throw IllegalStateException("rootProject block must be used in root scope")
+
+    this.action()
+}

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import javax.persistence.EntityManager
 
-@Suppress("CAST_NEVER_SUCCEEDS")
 @ExtendWith(EntityManagerExtension::class)
 class EclipselinkCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQueryDslSelectIntegrationTest() {
     override lateinit var entityManager: EntityManager

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/select/EclipselinkCriteriaQueryDslSelectIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import javax.persistence.EntityManager
 
+@Suppress("CAST_NEVER_SUCCEEDS")
 @ExtendWith(EntityManagerExtension::class)
 class EclipselinkCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQueryDslSelectIntegrationTest() {
     override lateinit var entityManager: EntityManager
@@ -25,6 +26,9 @@ class EclipselinkCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQueryDs
 
         // then
         assertThat(exception)
-            .hasMessageContaining("class ${SubQueryImpl::class.qualifiedName} cannot be cast to class ${SelectionImpl::class.qualifiedName}")
+            .isInstanceOf(ClassCastException::class.java)
+            .hasMessageContaining(SubQueryImpl::class.qualifiedName)
+            .hasMessageContaining("cannot be cast")
+            .hasMessageContaining(SelectionImpl::class.qualifiedName)
     }
 }

--- a/examples/eclipselink/build.gradle.kts
+++ b/examples/eclipselink/build.gradle.kts
@@ -1,3 +1,7 @@
+coverage {
+    exclude(project)
+}
+
 dependencies {
     implementation(Modules.eclipselink)
     implementation(Dependencies.eclipselink)

--- a/examples/hibernate/build.gradle.kts
+++ b/examples/hibernate/build.gradle.kts
@@ -1,3 +1,7 @@
+coverage {
+    exclude(project)
+}
+
 dependencies {
     implementation(Modules.hibernate)
     implementation(Dependencies.hibernate)

--- a/examples/spring-boot-2.3/build.gradle.kts
+++ b/examples/spring-boot-2.3/build.gradle.kts
@@ -8,6 +8,10 @@ apply(plugin = "org.springframework.boot")
 apply(plugin = "kotlin-spring")
 apply(plugin = "kotlin-jpa")
 
+coverage {
+    exclude(project)
+}
+
 dependencies {
     // implementation("com.linecorp.kotlin-jdsl:hibernate-kotlin-jdsl:x.y.z")
     implementation(Modules.hibernate)

--- a/examples/spring-boot-2.4/build.gradle.kts
+++ b/examples/spring-boot-2.4/build.gradle.kts
@@ -8,6 +8,10 @@ apply(plugin = "org.springframework.boot")
 apply(plugin = "kotlin-spring")
 apply(plugin = "kotlin-jpa")
 
+coverage {
+    exclude(project)
+}
+
 dependencies {
     // implementation("com.linecorp.kotlin-jdsl:hibernate-kotlin-jdsl:x.y.z")
     implementation(Modules.hibernate)

--- a/examples/spring-boot-2.5/build.gradle.kts
+++ b/examples/spring-boot-2.5/build.gradle.kts
@@ -8,6 +8,10 @@ apply(plugin = "org.springframework.boot")
 apply(plugin = "kotlin-spring")
 apply(plugin = "kotlin-jpa")
 
+coverage {
+    exclude(project)
+}
+
 dependencies {
     // implementation("com.linecorp.kotlin-jdsl:hibernate-kotlin-jdsl:x.y.z")
     implementation(Modules.hibernate)

--- a/examples/spring-boot-2.6/build.gradle.kts
+++ b/examples/spring-boot-2.6/build.gradle.kts
@@ -8,6 +8,10 @@ apply(plugin = "org.springframework.boot")
 apply(plugin = "kotlin-spring")
 apply(plugin = "kotlin-jpa")
 
+coverage {
+    exclude(project)
+}
+
 dependencies {
     // implementation("com.linecorp.kotlin-jdsl:spring-data-kotlin-jdsl-starter:x.y.z")
     implementation(Modules.springDataStarter)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,6 @@ module(name = ":spring-data-kotlin-jdsl-autoconfigure", path = "spring/data-auto
 module(name = ":spring-data-kotlin-jdsl-starter", path = "spring/data-starter")
 
 // TEST FIXTURE
-module(name = ":test-fixture", path = "test-fixture")
 module(name = ":test-fixture-core", path = "test-fixture/core")
 module(name = ":test-fixture-entity", path = "test-fixture/entity")
 module(name = ":test-fixture-integration", path = "test-fixture/integration")

--- a/test-fixture/core/build.gradle.kts
+++ b/test-fixture/core/build.gradle.kts
@@ -1,3 +1,7 @@
+coverage {
+    exclude(project)
+}
+
 dependencies {
     api(Dependencies.junit)
     api(Dependencies.mockk)

--- a/test-fixture/entity/build.gradle.kts
+++ b/test-fixture/entity/build.gradle.kts
@@ -1,3 +1,7 @@
+coverage {
+    exclude(project)
+}
+
 dependencies {
     compileOnly(Dependencies.javaPersistenceApi)
 }

--- a/test-fixture/integration/build.gradle.kts
+++ b/test-fixture/integration/build.gradle.kts
@@ -1,3 +1,7 @@
+coverage {
+    exclude(project)
+}
+
 dependencies {
     api(Modules.testFixtureCore)
     api(Modules.testFixtureEntity)


### PR DESCRIPTION
Motivation:
We need to automatically measure code coverage and run tests whenever a PR is posted or the main branch is pushed to ensure that the project is working properly.
Refer to #20

-- korean
우리는 PR 이 올라오거나 main 브랜치가 push 될 때마다 자동으로 code coverage 를 측정하고 테스트를 수행하여 프로젝트가 정상적으로 동작하고 있다는 사실을 보장해야 합니다.

Modifications:
I modified jacoco, a code coverage plugin, to fit our project, which is a multi-module, automatically build and upload coverage using github actions.
Edited documents to include PR templates and contributors and badges.

-- korean
코드 커버리지 플러그인인 jacoco 를 멀티 모듈인 우리 프로젝트 특성에 맞게 수정하였고 github actions 를 이용하여 자동으로 빌드하고 커버리지를 업로드 하도록 하였습니다.
PR 템플릿과 contributor, badge 를 포함하는 문서를 수정했습니다.

Result:
There is no change experienced by users. Code coverage is uploaded whenever a PR is created or the main branch is pushed.
If there is a project to exclude code coverage from, you can modify the build script as shown in the code below.

```kotlin
coverage {
    exclude(project)
}
```

-- korean
사용자가 체감하는 변화는 없습니다. 코드 커버리지가 PR이 생성되거나 main 브랜치가 push 될때마다 업로드 됩니다.
코드 커버리지를 제외할 프로젝트가 존재할 경우 위 코드와 같이 빌드 스크립트를 수정하면 됩니다.