### PR TITLE
Support Criteria Delete API

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ val books: List<Row> = queryFactory.listQuery {
 }
 ```
 
-### Update
+### Update & Delete
 
-Users can perform bulk update through update query.
-* kotlin-jdsl's update does not require from clause. Type T given as generic handles from automatically.
-* According to the JPA specification, update does not support join, fetch, group by, order by, limit.
+Users can perform bulk update through update/delete query.
+* kotlin-jdsl's update/delete does not require from clause. Type T given as generic handles from automatically.
+* According to the JPA specification, update/delete does not support join, fetch, group by, order by, limit.
 * If you want to use an association mapping as a where condition, you must use [associate](#associate).
 
 ```kotlin
@@ -103,8 +103,15 @@ val query: Query = queryFactory.updateQuery<Order> {
     setParams(col(Order::purchaserId) to 3000)
 }
 
-val udpatedRowsCount: Int = query.executeUpdate()
+val updatedRowsCount: Int = query.executeUpdate()
+
+val deleteQuery: Query = queryFactory.deleteQuery<Order> {
+    where(col(Order::purchaserId).`in`(1000, 2000))
+}
+
+val deletedRowsCount: Int = deleteQuery.executeUpdate()
 ```
+
 
 ### Expression
 
@@ -226,11 +233,16 @@ val query = queryFactory.selectQuery<String> {
     associate(OrderAddress::class, Address::class, on(OrderAddress::address))
 }
 
-queryFactory.updateQuery<OrderAddress> {
+val updatedRowCount = queryFactory.updateQuery<OrderAddress> {
     where(col(OrderAddress::id).equal(address1.id))
     associate(OrderAddress::class, Address::class, on(OrderAddress::address))
     set(col(Address::zipCode), "test")
     set(col(Address::baseAddress), "base")
+}.executeUpdate()
+
+val deletedRowCount = queryFactory.deleteQuery<OrderAddress> {
+    where(col(OrderAddress::id).equal(address1.id))
+    associate(OrderAddress::class, Address::class, on(OrderAddress::address))
 }.executeUpdate()
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ val books: List<Row> = queryFactory.listQuery {
 
 ### Update & Delete
 
-Users can perform bulk update through update/delete query.
+Users can perform bulk update/delete through update/delete query.
 * kotlin-jdsl's update/delete does not require from clause. Type T given as generic handles from automatically.
 * According to the JPA specification, update/delete does not support join, fetch, group by, order by, limit.
 * If you want to use an association mapping as a where condition, you must use [associate](#associate).

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/QueryFactory.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/QueryFactory.kt
@@ -1,6 +1,7 @@
 package com.linecorp.kotlinjdsl
 
 import com.linecorp.kotlinjdsl.query.spec.expression.SubqueryExpressionSpec
+import com.linecorp.kotlinjdsl.querydsl.CriteriaDeleteQueryDsl
 import com.linecorp.kotlinjdsl.querydsl.CriteriaQueryDsl
 import com.linecorp.kotlinjdsl.querydsl.SubqueryDsl
 import com.linecorp.kotlinjdsl.querydsl.CriteriaUpdateQueryDsl
@@ -13,5 +14,6 @@ interface QueryFactory {
     fun <T> typedQuery(returnType: Class<T>, dsl: CriteriaQueryDsl<T>.() -> Unit) = selectQuery(returnType, dsl)
     fun <T> selectQuery(returnType: Class<T>, dsl: CriteriaQueryDsl<T>.() -> Unit): TypedQuery<T>
     fun <T: Any> updateQuery(target: KClass<T>, dsl: CriteriaUpdateQueryDsl.() -> Unit): Query
+    fun <T: Any> deleteQuery(target: KClass<T>, dsl: CriteriaDeleteQueryDsl.() -> Unit): Query
     fun <T> subquery(returnType: Class<T>, dsl: SubqueryDsl<T>.() -> Unit): SubqueryExpressionSpec<T>
 }

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensions.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensions.kt
@@ -1,5 +1,6 @@
 package com.linecorp.kotlinjdsl
 
+import com.linecorp.kotlinjdsl.querydsl.CriteriaDeleteQueryDsl
 import com.linecorp.kotlinjdsl.querydsl.CriteriaQueryDsl
 import com.linecorp.kotlinjdsl.querydsl.CriteriaUpdateQueryDsl
 import com.linecorp.kotlinjdsl.querydsl.SubqueryDsl
@@ -26,6 +27,9 @@ inline fun <reified T> QueryFactory.selectQuery(noinline dsl: CriteriaQueryDsl<T
 
 inline fun <reified T: Any> QueryFactory.updateQuery(noinline dsl: CriteriaUpdateQueryDsl.() -> Unit) =
     updateQuery(T::class, dsl)
+
+inline fun <reified T: Any> QueryFactory.deleteQuery(noinline dsl: CriteriaDeleteQueryDsl.() -> Unit) =
+    deleteQuery(T::class, dsl)
 
 inline fun <reified T> QueryFactory.subquery(noinline dsl: SubqueryDsl<T>.() -> Unit) =
     subquery(T::class.java, dsl)

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/QueryFactoryImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/QueryFactoryImpl.kt
@@ -3,10 +3,7 @@ package com.linecorp.kotlinjdsl
 import com.linecorp.kotlinjdsl.query.creator.CriteriaQueryCreator
 import com.linecorp.kotlinjdsl.query.creator.SubqueryCreator
 import com.linecorp.kotlinjdsl.query.spec.expression.SubqueryExpressionSpec
-import com.linecorp.kotlinjdsl.querydsl.CriteriaQueryDsl
-import com.linecorp.kotlinjdsl.querydsl.QueryDslImpl
-import com.linecorp.kotlinjdsl.querydsl.SubqueryDsl
-import com.linecorp.kotlinjdsl.querydsl.CriteriaUpdateQueryDsl
+import com.linecorp.kotlinjdsl.querydsl.*
 import javax.persistence.Query
 import javax.persistence.TypedQuery
 import kotlin.reflect.KClass
@@ -27,6 +24,12 @@ class QueryFactoryImpl(
     override fun <T: Any> updateQuery(target: KClass<T>, dsl: CriteriaUpdateQueryDsl.() -> Unit): Query {
         return criteriaQueryCreator.createQuery(
             QueryDslImpl(target.java).apply(dsl).apply { from(target) }.createCriteriaUpdateQuerySpec()
+        )
+    }
+
+    override fun <T: Any> deleteQuery(target: KClass<T>, dsl: CriteriaDeleteQueryDsl.() -> Unit): Query {
+        return criteriaQueryCreator.createQuery(
+            QueryDslImpl(target.java).apply(dsl).apply { from(target) }.createCriteriaDeleteQuerySpec()
         )
     }
 

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/CriteriaQueryCreator.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/CriteriaQueryCreator.kt
@@ -1,5 +1,6 @@
 package com.linecorp.kotlinjdsl.query.creator
 
+import com.linecorp.kotlinjdsl.query.CriteriaDeleteQuerySpec
 import com.linecorp.kotlinjdsl.query.CriteriaQuerySpec
 import com.linecorp.kotlinjdsl.query.CriteriaUpdateQuerySpec
 import javax.persistence.Query
@@ -8,4 +9,5 @@ import javax.persistence.TypedQuery
 interface CriteriaQueryCreator {
     fun <T> createQuery(spec: CriteriaQuerySpec<T>): TypedQuery<T>
     fun <T> createQuery(spec: CriteriaUpdateQuerySpec<T>): Query
+    fun <T> createQuery(spec: CriteriaDeleteQuerySpec<T>): Query
 }

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/CriteriaQueryCreatorImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/CriteriaQueryCreatorImpl.kt
@@ -1,10 +1,12 @@
 package com.linecorp.kotlinjdsl.query.creator
 
+import com.linecorp.kotlinjdsl.query.CriteriaDeleteQuerySpec
 import com.linecorp.kotlinjdsl.query.CriteriaQuerySpec
 import com.linecorp.kotlinjdsl.query.CriteriaUpdateQuerySpec
 import javax.persistence.EntityManager
 import javax.persistence.Query
 import javax.persistence.TypedQuery
+import javax.persistence.criteria.CriteriaDelete
 import javax.persistence.criteria.CriteriaUpdate
 
 class CriteriaQueryCreatorImpl(
@@ -43,4 +45,17 @@ class CriteriaQueryCreatorImpl(
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> createQuery(spec: CriteriaDeleteQuerySpec<T>): Query {
+        val criteriaBuilder = em.criteriaBuilder
+        val query = criteriaBuilder.createCriteriaDelete(spec.targetEntity) as CriteriaDelete<Any>
+        val froms = spec.from.associate(spec.associate, query, spec.targetEntity)
+
+        spec.where.apply(froms, query, criteriaBuilder)
+
+        return em.createQuery(query).apply {
+            spec.jpaHint.apply(this)
+            spec.sqlHint.apply(this)
+        }
+    }
 }

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensionsTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensionsTest.kt
@@ -1,8 +1,11 @@
 package com.linecorp.kotlinjdsl
 
 import com.linecorp.kotlinjdsl.query.spec.expression.SubqueryExpressionSpec
+import com.linecorp.kotlinjdsl.querydsl.CriteriaDeleteQueryDsl
 import com.linecorp.kotlinjdsl.querydsl.CriteriaQueryDsl
+import com.linecorp.kotlinjdsl.querydsl.CriteriaUpdateQueryDsl
 import com.linecorp.kotlinjdsl.querydsl.SubqueryDsl
+import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -12,6 +15,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.stream.Stream
+import javax.persistence.Query
 import javax.persistence.TypedQuery
 
 @ExtendWith(MockKExtension::class)
@@ -124,6 +128,52 @@ internal class QueryFactoryExtensionsTest : WithKotlinJdslAssertions {
 
         confirmVerified(queryFactory)
     }
+
+    @Test
+    fun updateQuery() {
+        // given
+        every { queryFactory.updateQuery<Data1>(any(), any()) } returns typedQuery
+
+        val dsl: CriteriaUpdateQueryDsl.() -> Unit = {
+            set(col(Data1::id), 1)
+            where(col(Data1::id).equal(2))
+        }
+
+        // when
+        val actual: Query = queryFactory.updateQuery<Data1>(dsl)
+
+        // then
+        assertThat(actual).isEqualTo(typedQuery)
+
+        verify(exactly = 1) {
+            queryFactory.updateQuery(Data1::class, dsl)
+        }
+
+        confirmVerified(queryFactory)
+    }
+
+    @Test
+    fun deleteQuery() {
+        // given
+        every { queryFactory.deleteQuery<Data1>(any(), any()) } returns typedQuery
+
+        val dsl: CriteriaDeleteQueryDsl.() -> Unit = {
+            where(col(Data1::id).equal(1))
+        }
+
+        // when
+        val actual: Query = queryFactory.deleteQuery<Data1>(dsl)
+
+        // then
+        assertThat(actual).isEqualTo(typedQuery)
+
+        verify(exactly = 1) {
+            queryFactory.deleteQuery(Data1::class, dsl)
+        }
+
+        confirmVerified(queryFactory)
+    }
+
 
     @Test
     fun subquery() {

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/QueryFactoryImplTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/QueryFactoryImplTest.kt
@@ -126,6 +126,38 @@ internal class QueryFactoryImplTest : WithKotlinJdslAssertions {
     }
 
     @Test
+    fun deleteQuery() {
+        // given
+        val query: Query = mockk()
+
+        every { criteriaQueryCreator.createQuery(any<QueryDslImpl.CriteriaDeleteQuerySpecImpl<Data1>>()) } returns query
+
+        // when
+        val actual = sut.deleteQuery(Data1::class) {
+            where(col(Data1::id).equal(1))
+        }
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verify(exactly = 1) {
+            val columnSpec = ColumnSpec<Int>(EntitySpec(Data1::class.java), Data1::id.name)
+            criteriaQueryCreator.createQuery(
+                QueryDslImpl.CriteriaDeleteQuerySpecImpl(
+                    from = FromClause(EntitySpec(Data1::class.java)),
+                    associate = SimpleAssociatedJoinClause(emptyList()),
+                    where = WhereClause(EqualValueSpec(columnSpec, 1)),
+                    jpaHint = JpaQueryHintClauseImpl(emptyMap()),
+                    sqlHint = EmptySqlQueryHintClause,
+                    targetEntity = Data1::class.java
+                )
+            )
+        }
+
+        confirmVerified(criteriaQueryCreator)
+    }
+
+    @Test
     fun subquery() {
         // when
         val actual = sut.subquery(Data1::class.java) {

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/criteriaquery/EclipselinkCriteriaDeleteIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/criteriaquery/EclipselinkCriteriaDeleteIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.criteriaquery
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.criteriaquery.AbstractCriteriaDeleteIntegrationTest
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+class EclipselinkCriteriaDeleteIntegrationTest : AbstractCriteriaDeleteIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+}

--- a/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/hibernate/criteriaquery/HibernateCriteriaDeleteIntegrationTest.kt
+++ b/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/hibernate/criteriaquery/HibernateCriteriaDeleteIntegrationTest.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.hibernate.criteriaquery
+
+import com.linecorp.kotlinjdsl.test.integration.EntityManagerExtension
+import com.linecorp.kotlinjdsl.test.integration.criteriaquery.AbstractCriteriaDeleteIntegrationTest
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.EntityManager
+
+@ExtendWith(EntityManagerExtension::class)
+class HibernateCriteriaDeleteIntegrationTest : AbstractCriteriaDeleteIntegrationTest() {
+    override lateinit var entityManager: EntityManager
+}

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/CriteriaMutableQuerySpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/CriteriaMutableQuerySpec.kt
@@ -1,0 +1,24 @@
+package com.linecorp.kotlinjdsl.query
+
+import com.linecorp.kotlinjdsl.query.clause.from.FromClause
+import com.linecorp.kotlinjdsl.query.clause.from.SimpleAssociatedJoinClause
+import com.linecorp.kotlinjdsl.query.clause.hint.JpaQueryHintClause
+import com.linecorp.kotlinjdsl.query.clause.hint.SqlQueryHintClause
+import com.linecorp.kotlinjdsl.query.clause.where.CriteriaQueryWhereClause
+
+interface CriteriaMutableQuerySpec<T> {
+    val targetEntity: Class<T>
+    val from: FromClause
+    val associate: SimpleAssociatedJoinClause
+    val where: CriteriaQueryWhereClause
+    val jpaHint: JpaQueryHintClause
+    val sqlHint: SqlQueryHintClause
+}
+
+/**
+ * According to the current specification, CriteriaMutableQuerySpec and CriteriaDeleteQuerySpec are the same.
+ * so instead of creating an interface, create a typealias.
+ * If the specifications change in the future, separate them into separate interfaces.
+ * This is because CriteriaUpdateQuerySpec inherits from CriteriaMutableQuerySpec.
+ */
+typealias CriteriaDeleteQuerySpec<T> = CriteriaMutableQuerySpec<T>

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/CriteriaUpdateQuerySpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/CriteriaUpdateQuerySpec.kt
@@ -1,18 +1,7 @@
 package com.linecorp.kotlinjdsl.query
 
-import com.linecorp.kotlinjdsl.query.clause.from.FromClause
-import com.linecorp.kotlinjdsl.query.clause.from.SimpleAssociatedJoinClause
-import com.linecorp.kotlinjdsl.query.clause.hint.JpaQueryHintClause
-import com.linecorp.kotlinjdsl.query.clause.hint.SqlQueryHintClause
 import com.linecorp.kotlinjdsl.query.clause.set.SetClause
-import com.linecorp.kotlinjdsl.query.clause.where.CriteriaQueryWhereClause
 
-interface CriteriaUpdateQuerySpec<T> {
-    val targetEntity: Class<T>
-    val from: FromClause
-    val associate: SimpleAssociatedJoinClause
-    val where: CriteriaQueryWhereClause
-    val jpaHint: JpaQueryHintClause
-    val sqlHint: SqlQueryHintClause
+interface CriteriaUpdateQuerySpec<T> : CriteriaMutableQuerySpec<T> {
     val set: SetClause
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClause.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.query.clause.from
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
 import javax.persistence.criteria.AbstractQuery
+import javax.persistence.criteria.CriteriaDelete
 import javax.persistence.criteria.CriteriaUpdate
 
 data class FromClause(
@@ -13,6 +14,10 @@ data class FromClause(
     }
 
     fun associate(joinClause: SimpleAssociatedJoinClause, query: CriteriaUpdate<in Any>, targetEntity: Class<*>): Froms {
+        return SimpleAssociator(entity, joinClause.joins, query.from(targetEntity)).associateAll()
+    }
+
+    fun associate(joinClause: SimpleAssociatedJoinClause, query: CriteriaDelete<in Any>, targetEntity: Class<*>): Froms {
         return SimpleAssociator(entity, joinClause.joins, query.from(targetEntity)).associateAll()
     }
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/where/CriteriaQueryWhereClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/where/CriteriaQueryWhereClause.kt
@@ -2,10 +2,12 @@ package com.linecorp.kotlinjdsl.query.clause.where
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.CriteriaDelete
 import javax.persistence.criteria.CriteriaQuery
 import javax.persistence.criteria.CriteriaUpdate
 
 interface CriteriaQueryWhereClause {
     fun apply(froms: Froms, query: CriteriaQuery<*>, criteriaBuilder: CriteriaBuilder)
     fun apply(froms: Froms, query: CriteriaUpdate<*>, criteriaBuilder: CriteriaBuilder)
+    fun apply(froms: Froms, query: CriteriaDelete<*>, criteriaBuilder: CriteriaBuilder)
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/where/WhereClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/where/WhereClause.kt
@@ -17,6 +17,12 @@ data class WhereClause(
         query.where(predicate.toCriteriaPredicate(froms, query, criteriaBuilder))
     }
 
+    override fun apply(froms: Froms, query: CriteriaDelete<*>, criteriaBuilder: CriteriaBuilder) {
+        if (predicate.isEmpty()) return
+
+        query.where(predicate.toCriteriaPredicate(froms, query, criteriaBuilder))
+    }
+
     override fun apply(froms: Froms, query: Subquery<*>, criteriaBuilder: CriteriaBuilder) {
         applyInternally(froms, query, criteriaBuilder)
     }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/SubqueryCreator.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/SubqueryCreator.kt
@@ -2,30 +2,15 @@ package com.linecorp.kotlinjdsl.query.creator
 
 import com.linecorp.kotlinjdsl.query.SubquerySpec
 import com.linecorp.kotlinjdsl.query.spec.Froms
+import javax.persistence.criteria.CommonAbstractCriteria
 import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaQuery
-import javax.persistence.criteria.CriteriaUpdate
 import javax.persistence.criteria.Subquery
 
 interface SubqueryCreator {
     fun <T> createQuery(
         spec: SubquerySpec<T>,
         froms: Froms,
-        criteriaQuery: CriteriaQuery<*>,
-        criteriaBuilder: CriteriaBuilder
-    ): Subquery<T>
-
-    fun <T> createQuery(
-        spec: SubquerySpec<T>,
-        froms: Froms,
-        criteriaQuery: CriteriaUpdate<*>,
-        criteriaBuilder: CriteriaBuilder
-    ): Subquery<T>
-
-    fun <T> createQuery(
-        spec: SubquerySpec<T>,
-        froms: Froms,
-        subquery: Subquery<*>,
+        commonQuery: CommonAbstractCriteria,
         criteriaBuilder: CriteriaBuilder
     ): Subquery<T>
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/SubqueryCreatorImpl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/SubqueryCreatorImpl.kt
@@ -2,58 +2,23 @@ package com.linecorp.kotlinjdsl.query.creator
 
 import com.linecorp.kotlinjdsl.query.SubquerySpec
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaQuery
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Subquery
+import javax.persistence.criteria.*
 
 class SubqueryCreatorImpl : SubqueryCreator {
     override fun <T> createQuery(
         spec: SubquerySpec<T>,
         froms: Froms,
-        criteriaQuery: CriteriaQuery<*>,
+        commonQuery: CommonAbstractCriteria,
         criteriaBuilder: CriteriaBuilder
     ): Subquery<T> {
-        val query = criteriaQuery.subquery(spec.select.returnType)
+        val subquery = commonQuery.subquery(spec.select.returnType)
+        val subqueryFroms = spec.from.join(spec.join, subquery) + froms
 
-        return apply(spec, froms, query, criteriaBuilder)
-    }
+        spec.select.apply(subqueryFroms, subquery, criteriaBuilder)
+        spec.where.apply(subqueryFroms, subquery, criteriaBuilder)
+        spec.groupBy.apply(subqueryFroms, subquery, criteriaBuilder)
+        spec.having.apply(subqueryFroms, subquery, criteriaBuilder)
 
-    override fun <T> createQuery(
-        spec: SubquerySpec<T>,
-        froms: Froms,
-        criteriaQuery: CriteriaUpdate<*>,
-        criteriaBuilder: CriteriaBuilder
-    ): Subquery<T> {
-        val query = criteriaQuery.subquery(spec.select.returnType)
-
-        return apply(spec, froms, query, criteriaBuilder)
-    }
-
-    override fun <T> createQuery(
-        spec: SubquerySpec<T>,
-        froms: Froms,
-        subquery: Subquery<*>,
-        criteriaBuilder: CriteriaBuilder
-    ): Subquery<T> {
-        val query = subquery.subquery(spec.select.returnType)
-
-        return apply(spec, froms, query, criteriaBuilder)
-    }
-
-    private fun <T> apply(
-        spec: SubquerySpec<T>,
-        froms: Froms,
-        query: Subquery<T>,
-        criteriaBuilder: CriteriaBuilder
-    ): Subquery<T> {
-        val subqueryFroms = spec.from.join(spec.join, query) + froms
-
-        spec.select.apply(subqueryFroms, query, criteriaBuilder)
-        spec.where.apply(subqueryFroms, query, criteriaBuilder)
-        spec.groupBy.apply(subqueryFroms, query, criteriaBuilder)
-        spec.having.apply(subqueryFroms, query, criteriaBuilder)
-
-        return query
+        return subquery
     }
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/AvgSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/AvgSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class AvgSpec<T : Number?>(
     val column: ColumnSpec<T>
@@ -22,6 +19,16 @@ data class AvgSpec<T : Number?>(
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<Double> {
+        val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return criteriaBuilder.avg(expression)
+    }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<Double> {
         val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/CaseSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/CaseSpec.kt
@@ -2,10 +2,7 @@ package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class CaseSpec<T>(
     val whens: List<WhenSpec<out T>>,
@@ -29,6 +26,21 @@ data class CaseSpec<T>(
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> {
+        return criteriaBuilder.selectCase<T>().apply {
+            whens.forEach {
+                `when`(
+                    it.predicate.toCriteriaPredicate(froms, query, criteriaBuilder),
+                    it.result.toCriteriaExpression(froms, query, criteriaBuilder),
+                )
+            }
+        }.otherwise(`else`.toCriteriaExpression(froms, query, criteriaBuilder))
+    }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
         return criteriaBuilder.selectCase<T>().apply {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class ColumnSpec<T>(
     val entity: EntitySpec<*>,
@@ -15,7 +12,7 @@ data class ColumnSpec<T>(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return froms[entity].get(path)
+        return path(froms)
     }
 
     override fun toCriteriaExpression(
@@ -23,6 +20,17 @@ data class ColumnSpec<T>(
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return froms[entity].get(path)
+        return path(froms)
     }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> {
+        return path(froms)
+    }
+
+    private fun path(froms: Froms): Path<T> =
+        froms[entity].get(path)
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/CountSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/CountSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class CountSpec<T>(
     val distinct: Boolean = false,
@@ -23,6 +20,16 @@ data class CountSpec<T>(
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<Long> {
+        val jpaExpression = column.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return toCriteriaExpression(criteriaBuilder, jpaExpression)
+    }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<Long> {
         val jpaExpression = column.toCriteriaExpression(froms, query, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/EntitySpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/EntitySpec.kt
@@ -14,13 +14,21 @@ data class EntitySpec<T>(
         froms: Froms,
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
-    ): Expression<T> = froms[this].apply { applyAlias() }
+    ): Expression<T> = path(froms)
 
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
-    ): Expression<T> = froms[this].apply { applyAlias() }
+    ): Expression<T> = path(froms)
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> = path(froms)
+
+    private fun path(froms: Froms) = froms[this].apply { applyAlias() }
 
     private fun Path<T>.applyAlias() {
         this@EntitySpec.alias.takeIf { !it.startsWith(DEFAULT_ALIAS_TOKEN) }?.run { alias(this) }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ExpressionSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ExpressionSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 interface ExpressionSpec<T> {
     fun toCriteriaExpression(
@@ -16,6 +13,12 @@ interface ExpressionSpec<T> {
     fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T>
+
+    fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T>
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/FunctionSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/FunctionSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class FunctionSpec<T>(
     val name: String,
@@ -18,7 +15,7 @@ data class FunctionSpec<T>(
     ): Expression<T> {
         return toCriteriaExpression(
             criteriaBuilder = criteriaBuilder,
-            expressions = expressions.map { it.toCriteriaExpression(froms, query, criteriaBuilder) }.toTypedArray()
+            expressions = expressions.map { it.toCriteriaExpression(froms, query, criteriaBuilder) }
         )
     }
 
@@ -29,18 +26,29 @@ data class FunctionSpec<T>(
     ): Expression<T> {
         return toCriteriaExpression(
             criteriaBuilder = criteriaBuilder,
-            expressions = expressions.map { it.toCriteriaExpression(froms, query, criteriaBuilder) }.toTypedArray()
+            expressions = expressions.map { it.toCriteriaExpression(froms, query, criteriaBuilder) }
+        )
+    }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> {
+        return toCriteriaExpression(
+            criteriaBuilder = criteriaBuilder,
+            expressions = expressions.map { it.toCriteriaExpression(froms, query, criteriaBuilder) }
         )
     }
 
     private fun toCriteriaExpression(
         criteriaBuilder: CriteriaBuilder,
-        expressions: Array<Expression<out Any?>>
+        expressions: List<Expression<out Any?>>
     ): Expression<T> {
         return criteriaBuilder.function(
             name,
             returnType,
-            *expressions
+            *expressions.toTypedArray()
         )
     }
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/GreatestSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/GreatestSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class GreatestSpec<T : Comparable<T>?>(
     val column: ColumnSpec<T>
@@ -22,6 +19,16 @@ data class GreatestSpec<T : Comparable<T>?>(
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> {
+        val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return criteriaBuilder.greatest(expression)
+    }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
         val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/LeastSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/LeastSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class LeastSpec<T : Comparable<T>?>(
     val column: ColumnSpec<T>
@@ -22,6 +19,16 @@ data class LeastSpec<T : Comparable<T>?>(
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> {
+        val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return criteriaBuilder.least(expression)
+    }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
         val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/LiteralSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/LiteralSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class LiteralSpec<T : Any>(
     val value: T,
@@ -18,6 +15,12 @@ data class LiteralSpec<T : Any>(
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> = criteriaBuilder.literal(value)
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> = criteriaBuilder.literal(value)
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/MaxSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/MaxSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class MaxSpec<T : Number?>(
     val column: ColumnSpec<T>
@@ -22,6 +19,16 @@ data class MaxSpec<T : Number?>(
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> {
+        val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return criteriaBuilder.max(expression)
+    }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
         val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/MinSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/MinSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class MinSpec<T : Number?>(
     val column: ColumnSpec<T>
@@ -22,6 +19,16 @@ data class MinSpec<T : Number?>(
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> {
+        val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return criteriaBuilder.min(expression)
+    }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
         val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NullLiteralSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NullLiteralSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class NullLiteralSpec<T>(
     val type: Class<T>,
@@ -18,6 +15,12 @@ data class NullLiteralSpec<T>(
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T?> = criteriaBuilder.nullLiteral(type)
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T?> = criteriaBuilder.nullLiteral(type)
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/SubqueryExpressionSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/SubqueryExpressionSpec.kt
@@ -14,16 +14,20 @@ data class SubqueryExpressionSpec<T>(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return when (query) {
-            is CriteriaQuery -> subqueryCreator.createQuery(spec, froms, query, criteriaBuilder)
-            is Subquery -> subqueryCreator.createQuery(spec, froms, query, criteriaBuilder)
-            else -> throw IllegalStateException("${query::class.qualifiedName} could not create Subquery")
-        }
+        return subqueryCreator.createQuery(spec, froms, query, criteriaBuilder)
     }
 
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> {
+        return subqueryCreator.createQuery(spec, froms, query, criteriaBuilder)
+    }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
         return subqueryCreator.createQuery(spec, froms, query, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/SumSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/SumSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 data class SumSpec<T : Number?>(
     val column: ColumnSpec<T>
@@ -22,6 +19,16 @@ data class SumSpec<T : Number?>(
     override fun toCriteriaExpression(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Expression<T> {
+        val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return criteriaBuilder.sum(expression)
+    }
+
+    override fun toCriteriaExpression(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
         val expression = column.toCriteriaExpression(froms, query, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/AndSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/AndSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 data class AndSpec(
     val predicates: List<PredicateSpec?>,
@@ -25,7 +22,15 @@ data class AndSpec(
         return toCriteriaPredicate(criteriaBuilder) { it.toCriteriaPredicate(froms, query, criteriaBuilder) }
     }
 
-    fun toCriteriaPredicate(criteriaBuilder: CriteriaBuilder, predicate: (PredicateSpec) -> Predicate): Predicate {
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        return toCriteriaPredicate(criteriaBuilder) { it.toCriteriaPredicate(froms, query, criteriaBuilder) }
+    }
+
+    private fun toCriteriaPredicate(criteriaBuilder: CriteriaBuilder, predicate: (PredicateSpec) -> Predicate): Predicate {
         return predicates.asSequence()
             .filterNotNull()
             .map { predicate(it) }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/BetweenExpressionSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/BetweenExpressionSpec.kt
@@ -2,10 +2,7 @@ package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 data class BetweenExpressionSpec<T : Comparable<T>>(
     val left: ExpressionSpec<T>,
@@ -27,6 +24,18 @@ data class BetweenExpressionSpec<T : Comparable<T>>(
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        return criteriaBuilder.between(
+            left.toCriteriaExpression(froms, query, criteriaBuilder),
+            right1.toCriteriaExpression(froms, query, criteriaBuilder),
+            right2.toCriteriaExpression(froms, query, criteriaBuilder),
+        )
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         return criteriaBuilder.between(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/BetweenValueSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/BetweenValueSpec.kt
@@ -2,17 +2,14 @@ package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
+@Suppress("TYPE_MISMATCH_WARNING")
 data class BetweenValueSpec<T, R>(
     val left: ExpressionSpec<T>,
     val right1: R,
     val right2: R,
 ) : PredicateSpec where R : Comparable<R>, R : Any, T : R? {
-    @Suppress("TYPE_MISMATCH_WARNING")
     override fun toCriteriaPredicate(
         froms: Froms,
         query: AbstractQuery<*>,
@@ -21,10 +18,17 @@ data class BetweenValueSpec<T, R>(
         return criteriaBuilder.between<R>(left.toCriteriaExpression(froms, query, criteriaBuilder), right1, right2)
     }
 
-    @Suppress("TYPE_MISMATCH_WARNING")
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        return criteriaBuilder.between<R>(left.toCriteriaExpression(froms, query, criteriaBuilder), right1, right2)
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         return criteriaBuilder.between<R>(left.toCriteriaExpression(froms, query, criteriaBuilder), right1, right2)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EmptyPredicateSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EmptyPredicateSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 object EmptyPredicateSpec : PredicateSpec {
     override fun toCriteriaPredicate(
@@ -18,6 +15,14 @@ object EmptyPredicateSpec : PredicateSpec {
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        return criteriaBuilder.conjunction()
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         return criteriaBuilder.conjunction()

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EqualExpressionSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EqualExpressionSpec.kt
@@ -2,10 +2,7 @@ package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 data class EqualExpressionSpec<T>(
     val left: ExpressionSpec<T>,
@@ -25,6 +22,17 @@ data class EqualExpressionSpec<T>(
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        return criteriaBuilder.equal(
+            left.toCriteriaExpression(froms, query, criteriaBuilder),
+            right.toCriteriaExpression(froms, query, criteriaBuilder),
+        )
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         return criteriaBuilder.equal(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EqualValueSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EqualValueSpec.kt
@@ -2,10 +2,7 @@ package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 data class EqualValueSpec<T>(
     val left: ExpressionSpec<T>,
@@ -22,6 +19,14 @@ data class EqualValueSpec<T>(
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        return criteriaBuilder.equal(left.toCriteriaExpression(froms, query, criteriaBuilder), right)
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         return criteriaBuilder.equal(left.toCriteriaExpression(froms, query, criteriaBuilder), right)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/GreaterThanExpressionSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/GreaterThanExpressionSpec.kt
@@ -31,6 +31,17 @@ data class GreaterThanExpressionSpec<T : Comparable<T>>(
         return toCriteriaPredicate(criteriaBuilder, leftExpression, rightExpression)
     }
 
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        val leftExpression = left.toCriteriaExpression(froms, query, criteriaBuilder)
+        val rightExpression = right.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return toCriteriaPredicate(criteriaBuilder, leftExpression, rightExpression)
+    }
+
     private fun toCriteriaPredicate(
         criteriaBuilder: CriteriaBuilder,
         leftExpression: Expression<T>,

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/GreaterThanValueSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/GreaterThanValueSpec.kt
@@ -30,6 +30,16 @@ data class GreaterThanValueSpec<T, R>(
         return toCriteriaPredicate(criteriaBuilder, leftExpression)
     }
 
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        val leftExpression = left.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return toCriteriaPredicate(criteriaBuilder, leftExpression)
+    }
+
     private fun toCriteriaPredicate(
         criteriaBuilder: CriteriaBuilder,
         leftExpression: Expression<T>

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InExpressionSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InExpressionSpec.kt
@@ -2,10 +2,7 @@ package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 data class InExpressionSpec<T>(
     val left: ExpressionSpec<T>,
@@ -26,6 +23,18 @@ data class InExpressionSpec<T>(
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        if (rights.isEmpty()) return criteriaBuilder.conjunction()
+
+        return criteriaBuilder.`in`(left.toCriteriaExpression(froms, query, criteriaBuilder)).apply {
+            rights.forEach { value(it.toCriteriaExpression(froms, query, criteriaBuilder)) }
+        }
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         if (rights.isEmpty()) return criteriaBuilder.conjunction()

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InValueSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InValueSpec.kt
@@ -2,10 +2,7 @@ package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 data class InValueSpec<T>(
     val left: ExpressionSpec<T>,
@@ -26,6 +23,18 @@ data class InValueSpec<T>(
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        if (rights.isEmpty()) return criteriaBuilder.conjunction()
+
+        return criteriaBuilder.`in`(left.toCriteriaExpression(froms, query, criteriaBuilder)).apply {
+            rights.forEach { value(it) }
+        }
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         if (rights.isEmpty()) return criteriaBuilder.conjunction()

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsFalseSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsFalseSpec.kt
@@ -4,6 +4,7 @@ import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
 import javax.persistence.criteria.*
 
+@Suppress("UNCHECKED_CAST")
 data class IsFalseSpec(
     val expression: ExpressionSpec<out Boolean?>
 ) : PredicateSpec {
@@ -12,7 +13,6 @@ data class IsFalseSpec(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        @Suppress("UNCHECKED_CAST")
         return criteriaBuilder.isFalse(
             expression.toCriteriaExpression(froms, query, criteriaBuilder) as Expression<Boolean?>
         )
@@ -23,7 +23,16 @@ data class IsFalseSpec(
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        @Suppress("UNCHECKED_CAST")
+        return criteriaBuilder.isFalse(
+            expression.toCriteriaExpression(froms, query, criteriaBuilder) as Expression<Boolean?>
+        )
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
         return criteriaBuilder.isFalse(
             expression.toCriteriaExpression(froms, query, criteriaBuilder) as Expression<Boolean?>
         )

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsNullSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsNullSpec.kt
@@ -2,10 +2,7 @@ package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 data class IsNullSpec<T : Any?>(
     val expression: ExpressionSpec<T>
@@ -21,6 +18,14 @@ data class IsNullSpec<T : Any?>(
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        return criteriaBuilder.isNull(expression.toCriteriaExpression(froms, query, criteriaBuilder))
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         return criteriaBuilder.isNull(expression.toCriteriaExpression(froms, query, criteriaBuilder))

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsTrueSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsTrueSpec.kt
@@ -4,6 +4,7 @@ import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
 import javax.persistence.criteria.*
 
+@Suppress("UNCHECKED_CAST")
 data class IsTrueSpec(
     val expression: ExpressionSpec<out Boolean?>
 ) : PredicateSpec {
@@ -12,7 +13,6 @@ data class IsTrueSpec(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        @Suppress("UNCHECKED_CAST")
         return criteriaBuilder.isTrue(
             expression.toCriteriaExpression(froms, query, criteriaBuilder) as Expression<Boolean?>
         )
@@ -23,7 +23,16 @@ data class IsTrueSpec(
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        @Suppress("UNCHECKED_CAST")
+        return criteriaBuilder.isTrue(
+            expression.toCriteriaExpression(froms, query, criteriaBuilder) as Expression<Boolean?>
+        )
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
         return criteriaBuilder.isTrue(
             expression.toCriteriaExpression(froms, query, criteriaBuilder) as Expression<Boolean?>
         )

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LessThanExpressionSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LessThanExpressionSpec.kt
@@ -31,6 +31,17 @@ data class LessThanExpressionSpec<T : Comparable<T>>(
         return toCriteriaPredicate(criteriaBuilder, leftExpression, rightExpression)
     }
 
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        val leftExpression = left.toCriteriaExpression(froms, query, criteriaBuilder)
+        val rightExpression = right.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return toCriteriaPredicate(criteriaBuilder, leftExpression, rightExpression)
+    }
+
     private fun toCriteriaPredicate(
         criteriaBuilder: CriteriaBuilder,
         leftExpression: Expression<T>,

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LessThanValueSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LessThanValueSpec.kt
@@ -4,12 +4,12 @@ import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
 import javax.persistence.criteria.*
 
+@Suppress("TYPE_MISMATCH_WARNING")
 data class LessThanValueSpec<T, R>(
     val left: ExpressionSpec<T>,
     val right: R,
     val inclusive: Boolean,
 ) : PredicateSpec where R : Comparable<R>, R : Any, T : R? {
-    @Suppress("TYPE_MISMATCH_WARNING")
     override fun toCriteriaPredicate(
         froms: Froms,
         query: AbstractQuery<*>,
@@ -20,10 +20,19 @@ data class LessThanValueSpec<T, R>(
         return toCriteriaPredicate(criteriaBuilder, leftExpression)
     }
 
-    @Suppress("TYPE_MISMATCH_WARNING")
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        val leftExpression: Expression<T> = left.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        return toCriteriaPredicate(criteriaBuilder, leftExpression)
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         val leftExpression: Expression<T> = left.toCriteriaExpression(froms, query, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LikeSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LikeSpec.kt
@@ -4,6 +4,7 @@ import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
 import javax.persistence.criteria.*
 
+@Suppress("UNCHECKED_CAST")
 data class LikeSpec(
     val left: ExpressionSpec<out String?>,
     val right: String
@@ -13,7 +14,6 @@ data class LikeSpec(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        @Suppress("UNCHECKED_CAST")
         return criteriaBuilder.like(
             left.toCriteriaExpression(froms, query, criteriaBuilder) as Expression<String?>,
             right
@@ -25,7 +25,17 @@ data class LikeSpec(
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        @Suppress("UNCHECKED_CAST")
+        return criteriaBuilder.like(
+            left.toCriteriaExpression(froms, query, criteriaBuilder) as Expression<String?>,
+            right
+        )
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
         return criteriaBuilder.like(
             left.toCriteriaExpression(froms, query, criteriaBuilder) as Expression<String?>,
             right

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/NotSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/NotSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 data class NotSpec(
     val predicate: PredicateSpec,
@@ -20,6 +17,14 @@ data class NotSpec(
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        return criteriaBuilder.not(predicate.toCriteriaPredicate(froms, query, criteriaBuilder))
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         return criteriaBuilder.not(predicate.toCriteriaPredicate(froms, query, criteriaBuilder))

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/OrSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/OrSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 data class OrSpec(
     val predicates: List<PredicateSpec?>,
@@ -29,6 +26,22 @@ data class OrSpec(
     override fun toCriteriaPredicate(
         froms: Froms,
         query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        return toCriteriaPredicate(
+            criteriaBuilder = criteriaBuilder,
+            empty = { EmptyPredicateSpec.toCriteriaPredicate(froms, query, criteriaBuilder) }) {
+            it.toCriteriaPredicate(
+                froms,
+                query,
+                criteriaBuilder
+            )
+        }
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
         return toCriteriaPredicate(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/PredicateSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/PredicateSpec.kt
@@ -1,10 +1,7 @@
 package com.linecorp.kotlinjdsl.query.spec.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 interface PredicateSpec {
     companion object {
@@ -20,4 +17,5 @@ interface PredicateSpec {
 
     fun toCriteriaPredicate(froms: Froms, query: AbstractQuery<*>, criteriaBuilder: CriteriaBuilder): Predicate
     fun toCriteriaPredicate(froms: Froms, query: CriteriaUpdate<*>, criteriaBuilder: CriteriaBuilder): Predicate
+    fun toCriteriaPredicate(froms: Froms, query: CriteriaDelete<*>, criteriaBuilder: CriteriaBuilder): Predicate
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/CriteriaMutableQueryDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/CriteriaMutableQueryDsl.kt
@@ -1,0 +1,24 @@
+package com.linecorp.kotlinjdsl.querydsl
+
+import com.linecorp.kotlinjdsl.querydsl.expression.ExpressionDsl
+import com.linecorp.kotlinjdsl.querydsl.from.AssociateDsl
+import com.linecorp.kotlinjdsl.querydsl.from.RelationDsl
+import com.linecorp.kotlinjdsl.querydsl.hint.HintDsl
+import com.linecorp.kotlinjdsl.querydsl.predicate.PredicateDsl
+import com.linecorp.kotlinjdsl.querydsl.where.WhereDsl
+
+interface CriteriaMutableQueryDsl :
+    ExpressionDsl,
+    PredicateDsl,
+    AssociateDsl,
+    RelationDsl,
+    WhereDsl,
+    HintDsl
+
+/**
+ * According to the current specification, CriteriaMutableQueryDsl and CriteriaDeleteQueryDsl are the same.
+ * so instead of creating an interface, create a typealias.
+ * If the specifications change in the future, separate them into separate interfaces.
+ * This is because CriteriaUpdateQueryDsl inherits from CriteriaMutableQueryDsl.
+ */
+typealias CriteriaDeleteQueryDsl = CriteriaMutableQueryDsl

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/CriteriaUpdateQueryDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/CriteriaUpdateQueryDsl.kt
@@ -1,18 +1,5 @@
 package com.linecorp.kotlinjdsl.querydsl
 
-import com.linecorp.kotlinjdsl.querydsl.expression.ExpressionDsl
-import com.linecorp.kotlinjdsl.querydsl.from.AssociateDsl
-import com.linecorp.kotlinjdsl.querydsl.from.RelationDsl
-import com.linecorp.kotlinjdsl.querydsl.hint.HintDsl
-import com.linecorp.kotlinjdsl.querydsl.predicate.PredicateDsl
 import com.linecorp.kotlinjdsl.querydsl.set.SetParameterDsl
-import com.linecorp.kotlinjdsl.querydsl.where.WhereDsl
 
-interface CriteriaUpdateQueryDsl :
-    ExpressionDsl,
-    PredicateDsl,
-    AssociateDsl,
-    RelationDsl,
-    WhereDsl,
-    HintDsl,
-    SetParameterDsl
+interface CriteriaUpdateQueryDsl : CriteriaMutableQueryDsl, SetParameterDsl

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -1,5 +1,6 @@
 package com.linecorp.kotlinjdsl.querydsl
 
+import com.linecorp.kotlinjdsl.query.CriteriaDeleteQuerySpec
 import com.linecorp.kotlinjdsl.query.CriteriaQuerySpec
 import com.linecorp.kotlinjdsl.query.CriteriaUpdateQuerySpec
 import com.linecorp.kotlinjdsl.query.SubquerySpec
@@ -174,6 +175,17 @@ open class QueryDslImpl<T>(
         )
     }
 
+    fun createCriteriaDeleteQuerySpec(): CriteriaDeleteQuerySpec<T> {
+        return CriteriaDeleteQuerySpecImpl(
+            targetEntity = returnType,
+            from = getFromClause(),
+            associate = getSimpleAssociatedJoinClauseOnly(),
+            where = getWhereClause(),
+            sqlHint = getSqlQueryHintClause(),
+            jpaHint = getJpaQueryHintClause()
+        )
+    }
+
     fun createSubquerySpec(): SubquerySpec<T> {
         return SubquerySpecImpl(
             select = getSubquerySelectClause(),
@@ -312,6 +324,14 @@ open class QueryDslImpl<T>(
         override val set: SetClause
     ) : CriteriaUpdateQuerySpec<T>
 
+    data class CriteriaDeleteQuerySpecImpl<T>(
+        override val targetEntity: Class<T>,
+        override val from: FromClause,
+        override val associate: SimpleAssociatedJoinClause,
+        override val where: CriteriaQueryWhereClause,
+        override val jpaHint: JpaQueryHintClause,
+        override val sqlHint: SqlQueryHintClause
+    ) : CriteriaDeleteQuerySpec<T>
 
     data class SubquerySpecImpl<T>(
         override val select: SubquerySelectClause<T>,
@@ -320,14 +340,5 @@ open class QueryDslImpl<T>(
         override val where: SubqueryWhereClause,
         override val groupBy: SubqueryGroupByClause,
         override val having: SubqueryHavingClause
-    ) : SubquerySpec<T> {
-        constructor(spec: SubquerySpec<T>) : this(
-            select = spec.select,
-            from = spec.from,
-            join = spec.join,
-            where = spec.where,
-            groupBy = spec.groupBy,
-            having = spec.having,
-        )
-    }
+    ) : SubquerySpec<T>
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClauseTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClauseTest.kt
@@ -21,6 +21,9 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
     @MockK
     private lateinit var updateQuery: CriteriaUpdate<Data1>
 
+    @MockK
+    private lateinit var deleteQuery: CriteriaDelete<Data1>
+
     private val entitySpec1 = EntitySpec(Data1::class.java)
     private val entitySpec2 = EntitySpec(Data2::class.java)
     private val entitySpec3 = EntitySpec(Data3::class.java)
@@ -113,6 +116,101 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
 
     @Suppress("UNCHECKED_CAST")
     @Test
+    fun `associate update`() {
+        // given
+        val fromEntitySpec = entitySpec1
+        val fromClause = FromClause(fromEntitySpec)
+
+        val joinSpec1 = SimpleAssociatedJoinSpec(entitySpec1, entitySpec2, "data2")
+        val joinSpec2 = SimpleAssociatedJoinSpec(entitySpec2, entitySpec3, "data3")
+        val joinClause = SimpleAssociatedJoinClause(listOf(joinSpec1, joinSpec2))
+
+        val root = mockk<Root<Data1>>()
+        val join1 = mockk<Path<Any>>()
+        val join2 = mockk<MockFetch<Any, Any>>()
+
+        every { updateQuery.from(Data1::class.java) } returns root
+        every { deleteQuery.from(Data1::class.java) } returns root
+        every { root.get<Any>(joinSpec1.path) } returns join1
+        every { join1.get<Any>(joinSpec2.path) } returns join2
+
+        // when
+        val actual = fromClause.associate(joinClause, updateQuery as CriteriaUpdate<in Any>, Data1::class.java)
+        val deleteActual = fromClause.associate(joinClause, deleteQuery as CriteriaDelete<in Any>, Data1::class.java)
+
+        // then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(
+            Froms(
+                root = root,
+                map = mapOf(
+                    entitySpec1 to root,
+                    entitySpec2 to join1,
+                    entitySpec3 to join2,
+                )
+            )
+        )
+        assertThat(deleteActual).usingRecursiveComparison().isEqualTo(
+            Froms(
+                root = root,
+                map = mapOf(
+                    entitySpec1 to root,
+                    entitySpec2 to join1,
+                    entitySpec3 to join2,
+                )
+            )
+        )
+
+        verify(exactly = 1) {
+            updateQuery.from(Data1::class.java)
+            deleteQuery.from(Data1::class.java)
+        }
+
+        verify(exactly = 2) {
+            root.get<Any>(joinSpec1.path)
+            join1.get<Any>(joinSpec2.path)
+        }
+
+        verify {
+            root.hashCode()
+            join1.hashCode()
+            join2.hashCode()
+        }
+
+        confirmVerified(root, join1, join2, updateQuery, deleteQuery)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `associate update - if associate is incomplete then throw exception`() {
+        // given
+        val fromEntitySpec = entitySpec1
+        val fromClause = FromClause(fromEntitySpec)
+
+        val joinSpec = SimpleAssociatedJoinSpec(entitySpec2, entitySpec3, "data3")
+        val joinClause = SimpleAssociatedJoinClause(listOf(joinSpec))
+
+        val root = mockk<Root<Data1>>()
+
+        every { updateQuery.from(Data1::class.java) } returns root
+
+        // when
+        val exception = catchThrowable(IllegalStateException::class) {
+            fromClause.associate(joinClause, updateQuery as CriteriaUpdate<in Any>, Data1::class.java)
+        }
+
+        // then
+        assertThat(exception)
+            .hasMessageContaining("Associate clause is incomplete. Please check if the following Entities are associated")
+
+        verify(exactly = 1) {
+            updateQuery.from(Data1::class.java)
+        }
+
+        confirmVerified(root, updateQuery)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
     fun associate() {
         // given
         val fromEntitySpec = entitySpec1
@@ -127,11 +225,13 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
         val join2 = mockk<MockFetch<Any, Any>>()
 
         every { updateQuery.from(Data1::class.java) } returns root
+        every { deleteQuery.from(Data1::class.java) } returns root
         every { root.get<Any>(joinSpec1.path) } returns join1
         every { join1.get<Any>(joinSpec2.path) } returns join2
 
         // when
         val actual = fromClause.associate(joinClause, updateQuery as CriteriaUpdate<in Any>, Data1::class.java)
+        val deleteActual = fromClause.associate(joinClause, deleteQuery as CriteriaDelete<in Any>, Data1::class.java)
 
         // then
         assertThat(actual).usingRecursiveComparison().isEqualTo(
@@ -144,9 +244,23 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
                 )
             )
         )
+        assertThat(deleteActual).usingRecursiveComparison().isEqualTo(
+            Froms(
+                root = root,
+                map = mapOf(
+                    entitySpec1 to root,
+                    entitySpec2 to join1,
+                    entitySpec3 to join2,
+                )
+            )
+        )
 
         verify(exactly = 1) {
             updateQuery.from(Data1::class.java)
+            deleteQuery.from(Data1::class.java)
+        }
+
+        verify(exactly = 2) {
             root.get<Any>(joinSpec1.path)
             join1.get<Any>(joinSpec2.path)
         }
@@ -157,7 +271,7 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
             join2.hashCode()
         }
 
-        confirmVerified(root, join1, join2, updateQuery)
+        confirmVerified(root, join1, join2, updateQuery, deleteQuery)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/clause/where/WhereClauseTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/clause/where/WhereClauseTest.kt
@@ -28,6 +28,9 @@ internal class WhereClauseTest : WithKotlinJdslAssertions {
     private lateinit var criteriaUpdateQuery: CriteriaUpdate<Int>
 
     @MockK
+    private lateinit var criteriaDeleteQuery: CriteriaDelete<Int>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -96,6 +99,40 @@ internal class WhereClauseTest : WithKotlinJdslAssertions {
 
         // then
         confirmVerified(froms, subquery, criteriaUpdateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `apply criteria delete query`() {
+        // given
+        val predicateSpec: PredicateSpec = mockk()
+        val predicate: Predicate = mockk()
+
+        every { predicateSpec.isEmpty() } returns false
+        every { predicateSpec.toCriteriaPredicate(froms, criteriaDeleteQuery, criteriaBuilder) } returns predicate
+        every { criteriaDeleteQuery.where(predicate) } returns criteriaDeleteQuery
+
+        // when
+        WhereClause(predicateSpec).apply(froms, criteriaDeleteQuery, criteriaBuilder)
+
+        // then
+        verify(exactly = 1) {
+            predicateSpec.isEmpty()
+            predicateSpec.toCriteriaPredicate(froms, criteriaDeleteQuery, criteriaBuilder)
+            criteriaDeleteQuery.where(predicate)
+
+            criteriaDeleteQuery.where(predicate)
+        }
+
+        confirmVerified(predicateSpec, froms, subquery, criteriaDeleteQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `apply criteria delete query - if predicate is empty then do nothing`() {
+        // when
+        WhereClause(PredicateSpec.empty).apply(froms, criteriaDeleteQuery, criteriaBuilder)
+
+        // then
+        confirmVerified(froms, subquery, criteriaDeleteQuery, criteriaBuilder)
     }
 
     @Test

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/FromsTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/FromsTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import javax.persistence.criteria.From
+import javax.persistence.criteria.Path
 import javax.persistence.criteria.Root
 
 @ExtendWith(MockKExtension::class)
@@ -17,7 +18,7 @@ internal class FromsTest : WithKotlinJdslAssertions {
         val root: Root<*> = mockk()
 
         val entitySpec1 = EntitySpec(Data1::class.java)
-        val from1: From<*, *> = mockk()
+        val from1: Path<*> = mockk()
 
         val entitySpec2 = EntitySpec(Data2::class.java)
         val from2: From<*, *> = mockk()

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/AvgSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/AvgSpecTest.kt
@@ -24,6 +24,9 @@ internal class AvgSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -78,5 +81,32 @@ internal class AvgSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(column, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression`() {
+        // given
+        val column = mockk<ColumnSpec<Int>>()
+        val columnExpression = mockk<Expression<Int>>()
+
+        val avgExpression = mockk<Expression<Double>>()
+
+        every { column.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns columnExpression
+        every { criteriaBuilder.avg(any<Expression<Int>>()) } returns avgExpression
+
+        // when
+        val spec = AvgSpec(column)
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(avgExpression)
+
+        verify(exactly = 1) {
+            column.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.avg(columnExpression)
+        }
+
+        confirmVerified(column, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpecTest.kt
@@ -24,6 +24,9 @@ internal class ColumnSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -76,6 +79,30 @@ internal class ColumnSpecTest : WithKotlinJdslAssertions {
         confirmVerified(from, froms, updateQuery, criteriaBuilder)
     }
 
+    @Test
+    fun `delete toCriteriaExpression`() {
+        // given
+        val from = mockk<From<*, Data>>()
+        val path = mockk<Path<String>>()
+
+        every { froms[any<EntitySpec<Data>>()] } returns from
+        every { from.get<String>(any<String>()) } returns path
+
+        // when
+        val spec = ColumnSpec<String>(EntitySpec(Data::class.java), "name")
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(path)
+
+        verify {
+            froms[EntitySpec(Data::class.java)]
+            from.get<String>("name")
+        }
+
+        confirmVerified(from, froms, deleteQuery, criteriaBuilder)
+    }
 
     private class Data {
         val name = "name"

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/CountSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/CountSpecTest.kt
@@ -24,6 +24,9 @@ internal class CountSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -132,5 +135,59 @@ internal class CountSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(column, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression - distinct`() {
+        // given
+        val column = mockk<ColumnSpec<Int>>()
+        val columnExpression = mockk<Expression<Int>>()
+
+        val countExpression = mockk<Expression<Long>>()
+
+        every { column.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns columnExpression
+        every { criteriaBuilder.countDistinct(any<Expression<Int>>()) } returns countExpression
+
+        // when
+        val spec = CountSpec(distinct = true, column)
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(countExpression)
+
+        verify(exactly = 1) {
+            column.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.countDistinct(columnExpression)
+        }
+
+        confirmVerified(column, froms, deleteQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression - non distinct`() {
+        // given
+        val column = mockk<ColumnSpec<Int>>()
+        val columnExpression = mockk<Expression<Int>>()
+
+        val countExpression = mockk<Expression<Long>>()
+
+        every { column.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns columnExpression
+        every { criteriaBuilder.count(any<Expression<Int>>()) } returns countExpression
+
+        // when
+        val spec = CountSpec(distinct = false, column)
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(countExpression)
+
+        verify(exactly = 1) {
+            column.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.count(columnExpression)
+        }
+
+        confirmVerified(column, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/EntitySpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/EntitySpecTest.kt
@@ -10,10 +10,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.From
+import javax.persistence.criteria.*
 
 @ExtendWith(MockKExtension::class)
 internal class EntitySpecTest : WithKotlinJdslAssertions {
@@ -24,7 +21,10 @@ internal class EntitySpecTest : WithKotlinJdslAssertions {
     private lateinit var query: AbstractQuery<*>
 
     @MockK
-    private lateinit var updateQUery: CriteriaUpdate<*>
+    private lateinit var updateQuery: CriteriaUpdate<*>
+
+    @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
 
     @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
@@ -85,7 +85,7 @@ internal class EntitySpecTest : WithKotlinJdslAssertions {
         // when
         val spec = EntitySpec(Data::class.java)
 
-        val actual = spec.toCriteriaExpression(froms, updateQUery, criteriaBuilder)
+        val actual = spec.toCriteriaExpression(froms, updateQuery, criteriaBuilder)
 
         // then
         assertThat(actual).isEqualTo(from)
@@ -94,7 +94,7 @@ internal class EntitySpecTest : WithKotlinJdslAssertions {
             froms[spec]
         }
 
-        confirmVerified(froms, updateQUery, criteriaBuilder)
+        confirmVerified(froms, updateQuery, criteriaBuilder)
     }
 
     @Test
@@ -108,7 +108,7 @@ internal class EntitySpecTest : WithKotlinJdslAssertions {
         // when
         val spec = EntitySpec(Data::class.java, "data1")
 
-        val actual = spec.toCriteriaExpression(froms, updateQUery, criteriaBuilder)
+        val actual = spec.toCriteriaExpression(froms, updateQuery, criteriaBuilder)
 
         // then
         assertThat(actual).isEqualTo(from)
@@ -118,7 +118,53 @@ internal class EntitySpecTest : WithKotlinJdslAssertions {
             from.alias("data1")
         }
 
-        confirmVerified(froms, updateQUery, criteriaBuilder)
+        confirmVerified(froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression`() {
+        // given
+        val from = mockk<From<*, Data>>()
+
+        every { froms[any<EntitySpec<Data>>()] } returns from
+
+        // when
+        val spec = EntitySpec(Data::class.java)
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(from)
+
+        verify(exactly = 1) {
+            froms[spec]
+        }
+
+        confirmVerified(froms, deleteQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression with alias`() {
+        // given
+        val from = mockk<From<*, Data>>()
+
+        every { froms[any<EntitySpec<Data>>()] } returns from
+        every { from.alias("data1") } returns mockk()
+
+        // when
+        val spec = EntitySpec(Data::class.java, "data1")
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(from)
+
+        verify(exactly = 1) {
+            froms[spec]
+            from.alias("data1")
+        }
+
+        confirmVerified(froms, deleteQuery, criteriaBuilder)
     }
 
     private class Data

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/GreatestSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/GreatestSpecTest.kt
@@ -24,6 +24,9 @@ internal class GreatestSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -78,5 +81,32 @@ internal class GreatestSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(column, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression`() {
+        // given
+        val column = mockk<ColumnSpec<Int>>()
+        val columnExpression = mockk<Expression<Int>>()
+
+        val greatestExpression = mockk<Expression<Int>>()
+
+        every { column.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns columnExpression
+        every { criteriaBuilder.greatest(any<Expression<Int>>()) } returns greatestExpression
+
+        // when
+        val spec = GreatestSpec(column)
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(greatestExpression)
+
+        verify(exactly = 1) {
+            column.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.greatest(columnExpression)
+        }
+
+        confirmVerified(column, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/LeastSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/LeastSpecTest.kt
@@ -24,6 +24,9 @@ internal class LeastSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -78,5 +81,32 @@ internal class LeastSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(column, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression`() {
+        // given
+        val column = mockk<ColumnSpec<Int>>()
+        val columnExpression = mockk<Expression<Int>>()
+
+        val leastExpression = mockk<Expression<Int>>()
+
+        every { column.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns columnExpression
+        every { criteriaBuilder.least(any<Expression<Int>>()) } returns leastExpression
+
+        // when
+        val spec = LeastSpec(column)
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(leastExpression)
+
+        verify(exactly = 1) {
+            column.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.least(columnExpression)
+        }
+
+        confirmVerified(column, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/LiteralSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/LiteralSpecTest.kt
@@ -10,10 +10,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 @ExtendWith(MockKExtension::class)
 internal class LiteralSpecTest : WithKotlinJdslAssertions {
@@ -25,6 +22,9 @@ internal class LiteralSpecTest : WithKotlinJdslAssertions {
 
     @MockK
     private lateinit var updateQuery: CriteriaUpdate<*>
+
+    @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
 
     @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
@@ -71,5 +71,27 @@ internal class LiteralSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression`() {
+        // given
+        val expression = mockk<Expression<String>>()
+
+        every { criteriaBuilder.literal(any<String>()) } returns expression
+
+        // when
+        val spec = LiteralSpec("TEST")
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(expression)
+
+        verify(exactly = 1) {
+            criteriaBuilder.literal("TEST")
+        }
+
+        confirmVerified(froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/MaxSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/MaxSpecTest.kt
@@ -24,6 +24,9 @@ internal class MaxSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -78,5 +81,32 @@ internal class MaxSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(column, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression`() {
+        // given
+        val column = mockk<ColumnSpec<Int>>()
+        val columnExpression = mockk<Expression<Int>>()
+
+        val maxExpression = mockk<Expression<Int>>()
+
+        every { column.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns columnExpression
+        every { criteriaBuilder.max(any<Expression<Int>>()) } returns maxExpression
+
+        // when
+        val spec = MaxSpec(column)
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(maxExpression)
+
+        verify(exactly = 1) {
+            column.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.max(columnExpression)
+        }
+
+        confirmVerified(column, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/MinSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/MinSpecTest.kt
@@ -24,6 +24,9 @@ internal class MinSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -78,5 +81,32 @@ internal class MinSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(column, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression`() {
+        // given
+        val column = mockk<ColumnSpec<Int>>()
+        val columnExpression = mockk<Expression<Int>>()
+
+        val minExpression = mockk<Expression<Int>>()
+
+        every { column.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns columnExpression
+        every { criteriaBuilder.min(any<Expression<Int>>()) } returns minExpression
+
+        // when
+        val spec = MinSpec(column)
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(minExpression)
+
+        verify(exactly = 1) {
+            column.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.min(columnExpression)
+        }
+
+        confirmVerified(column, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NullLiteralSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NullLiteralSpecTest.kt
@@ -10,10 +10,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Expression
+import javax.persistence.criteria.*
 
 @ExtendWith(MockKExtension::class)
 internal class NullLiteralSpecTest : WithKotlinJdslAssertions {
@@ -27,10 +24,27 @@ internal class NullLiteralSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
     fun toCriteriaExpression() {
+        toCriteriaExpression { it.toCriteriaExpression(froms, query, criteriaBuilder) }
+    }
+
+    @Test
+    fun `update toCriteriaExpression`() {
+        toCriteriaExpression { it.toCriteriaExpression(froms, updateQuery, criteriaBuilder) }
+    }
+
+    @Test
+    fun `delete toCriteriaExpression`() {
+        toCriteriaExpression { it.toCriteriaExpression(froms, deleteQuery, criteriaBuilder) }
+    }
+
+    private fun toCriteriaExpression(predicate: (NullLiteralSpec<String>) -> Expression<String?>) {
         // given
         val expression = mockk<Expression<String?>>()
 
@@ -39,7 +53,7 @@ internal class NullLiteralSpecTest : WithKotlinJdslAssertions {
         // when
         val spec = NullLiteralSpec(String::class.java)
 
-        val actual = spec.toCriteriaExpression(froms, query, criteriaBuilder)
+        val actual = predicate(spec)
 
         // then
         assertThat(actual).isEqualTo(expression)
@@ -49,27 +63,5 @@ internal class NullLiteralSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(froms, query, criteriaBuilder)
-    }
-
-    @Test
-    fun `update toCriteriaExpression`() {
-        // given
-        val expression = mockk<Expression<String?>>()
-
-        every { criteriaBuilder.nullLiteral<String>(any()) } returns expression
-
-        // when
-        val spec = NullLiteralSpec(String::class.java)
-
-        val actual = spec.toCriteriaExpression(froms, updateQuery, criteriaBuilder)
-
-        // then
-        assertThat(actual).isEqualTo(expression)
-
-        verify(exactly = 1) {
-            criteriaBuilder.nullLiteral(String::class.java)
-        }
-
-        confirmVerified(froms, updateQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/SumSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/SumSpecTest.kt
@@ -24,6 +24,9 @@ internal class SumSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -78,5 +81,32 @@ internal class SumSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(column, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression`() {
+        // given
+        val column = mockk<ColumnSpec<Int>>()
+        val columnExpression = mockk<Expression<Int>>()
+
+        val sumExpression = mockk<Expression<Int>>()
+
+        every { column.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns columnExpression
+        every { criteriaBuilder.sum(any<Expression<Int>>()) } returns sumExpression
+
+        // when
+        val spec = SumSpec(column)
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(sumExpression)
+
+        verify(exactly = 1) {
+            column.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.sum(columnExpression)
+        }
+
+        confirmVerified(column, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/AndSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/AndSpecTest.kt
@@ -24,6 +24,9 @@ internal class AndSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -134,5 +137,60 @@ internal class AndSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val predicateSpec1: PredicateSpec = mockk()
+        val predicateSpec2: PredicateSpec = mockk()
+        val predicateSpec3: PredicateSpec? = null
+
+        val predicate1: Predicate = mockk()
+        val predicate2: Predicate = mockk()
+        val andPredicate: Predicate = mockk()
+
+        every { predicateSpec1.toCriteriaPredicate(any(), any<CriteriaDelete<*>>(), any()) } returns predicate1
+        every { predicateSpec2.toCriteriaPredicate(any(), any<CriteriaDelete<*>>(), any()) } returns predicate2
+
+        every { criteriaBuilder.and(any(), any()) } returns andPredicate
+
+        // when
+        val actual = AndSpec(listOf(predicateSpec1, predicateSpec2, predicateSpec3))
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(andPredicate)
+
+        verify(exactly = 1) {
+            predicateSpec1.toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+            predicateSpec2.toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.and(predicate1, predicate2)
+        }
+
+        confirmVerified(predicateSpec1, predicateSpec2, froms, deleteQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate - if predicate is empty then return conjunction`() {
+        // given
+        val predicateSpec1: PredicateSpec? = null
+        val predicateSpec2: PredicateSpec? = null
+
+        val andPredicate: Predicate = mockk()
+
+        every { criteriaBuilder.conjunction() } returns andPredicate
+
+        // when
+        val actual = AndSpec(listOf(predicateSpec1, predicateSpec2)).toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(andPredicate)
+
+        verify(exactly = 1) {
+            criteriaBuilder.conjunction()
+        }
+
+        confirmVerified(froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/BetweenExpressionSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/BetweenExpressionSpecTest.kt
@@ -25,6 +25,9 @@ internal class BetweenExpressionSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -114,6 +117,51 @@ internal class BetweenExpressionSpecTest : WithKotlinJdslAssertions {
             rightExpressionSpec1,
             rightExpressionSpec2,
             froms, updateQuery, criteriaBuilder
+        )
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val rightExpressionSpec1: ExpressionSpec<Int> = mockk()
+        val rightExpressionSpec2: ExpressionSpec<Int> = mockk()
+
+        val leftExpression: Expression<Int> = mockk()
+        val rightExpression1: Expression<Int> = mockk()
+        val rightExpression2: Expression<Int> = mockk()
+
+        val betweenPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+        every { rightExpressionSpec1.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns rightExpression1
+        every { rightExpressionSpec2.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns rightExpression2
+
+        every { criteriaBuilder.between(any(), any<Expression<Int>>(), any()) } returns betweenPredicate
+
+        // when
+        val actual = BetweenExpressionSpec(
+            leftExpressionSpec,
+            rightExpressionSpec1,
+            rightExpressionSpec2
+        ).toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(betweenPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            rightExpressionSpec1.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            rightExpressionSpec2.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+            criteriaBuilder.between(leftExpression, rightExpression1, rightExpression2)
+        }
+
+        confirmVerified(
+            leftExpressionSpec,
+            rightExpressionSpec1,
+            rightExpressionSpec2,
+            froms, deleteQuery, criteriaBuilder
         )
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/BetweenValueSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/BetweenValueSpecTest.kt
@@ -25,6 +25,9 @@ internal class BetweenValueSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -89,5 +92,37 @@ internal class BetweenValueSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(leftExpressionSpec, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int?> = mockk()
+        val right1 = 10
+        val right2 = 20
+
+        val leftExpression: Expression<Int?> = mockk()
+
+        val betweenPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+
+        every { criteriaBuilder.between(any(), any<Int>(), any()) } returns betweenPredicate
+
+        // when
+        val actual = BetweenValueSpec(leftExpressionSpec, right1, right2)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(betweenPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+            @Suppress("TYPE_MISMATCH_WARNING")
+            criteriaBuilder.between<Int>(leftExpression, right1, right2)
+        }
+
+        confirmVerified(leftExpressionSpec, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EmptyPredicateSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EmptyPredicateSpecTest.kt
@@ -10,10 +10,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 @ExtendWith(MockKExtension::class)
 internal class EmptyPredicateSpecTest : WithKotlinJdslAssertions {
@@ -27,17 +24,34 @@ internal class EmptyPredicateSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
     fun toCriteriaPredicate() {
+        toCriteriaPredicate { EmptyPredicateSpec.toCriteriaPredicate(froms, query, criteriaBuilder) }
+    }
+
+    @Test
+    fun `update toCriteriaPredicate`() {
+        toCriteriaPredicate { EmptyPredicateSpec.toCriteriaPredicate(froms, updateQuery, criteriaBuilder) }
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        toCriteriaPredicate { EmptyPredicateSpec.toCriteriaPredicate(froms, deleteQuery, criteriaBuilder) }
+    }
+
+    private fun toCriteriaPredicate(predicate: () -> Predicate) {
         // given
         val emptyPredicate: Predicate = mockk()
 
         every { criteriaBuilder.conjunction() } returns emptyPredicate
 
         // when
-        val actual = EmptyPredicateSpec.toCriteriaPredicate(froms, query, criteriaBuilder)
+        val actual = predicate()
 
         // then
         assertThat(actual).isEqualTo(emptyPredicate)
@@ -47,25 +61,5 @@ internal class EmptyPredicateSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(froms, query, criteriaBuilder)
-    }
-
-    @Test
-    fun `update toCriteriaPredicate`() {
-        // given
-        val emptyPredicate: Predicate = mockk()
-
-        every { criteriaBuilder.conjunction() } returns emptyPredicate
-
-        // when
-        val actual = EmptyPredicateSpec.toCriteriaPredicate(froms, updateQuery, criteriaBuilder)
-
-        // then
-        assertThat(actual).isEqualTo(emptyPredicate)
-
-        verify(exactly = 1) {
-            criteriaBuilder.conjunction()
-        }
-
-        confirmVerified(froms, updateQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EqualExpressionSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EqualExpressionSpecTest.kt
@@ -24,6 +24,9 @@ internal class EqualExpressionSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -83,6 +86,37 @@ internal class EqualExpressionSpecTest : WithKotlinJdslAssertions {
         verify(exactly = 1) {
             leftExpressionSpec.toCriteriaExpression(froms, updateQuery, criteriaBuilder)
             rightExpressionSpec.toCriteriaExpression(froms, updateQuery, criteriaBuilder)
+
+            criteriaBuilder.equal(leftExpression, rightExpression)
+        }
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val rightExpressionSpec: ExpressionSpec<Int> = mockk()
+
+        val leftExpression: Expression<Int> = mockk()
+        val rightExpression: Expression<Int> = mockk()
+
+        val equalPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+        every { rightExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns rightExpression
+
+        every { criteriaBuilder.equal(leftExpression, rightExpression) } returns equalPredicate
+
+        // when
+        val actual = EqualExpressionSpec(leftExpressionSpec, rightExpressionSpec)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(equalPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            rightExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
 
             criteriaBuilder.equal(leftExpression, rightExpression)
         }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EqualValueSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/EqualValueSpecTest.kt
@@ -25,6 +25,9 @@ internal class EqualValueSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -81,5 +84,33 @@ internal class EqualValueSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(leftExpressionSpec, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val right = 10
+
+        val leftExpression: Expression<Int> = mockk()
+
+        val equalPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder) } returns leftExpression
+
+        every { criteriaBuilder.equal(any(), any<Int>()) } returns equalPredicate
+
+        // when
+        val actual = EqualValueSpec(leftExpressionSpec, right).toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(equalPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.equal(leftExpression, right)
+        }
+
+        confirmVerified(leftExpressionSpec, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/GreaterThanExpressionSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/GreaterThanExpressionSpecTest.kt
@@ -25,6 +25,9 @@ internal class GreaterThanExpressionSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -176,6 +179,82 @@ internal class GreaterThanExpressionSpecTest : WithKotlinJdslAssertions {
             leftExpressionSpec,
             rightExpressionSpec,
             froms, updateQuery, criteriaBuilder
+        )
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate - inclusive`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val rightExpressionSpec: ExpressionSpec<Int> = mockk()
+
+        val leftExpression: Expression<Int> = mockk()
+        val rightExpression: Expression<Int> = mockk()
+
+        val greaterThanOrEqualToPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+        every { rightExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns rightExpression
+
+        every {
+            criteriaBuilder.greaterThanOrEqualTo(any(), any<Expression<Int>>())
+        } returns greaterThanOrEqualToPredicate
+
+        // when
+        val actual = GreaterThanExpressionSpec(leftExpressionSpec, rightExpressionSpec, true)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(greaterThanOrEqualToPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            rightExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+            criteriaBuilder.greaterThanOrEqualTo(leftExpression, rightExpression)
+        }
+
+        confirmVerified(
+            leftExpressionSpec,
+            rightExpressionSpec,
+            froms, deleteQuery, criteriaBuilder
+        )
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate - not inclusive`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val rightExpressionSpec: ExpressionSpec<Int> = mockk()
+
+        val leftExpression: Expression<Int> = mockk()
+        val rightExpression: Expression<Int> = mockk()
+
+        val greaterThanPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+        every { rightExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns rightExpression
+
+        every { criteriaBuilder.greaterThan(any(), any<Expression<Int>>()) } returns greaterThanPredicate
+
+        // when
+        val actual = GreaterThanExpressionSpec(leftExpressionSpec, rightExpressionSpec, false)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(greaterThanPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            rightExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+            criteriaBuilder.greaterThan(leftExpression, rightExpression)
+        }
+
+        confirmVerified(
+            leftExpressionSpec,
+            rightExpressionSpec,
+            froms, deleteQuery, criteriaBuilder
         )
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/GreaterThanValueSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/GreaterThanValueSpecTest.kt
@@ -25,6 +25,9 @@ internal class GreaterThanValueSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -141,5 +144,63 @@ internal class GreaterThanValueSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate - inclusive`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val right = 10
+
+        val leftExpression: Expression<Int> = mockk()
+
+        val greaterThanEqualToPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+
+        every { criteriaBuilder.greaterThanOrEqualTo(any(), any<Int>()) } returns greaterThanEqualToPredicate
+
+        // when
+        val actual = GreaterThanValueSpec(leftExpressionSpec, right, true)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(greaterThanEqualToPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.greaterThanOrEqualTo(leftExpression, right)
+        }
+
+        confirmVerified(froms, deleteQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate - not inclusive`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val right = 10
+
+        val leftExpression: Expression<Int> = mockk()
+
+        val greaterThanPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+
+        every { criteriaBuilder.greaterThan(any(), any<Int>()) } returns greaterThanPredicate
+
+        // when
+        val actual = GreaterThanValueSpec(leftExpressionSpec, right, false)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(greaterThanPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.greaterThan(leftExpression, right)
+        }
+
+        confirmVerified(froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsFalseSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsFalseSpecTest.kt
@@ -25,6 +25,9 @@ internal class IsFalseSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -77,5 +80,31 @@ internal class IsFalseSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(expressionSpec, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val expressionSpec: ExpressionSpec<Boolean?> = mockk()
+
+        val expression: Expression<Boolean?> = mockk()
+
+        val isFalsePredicate: Predicate = mockk()
+
+        every { expressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder) } returns expression
+        every { criteriaBuilder.isFalse(expression) } returns isFalsePredicate
+
+        // when
+        val actual = IsFalseSpec(expressionSpec).toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(isFalsePredicate)
+
+        verify(exactly = 1) {
+            expressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.isFalse(expression)
+        }
+
+        confirmVerified(expressionSpec, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsNullSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsNullSpecTest.kt
@@ -25,6 +25,9 @@ internal class IsNullSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -77,5 +80,31 @@ internal class IsNullSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(expressionSpec, froms, updateQuery, criteriaBuilder)
+    }
+    
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val expressionSpec: ExpressionSpec<Boolean?> = mockk()
+
+        val expression: Expression<Boolean?> = mockk()
+
+        val isNullPredicate: Predicate = mockk()
+
+        every { expressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder) } returns expression
+        every { criteriaBuilder.isNull(expression) } returns isNullPredicate
+
+        // when
+        val actual = IsNullSpec(expressionSpec).toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(isNullPredicate)
+
+        verify(exactly = 1) {
+            expressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.isNull(expression)
+        }
+
+        confirmVerified(expressionSpec, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsTrueSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/IsTrueSpecTest.kt
@@ -25,6 +25,9 @@ internal class IsTrueSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -77,5 +80,31 @@ internal class IsTrueSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(expressionSpec, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val expressionSpec: ExpressionSpec<Boolean?> = mockk()
+
+        val expression: Expression<Boolean?> = mockk()
+
+        val isTruePredicate: Predicate = mockk()
+
+        every { expressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder) } returns expression
+        every { criteriaBuilder.isTrue(expression) } returns isTruePredicate
+
+        // when
+        val actual = IsTrueSpec(expressionSpec).toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(isTruePredicate)
+
+        verify(exactly = 1) {
+            expressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.isTrue(expression)
+        }
+
+        confirmVerified(expressionSpec, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LessThanExpressionSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LessThanExpressionSpecTest.kt
@@ -25,6 +25,9 @@ internal class LessThanExpressionSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -176,6 +179,82 @@ internal class LessThanExpressionSpecTest : WithKotlinJdslAssertions {
             leftExpressionSpec,
             rightExpressionSpec,
             froms, updateQuery, criteriaBuilder
+        )
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate - inclusive`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val rightExpressionSpec: ExpressionSpec<Int> = mockk()
+
+        val leftExpression: Expression<Int> = mockk()
+        val rightExpression: Expression<Int> = mockk()
+
+        val lessThanOrEqualToPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+        every { rightExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns rightExpression
+
+        every {
+            criteriaBuilder.lessThanOrEqualTo(any(), any<Expression<Int>>())
+        } returns lessThanOrEqualToPredicate
+
+        // when
+        val actual = LessThanExpressionSpec(leftExpressionSpec, rightExpressionSpec, true)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(lessThanOrEqualToPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            rightExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+            criteriaBuilder.lessThanOrEqualTo(leftExpression, rightExpression)
+        }
+
+        confirmVerified(
+            leftExpressionSpec,
+            rightExpressionSpec,
+            froms, deleteQuery, criteriaBuilder
+        )
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate - not inclusive`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val rightExpressionSpec: ExpressionSpec<Int> = mockk()
+
+        val leftExpression: Expression<Int> = mockk()
+        val rightExpression: Expression<Int> = mockk()
+
+        val lessThanPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+        every { rightExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns rightExpression
+
+        every { criteriaBuilder.lessThan(any(), any<Expression<Int>>()) } returns lessThanPredicate
+
+        // when
+        val actual = LessThanExpressionSpec(leftExpressionSpec, rightExpressionSpec, false)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(lessThanPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            rightExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+            criteriaBuilder.lessThan(leftExpression, rightExpression)
+        }
+
+        confirmVerified(
+            leftExpressionSpec,
+            rightExpressionSpec,
+            froms, deleteQuery, criteriaBuilder
         )
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LessThanValueSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LessThanValueSpecTest.kt
@@ -25,6 +25,9 @@ internal class LessThanValueSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -141,5 +144,63 @@ internal class LessThanValueSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate - inclusive`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val right = 10
+
+        val leftExpression: Expression<Int> = mockk()
+
+        val lessThanEqualToPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+
+        every { criteriaBuilder.lessThanOrEqualTo(any(), any<Int>()) } returns lessThanEqualToPredicate
+
+        // when
+        val actual = LessThanValueSpec(leftExpressionSpec, right, true)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(lessThanEqualToPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.lessThanOrEqualTo(leftExpression, right)
+        }
+
+        confirmVerified(froms, deleteQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate - not inclusive`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<Int> = mockk()
+        val right = 10
+
+        val leftExpression: Expression<Int> = mockk()
+
+        val lessThanPredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns leftExpression
+
+        every { criteriaBuilder.lessThan(any(), any<Int>()) } returns lessThanPredicate
+
+        // when
+        val actual = LessThanValueSpec(leftExpressionSpec, right, false)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(lessThanPredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.lessThan(leftExpression, right)
+        }
+
+        confirmVerified(froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LikeSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/LikeSpecTest.kt
@@ -25,6 +25,9 @@ internal class LikeSpecTest : WithKotlinJdslAssertions {
     private lateinit var updateQuery: CriteriaUpdate<*>
 
     @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
 
     @Test
@@ -79,5 +82,32 @@ internal class LikeSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(leftExpressionSpec, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val leftExpressionSpec: ExpressionSpec<String?> = mockk()
+        val right = "%test%"
+
+        val likeExpression: Expression<String?> = mockk()
+
+        val likePredicate: Predicate = mockk()
+
+        every { leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder) } returns likeExpression
+        every { criteriaBuilder.like(likeExpression, right) } returns likePredicate
+
+        // when
+        val actual = LikeSpec(leftExpressionSpec, right).toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(likePredicate)
+
+        verify(exactly = 1) {
+            leftExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.like(likeExpression, right)
+        }
+
+        confirmVerified(leftExpressionSpec, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/NotSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/NotSpecTest.kt
@@ -10,10 +10,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 @ExtendWith(MockKExtension::class)
 internal class NotSpecTest : WithKotlinJdslAssertions {
@@ -25,6 +22,9 @@ internal class NotSpecTest : WithKotlinJdslAssertions {
 
     @MockK
     private lateinit var updateQuery: CriteriaUpdate<*>
+
+    @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
 
     @MockK
     private lateinit var criteriaBuilder: CriteriaBuilder
@@ -77,5 +77,30 @@ internal class NotSpecTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(predicateSpec, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val predicateSpec: PredicateSpec = mockk()
+        val predicate: Predicate = mockk()
+
+        val notPredicate: Predicate = mockk()
+
+        every { predicateSpec.toCriteriaPredicate(froms, deleteQuery, criteriaBuilder) } returns predicate
+        every { criteriaBuilder.not(predicate) } returns notPredicate
+
+        // when
+        val actual = NotSpec(predicateSpec).toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(notPredicate)
+
+        verify(exactly = 1) {
+            predicateSpec.toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.not(predicate)
+        }
+
+        confirmVerified(predicateSpec, froms, deleteQuery, criteriaBuilder)
     }
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/PredicateSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/PredicateSpecTest.kt
@@ -3,10 +3,7 @@ package com.linecorp.kotlinjdsl.query.spec.predicate
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
 import org.junit.jupiter.api.Test
-import javax.persistence.criteria.AbstractQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaUpdate
-import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.*
 
 internal class PredicateSpecTest : WithKotlinJdslAssertions {
     private val predicateSpec1: PredicateSpec = object : PredicateSpec {
@@ -25,6 +22,14 @@ internal class PredicateSpecTest : WithKotlinJdslAssertions {
         ): Predicate {
             return criteriaBuilder.conjunction()
         }
+
+        override fun toCriteriaPredicate(
+            froms: Froms,
+            query: CriteriaDelete<*>,
+            criteriaBuilder: CriteriaBuilder
+        ): Predicate {
+            return criteriaBuilder.conjunction()
+        }
     }
 
     private val predicateSpec2: PredicateSpec = object : PredicateSpec {
@@ -39,6 +44,14 @@ internal class PredicateSpecTest : WithKotlinJdslAssertions {
         override fun toCriteriaPredicate(
             froms: Froms,
             query: CriteriaUpdate<*>,
+            criteriaBuilder: CriteriaBuilder
+        ): Predicate {
+            return criteriaBuilder.conjunction()
+        }
+
+        override fun toCriteriaPredicate(
+            froms: Froms,
+            query: CriteriaDelete<*>,
             criteriaBuilder: CriteriaBuilder
         ): Predicate {
             return criteriaBuilder.conjunction()

--- a/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactory.kt
+++ b/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactory.kt
@@ -2,10 +2,7 @@ package com.linecorp.kotlinjdsl.spring.data
 
 import com.linecorp.kotlinjdsl.query.clause.select.SingleSelectClause
 import com.linecorp.kotlinjdsl.query.spec.expression.SubqueryExpressionSpec
-import com.linecorp.kotlinjdsl.querydsl.CriteriaUpdateQueryDsl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataCriteriaQueryDsl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataPageableQueryDsl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataSubqueryDsl
+import com.linecorp.kotlinjdsl.spring.data.querydsl.*
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import javax.persistence.Query
@@ -18,7 +15,8 @@ interface SpringDataQueryFactory {
         selectQuery(returnType, dsl)
 
     fun <T> selectQuery(returnType: Class<T>, dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit): TypedQuery<T>
-    fun <T: Any> updateQuery(returnType: KClass<T>, dsl: CriteriaUpdateQueryDsl.() -> Unit): Query
+    fun <T: Any> updateQuery(target: KClass<T>, dsl: SpringDataCriteriaUpdateQueryDsl.() -> Unit): Query
+    fun <T: Any> deleteQuery(target: KClass<T>, dsl: SpringDataCriteriaDeleteQueryDsl.() -> Unit): Query
     fun <T> subquery(returnType: Class<T>, dsl: SpringDataSubqueryDsl<T>.() -> Unit): SubqueryExpressionSpec<T>
     fun <T> pageQuery(returnType: Class<T>, pageable: Pageable, dsl: SpringDataPageableQueryDsl<T>.() -> Unit): Page<T>
     fun <T> pageQuery(

--- a/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensions.kt
+++ b/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensions.kt
@@ -1,9 +1,10 @@
 package com.linecorp.kotlinjdsl.spring.data
 
+import com.linecorp.kotlinjdsl.QueryFactory
 import com.linecorp.kotlinjdsl.query.clause.select.SingleSelectClause
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataCriteriaQueryDsl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataPageableQueryDsl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataSubqueryDsl
+import com.linecorp.kotlinjdsl.querydsl.CriteriaDeleteQueryDsl
+import com.linecorp.kotlinjdsl.querydsl.CriteriaUpdateQueryDsl
+import com.linecorp.kotlinjdsl.spring.data.querydsl.*
 import org.springframework.data.domain.Pageable
 import java.util.stream.Stream
 
@@ -25,6 +26,12 @@ inline fun <reified T> SpringDataQueryFactory.typedQuery(noinline dsl: SpringDat
 
 inline fun <reified T> SpringDataQueryFactory.selectQuery(noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit) =
     selectQuery(T::class.java, dsl)
+
+inline fun <reified T: Any> SpringDataQueryFactory.updateQuery(noinline dsl: SpringDataCriteriaUpdateQueryDsl.() -> Unit) =
+    updateQuery(T::class, dsl)
+
+inline fun <reified T: Any> SpringDataQueryFactory.deleteQuery(noinline dsl: SpringDataCriteriaDeleteQueryDsl.() -> Unit) =
+    deleteQuery(T::class, dsl)
 
 inline fun <reified T> SpringDataQueryFactory.subquery(noinline dsl: SpringDataSubqueryDsl<T>.() -> Unit) =
     subquery(T::class.java, dsl)

--- a/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryImpl.kt
+++ b/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryImpl.kt
@@ -5,10 +5,7 @@ import com.linecorp.kotlinjdsl.query.creator.CriteriaQueryCreator
 import com.linecorp.kotlinjdsl.query.creator.SubqueryCreator
 import com.linecorp.kotlinjdsl.query.spec.expression.SubqueryExpressionSpec
 import com.linecorp.kotlinjdsl.querydsl.CriteriaUpdateQueryDsl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataCriteriaQueryDsl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataPageableQueryDsl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataQueryDslImpl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataSubqueryDsl
+import com.linecorp.kotlinjdsl.spring.data.querydsl.*
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.support.PageableExecutionUtils
@@ -29,12 +26,18 @@ class SpringDataQueryFactoryImpl(
         return criteriaQueryCreator.createQuery(criteriaQuerySpec)
     }
 
-    override fun <T : Any> updateQuery(returnType: KClass<T>, dsl: CriteriaUpdateQueryDsl.() -> Unit): Query {
-        val criteriaQuerySpec = SpringDataQueryDslImpl(returnType.java).apply(dsl).apply {
-            from(returnType)
+    override fun <T : Any> updateQuery(target: KClass<T>, dsl: SpringDataCriteriaUpdateQueryDsl.() -> Unit): Query {
+        val criteriaQuerySpec = SpringDataQueryDslImpl(target.java).apply(dsl).apply {
+            from(target)
         }.createCriteriaUpdateQuerySpec()
 
         return criteriaQueryCreator.createQuery(criteriaQuerySpec)
+    }
+
+    override fun <T: Any> deleteQuery(target: KClass<T>, dsl: SpringDataCriteriaDeleteQueryDsl.() -> Unit): Query {
+        return criteriaQueryCreator.createQuery(
+            SpringDataQueryDslImpl(target.java).apply(dsl).apply { from(target) }.createCriteriaDeleteQuerySpec()
+        )
     }
 
     override fun <T> subquery(

--- a/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/querydsl/SpringDataCriteriaMutableQueryDsl.kt
+++ b/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/querydsl/SpringDataCriteriaMutableQueryDsl.kt
@@ -1,0 +1,10 @@
+package com.linecorp.kotlinjdsl.spring.data.querydsl
+
+import com.linecorp.kotlinjdsl.querydsl.CriteriaMutableQueryDsl
+import com.linecorp.kotlinjdsl.spring.data.querydsl.predicate.SpringDataPredicateDsl
+
+interface SpringDataCriteriaMutableQueryDsl :
+    CriteriaMutableQueryDsl,
+    SpringDataPredicateDsl
+
+typealias SpringDataCriteriaDeleteQueryDsl = SpringDataCriteriaMutableQueryDsl

--- a/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/querydsl/SpringDataCriteriaUpdateQueryDsl.kt
+++ b/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/querydsl/SpringDataCriteriaUpdateQueryDsl.kt
@@ -1,0 +1,8 @@
+package com.linecorp.kotlinjdsl.spring.data.querydsl
+
+import com.linecorp.kotlinjdsl.querydsl.CriteriaUpdateQueryDsl
+import com.linecorp.kotlinjdsl.spring.data.querydsl.predicate.SpringDataPredicateDsl
+
+interface SpringDataCriteriaUpdateQueryDsl :
+    CriteriaUpdateQueryDsl,
+    SpringDataPredicateDsl

--- a/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/querydsl/SpringDataQueryDslImpl.kt
+++ b/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/querydsl/SpringDataQueryDslImpl.kt
@@ -18,7 +18,7 @@ import org.springframework.data.domain.Pageable
 class SpringDataQueryDslImpl<T>(
     returnType: Class<T>,
 ) : QueryDslImpl<T>(returnType),
-    SpringDataCriteriaQueryDsl<T>, SpringDataSubqueryDsl<T>, SpringDataPageableQueryDsl<T> {
+    SpringDataCriteriaQueryDsl<T>, SpringDataSubqueryDsl<T>, SpringDataPageableQueryDsl<T>, SpringDataCriteriaUpdateQueryDsl, SpringDataCriteriaDeleteQueryDsl {
     var pageable: Pageable = Pageable.unpaged()
 
     fun createPageableQuerySpec(): CriteriaQuerySpec<T> {

--- a/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
+++ b/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
@@ -4,9 +4,7 @@ import com.linecorp.kotlinjdsl.query.clause.select.SingleSelectClause
 import com.linecorp.kotlinjdsl.query.spec.expression.SubqueryExpressionSpec
 import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.querydsl.expression.column
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataCriteriaQueryDsl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataPageableQueryDsl
-import com.linecorp.kotlinjdsl.spring.data.querydsl.SpringDataSubqueryDsl
+import com.linecorp.kotlinjdsl.spring.data.querydsl.*
 import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
 import com.linecorp.kotlinjdsl.test.entity.order.Order
 import io.mockk.confirmVerified
@@ -19,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import java.util.stream.Stream
+import javax.persistence.Query
 import javax.persistence.TypedQuery
 import kotlin.streams.toList
 
@@ -87,7 +86,7 @@ internal class SpringDataQueryFactoryExtensionsTest : WithKotlinJdslAssertions {
     }
 
     @Test
-    fun typedQuery() {
+    fun selectQuery() {
         // given
         every { queryFactory.selectQuery<Data1>(any(), any()) } returns typedQuery
 
@@ -97,13 +96,58 @@ internal class SpringDataQueryFactoryExtensionsTest : WithKotlinJdslAssertions {
         }
 
         // when
-        val actual: TypedQuery<Data1> = queryFactory.typedQuery(dsl)
+        val actual: TypedQuery<Data1> = queryFactory.selectQuery(dsl)
 
         // then
         assertThat(actual).isEqualTo(typedQuery)
 
         verify(exactly = 1) {
             queryFactory.selectQuery(Data1::class.java, dsl)
+        }
+
+        confirmVerified(queryFactory)
+    }
+
+    @Test
+    fun updateQuery() {
+        // given
+        every { queryFactory.updateQuery<Data1>(any(), any()) } returns typedQuery
+
+        val dsl: SpringDataCriteriaUpdateQueryDsl.() -> Unit = {
+            set(col(Data1::id), 1)
+            where(col(Data1::id).equal(2))
+        }
+
+        // when
+        val actual: Query = queryFactory.updateQuery<Data1>(dsl)
+
+        // then
+        assertThat(actual).isEqualTo(typedQuery)
+
+        verify(exactly = 1) {
+            queryFactory.updateQuery(Data1::class, dsl)
+        }
+
+        confirmVerified(queryFactory)
+    }
+
+    @Test
+    fun deleteQuery() {
+        // given
+        every { queryFactory.deleteQuery<Data1>(any(), any()) } returns typedQuery
+
+        val dsl: SpringDataCriteriaDeleteQueryDsl.() -> Unit = {
+            where(col(Data1::id).equal(1))
+        }
+
+        // when
+        val actual: Query = queryFactory.deleteQuery<Data1>(dsl)
+
+        // then
+        assertThat(actual).isEqualTo(typedQuery)
+
+        verify(exactly = 1) {
+            queryFactory.deleteQuery(Data1::class, dsl)
         }
 
         confirmVerified(queryFactory)

--- a/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryImplTest.kt
+++ b/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryImplTest.kt
@@ -133,6 +133,38 @@ internal class SpringDataQueryFactoryImplTest : WithKotlinJdslAssertions {
     }
 
     @Test
+    fun deleteQuery() {
+        // given
+        val query: Query = mockk()
+
+        every { criteriaQueryCreator.createQuery(any<QueryDslImpl.CriteriaDeleteQuerySpecImpl<Data1>>()) } returns query
+
+        // when
+        val actual = sut.deleteQuery(Data1::class) {
+            where(col(Data1::id).equal(1))
+        }
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verify(exactly = 1) {
+            val columnSpec = ColumnSpec<Int>(EntitySpec(Data1::class.java), Data1::id.name)
+            criteriaQueryCreator.createQuery(
+                QueryDslImpl.CriteriaDeleteQuerySpecImpl(
+                    from = FromClause(EntitySpec(Data1::class.java)),
+                    associate = SimpleAssociatedJoinClause(emptyList()),
+                    where = WhereClause(EqualValueSpec(columnSpec, 1)),
+                    jpaHint = JpaQueryHintClauseImpl(emptyMap()),
+                    sqlHint = EmptySqlQueryHintClause,
+                    targetEntity = Data1::class.java
+                )
+            )
+        }
+
+        confirmVerified(criteriaQueryCreator)
+    }
+
+    @Test
     fun subquery() {
         // when
         val actual = sut.subquery(Data1::class.java) {

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
@@ -1,0 +1,75 @@
+package com.linecorp.kotlinjdsl.test.integration.criteriaquery
+
+import com.linecorp.kotlinjdsl.deleteQuery
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.selectQuery
+import com.linecorp.kotlinjdsl.test.entity.Address
+import com.linecorp.kotlinjdsl.test.entity.order.OrderAddress
+import com.linecorp.kotlinjdsl.test.integration.AbstractCriteriaQueryDslIntegrationTest
+import org.junit.jupiter.api.Test
+
+abstract class AbstractCriteriaDeleteIntegrationTest : AbstractCriteriaQueryDslIntegrationTest() {
+    @Test
+    fun delete() {
+        // when
+        val address1 = orderAddress { }
+
+        entityManager.run {
+            persist(address1)
+            flush(); clear()
+        }
+
+        queryFactory.deleteQuery<OrderAddress> {
+            where(col(OrderAddress::id).equal(address1.id))
+        }.executeUpdate()
+
+        // when
+        val query = queryFactory.selectQuery<OrderAddress> {
+            select(entity(OrderAddress::class))
+            from(entity(OrderAddress::class))
+            where(col(OrderAddress::id).equal(address1.id),)
+            associate(OrderAddress::class, Address::class, on(OrderAddress::address))
+        }
+
+        // then
+        assertThat(query.resultList).isEmpty()
+    }
+
+    @Test
+    fun deleteEmbedded() {
+        // given
+        val address1 = orderAddress { }
+
+        entityManager.run {
+            persist(address1)
+            flush(); clear()
+        }
+
+        queryFactory.deleteQuery<OrderAddress> {
+            where(
+                and(
+                    col(OrderAddress::id).equal(address1.id),
+                    col(Address::zipCode).equal(address1.address.zipCode),
+                )
+            )
+            associate(OrderAddress::class, Address::class, on(OrderAddress::address))
+        }.executeUpdate()
+
+        // when
+        val query = queryFactory.selectQuery<OrderAddress> {
+            select(entity(OrderAddress::class))
+            from(entity(OrderAddress::class))
+            where(
+                and(
+                    col(OrderAddress::id).equal(address1.id),
+                    col(Address::zipCode).equal(address1.address.zipCode),
+                )
+            )
+            associate(OrderAddress::class, Address::class, on(OrderAddress::address))
+        }
+
+        // then
+        assertThat(query.resultList).isEmpty()
+
+    }
+}


### PR DESCRIPTION
# Motivation:

Our library currently only supports select and update.
Delete should also be supported.

Please refer to #29

-- korean
우리 라이브러리는 현재 select, update 만 지원하고 있고
delete 도 같이 지원해야 합니다.

#29 을 참고해주세요.

# Modifications:
Added toCriteriaExpression methods for CriteriaDelete to ExpressionSpec and PredicateSpec for CriteriaDelete
deleteQuery is implemented in QueryFactory, SpringDataQueryFactory.
Implemented updateQuery of SpringDataQueryFactory which was missing from Update PR.
For SubqueryCreator, CommonAbstractCriteria supports the criteria.subquery method in common and has been merged into one.

Dsl and Spec commonly used in Update/Delete are defined as CriteriaMutableQuery*, and Mutable interface is inherited from Update. Also, delete currently has the same interface as CriteriaMutableQuery* , so we defined it as CriteriaDeleteQuery* as the typealias.

-- korean
CriteriaDelete 를 위해 ExpressionSpec, PredicateSpec 에 CriteriaDelete 를 위한 toCriteriaExpression 메소드들을 추가했고
QueryFactory, SpringDataQueryFactory 에 deleteQuery 가 구현 되었습니다.
Update PR 에서 누락 되었던 SpringDataQueryFactory의 updateQuery를 구현했습니다.
SubqueryCreator의 경우 CommonAbstractCriteria가 criteria.subquery 메소드를 공통으로 지원하여 한개로 합쳤습니다.

Update/Delete 에서 공통으로 사용하는 Dsl 및 Spec 을 CriteriaMutableQuery* 로 정의하고 Update 에서 Mutable을 인터페이스 상속 하였습니다. 또한 delete 는 CriteriaMutableQuery* 와 동일한 인터페이스를 현재 가지므로 typealias 로 CriteriaDeleteQuery* 로 정의하였습니다.

# Result:
Users can create and execute delete queries as shown below.

-- korean
사용자는 아래와 같이 삭제 쿼리를 생성하고 실행할 수 있습니다.

queryFactory.deleteQuery<OrderAddress> {
    where(col(OrderAddress::id).equal(address1.id))
    associate(OrderAddress::class, Address::class, on(OrderAddress::address))
}.executeUpdate()