### PR TITLE
publish query module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.linecorp.kotlin-jdsl"
-    version = "1.1.0.RELEASE"
+    version = "1.2.0.RELEASE"
 
     repositories {
         mavenCentral()

--- a/query/build.gradle.kts
+++ b/query/build.gradle.kts
@@ -1,3 +1,5 @@
+apply<PublishPlugin>()
+
 dependencies {
     compileOnly(Dependencies.javaPersistenceApi)
     compileOnly(Dependencies.slf4j)


### PR DESCRIPTION
# Motivation:
publish query module & version up

# Modifications:

If the query module is not published, there is a problem with the dependency and it is published.

# Result:
kotlin-jdsl-query module published