### PR TITLE
code coverage upload if github event is not pull request

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,10 +26,10 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: CodeCoverage(with test) with Gradle
-        if: github.event_name != 'pull_request'
         run: ./gradlew codeCoverageReport
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
+        if: github.event_name != 'pull_request'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: CodeCoverage(with test) with Gradle
+        if: github.event_name != 'pull_request'
         run: ./gradlew codeCoverageReport
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ If you believe you have discovered a vulnerability or have an issue related to s
 ```
 See [LICENSE](LICENSE) for more details.
 
-# Our Lovely Contrubutors
+# Our Lovely Contributors
 See [the complete list of our contributors](https://github.com/line/kotlin-jdsl/contributors).
 
 <a href="https://github.com/line/kotlin-jdsl/graphs/contributors">


### PR DESCRIPTION
# Motivation:

* We are uploading code coverage whenever PR occurs due to github actions. This part is judged to be inappropriate, and the complete code coverage of our project was modified because it was thought that it should be uploaded only when a push to the main branch occurred.
Refer to #26 

-- korean
github actions 로 인해 PR 이 발생할 때마다 code coverage 를 업로드 하고 있습니다. 이부분은 적절하지 않다고 판단되며 완전한 우리 프로젝트의 코드 커버리지는 main 브랜치에 push 가 일어났을때만 업로드 되는게 맞다고 생각되어 수정을 하였습니다.

# Modifications:

* The part of uploading code coverage in the workflow of github actions has been modified to be performed only when it is not a PR event.

-- korean
github actions 의 workflow 중 code coverage를 업로드하는 부분을 PR 이벤트가 아닐 경우에만 수행되도록 수정했습니다.

# Result:
* Code coverage is not uploaded when a PR event occurs.

-- korean
PR 이벤트가 일어났을때는 code coverage 가 업로드 되지 않습니다.