### PR TITLE
Improve create object performance for QueryDslImpl & ReactiveQueryDslImpl

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group = "com.linecorp.kotlin-jdsl"
-    version = "2.0.0.RELEASE"
+    version = "2.0.1.RELEASE"
 
     repositories {
         mavenCentral()

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -53,16 +53,25 @@ open class QueryDslImpl<T>(
     private var singleSelectClause: SingleSelectClause<T>? = null
     private var multiSelectClause: MultiSelectClause<T>? = null
     private var fromClause: FromClause<*>? = null
-    private var joins: Lazy<MutableList<JoinSpec<*>>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
-    private var wheres: Lazy<MutableList<PredicateSpec>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
-    private var groupBys: Lazy<MutableList<ExpressionSpec<*>>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
-    private var havings: Lazy<MutableList<PredicateSpec>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
-    private var orderBys: Lazy<MutableList<OrderSpec>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
+    private var joins: MutableList<JoinSpec<*>>? = null
+    private var wheres: MutableList<PredicateSpec>? = null
+    private var groupBys: MutableList<ExpressionSpec<*>>? = null
+    private var havings: MutableList<PredicateSpec>? = null
+    private var orderBys: MutableList<OrderSpec>? = null
     private var offset: Int? = null
     private var maxResults: Int? = null
-    private var sqlHints: Lazy<MutableList<String>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
-    private var jpaHints: Lazy<MutableMap<String, Any>> = lazy(LazyThreadSafetyMode.NONE) { mutableMapOf() }
-    private var params: Lazy<MutableMap<ColumnSpec<*>, Any?>> = lazy(LazyThreadSafetyMode.NONE) { mutableMapOf() }
+    private var sqlHints: MutableList<String>? = null
+    private var jpaHints: MutableMap<String, Any>? = null
+    private var params: MutableMap<ColumnSpec<*>, Any?>? = null
+
+    private fun lazyJoins() = (joins ?: mutableListOf<JoinSpec<*>>().apply { joins = this })
+    private fun lazyWheres() = (wheres ?: mutableListOf<PredicateSpec>().apply { wheres = this })
+    private fun lazyGroupBys() = (groupBys ?: mutableListOf<ExpressionSpec<*>>().apply { groupBys = this })
+    private fun lazyHavings() = (havings ?: mutableListOf<PredicateSpec>().apply { havings = this })
+    private fun lazyOrderBys() = (orderBys ?: mutableListOf<OrderSpec>().apply { orderBys = this })
+    private fun lazySqlHints() = (sqlHints ?: mutableListOf<String>().apply { sqlHints = this })
+    private fun lazyJpaHints() = (jpaHints ?: mutableMapOf<String, Any>().apply { jpaHints = this })
+    private fun lazyParams() = (params ?: mutableMapOf<ColumnSpec<*>, Any?>().apply { params = this })
 
     override fun select(distinct: Boolean, expression: ExpressionSpec<T>): SingleSelectClause<T> {
         return SingleSelectClause(
@@ -85,12 +94,12 @@ open class QueryDslImpl<T>(
     }
 
     override fun <T, R> join(left: EntitySpec<T>, right: EntitySpec<R>, relation: Relation<T, R?>, joinType: JoinType) {
-        joins.value.add(SimpleJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
+        (joins ?: mutableListOf<JoinSpec<*>>().apply { joins = this }).add(SimpleJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
     override fun <T> join(entity: EntitySpec<T>, predicate: PredicateSpec) {
-        joins.value.add(CrossJoinSpec(entity))
-        wheres.value.add(predicate)
+        lazyJoins().add(CrossJoinSpec(entity))
+        lazyWheres().add(predicate)
     }
 
     override fun <T, R> associate(
@@ -99,7 +108,7 @@ open class QueryDslImpl<T>(
         relation: Relation<T, R?>,
         joinType: JoinType
     ) {
-        joins.value.add(SimpleAssociatedJoinSpec(left = left, right = right, path = relation.path))
+        lazyJoins().add(SimpleAssociatedJoinSpec(left = left, right = right, path = relation.path))
     }
 
     override fun <T, R> fetch(
@@ -108,23 +117,23 @@ open class QueryDslImpl<T>(
         relation: Relation<T, R?>,
         joinType: JoinType
     ) {
-        joins.value.add(FetchJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
+        lazyJoins().add(FetchJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
     override fun where(predicate: PredicateSpec) {
-        wheres.value.add(predicate)
+        lazyWheres().add(predicate)
     }
 
     override fun groupBy(columns: List<ExpressionSpec<*>>) {
-        groupBys.value.addAll(columns)
+        lazyGroupBys().addAll(columns)
     }
 
     override fun having(predicate: PredicateSpec) {
-        havings.value.add(predicate)
+        lazyHavings().add(predicate)
     }
 
     override fun orderBy(orders: List<OrderSpec>) {
-        orderBys.value.addAll(orders)
+        lazyOrderBys().addAll(orders)
     }
 
     override fun offset(offset: Int) {
@@ -136,19 +145,19 @@ open class QueryDslImpl<T>(
     }
 
     override fun sqlHints(hints: List<String>) {
-        sqlHints.value.addAll(hints)
+        lazySqlHints().addAll(hints)
     }
 
     override fun hints(hints: Map<String, Any>) {
-        jpaHints.value.putAll(hints)
+        lazyJpaHints().putAll(hints)
     }
 
     override fun setParams(params: Map<ColumnSpec<*>, Any?>) {
-        this.params.value.putAll(params)
+        lazyParams().putAll(params)
     }
 
     override fun set(column: ColumnSpec<*>, value: Any?) {
-        params.value[column] = value
+        lazyParams()[column] = value
     }
 
     fun createCriteriaQuerySpec(): CriteriaQuerySpec<T, TypedQuery<T>> {
@@ -352,7 +361,4 @@ open class QueryDslImpl<T>(
         override val groupBy: SubqueryGroupByClause,
         override val having: SubqueryHavingClause
     ) : SubquerySpec<T>
-
-    private fun <T> Lazy<List<T>>.orEmpty() = if (isInitialized()) value else emptyList()
-    private fun <K, V> Lazy<Map<K, V>>.orEmpty() = if (isInitialized()) value else emptyMap()
 }

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -94,7 +94,7 @@ open class QueryDslImpl<T>(
     }
 
     override fun <T, R> join(left: EntitySpec<T>, right: EntitySpec<R>, relation: Relation<T, R?>, joinType: JoinType) {
-        (joins ?: mutableListOf<JoinSpec<*>>().apply { joins = this }).add(SimpleJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
+        lazyJoins().add(SimpleJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
     override fun <T> join(entity: EntitySpec<T>, predicate: PredicateSpec) {

--- a/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
+++ b/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
@@ -48,16 +48,25 @@ open class ReactiveQueryDslImpl<T>(
     private var singleSelectClause: SingleSelectClause<T>? = null
     private var multiSelectClause: MultiSelectClause<T>? = null
     private var fromClause: FromClause<*>? = null
-    private var joins: Lazy<MutableList<JoinSpec<*>>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
-    private var wheres: Lazy<MutableList<PredicateSpec>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
-    private var groupBys: Lazy<MutableList<ExpressionSpec<*>>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
-    private var havings: Lazy<MutableList<PredicateSpec>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
-    private var orderBys: Lazy<MutableList<OrderSpec>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
+    private var joins: MutableList<JoinSpec<*>>? = null
+    private var wheres: MutableList<PredicateSpec>? = null
+    private var groupBys: MutableList<ExpressionSpec<*>>? = null
+    private var havings: MutableList<PredicateSpec>? = null
+    private var orderBys: MutableList<OrderSpec>? = null
     private var offset: Int? = null
     private var maxResults: Int? = null
-    private var sqlHints: Lazy<MutableList<String>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
-    private var jpaHints: Lazy<MutableMap<String, Any>> = lazy(LazyThreadSafetyMode.NONE) { mutableMapOf() }
-    private var params: Lazy<MutableMap<ColumnSpec<*>, Any?>> = lazy(LazyThreadSafetyMode.NONE) { mutableMapOf() }
+    private var sqlHints: MutableList<String>? = null
+    private var jpaHints: MutableMap<String, Any>? = null
+    private var params: MutableMap<ColumnSpec<*>, Any?>? = null
+
+    private fun lazyJoins() = (joins ?: mutableListOf<JoinSpec<*>>().apply { joins = this })
+    private fun lazyWheres() = (wheres ?: mutableListOf<PredicateSpec>().apply { wheres = this })
+    private fun lazyGroupBys() = (groupBys ?: mutableListOf<ExpressionSpec<*>>().apply { groupBys = this })
+    private fun lazyHavings() = (havings ?: mutableListOf<PredicateSpec>().apply { havings = this })
+    private fun lazyOrderBys() = (orderBys ?: mutableListOf<OrderSpec>().apply { orderBys = this })
+    private fun lazySqlHints() = (sqlHints ?: mutableListOf<String>().apply { sqlHints = this })
+    private fun lazyJpaHints() = (jpaHints ?: mutableMapOf<String, Any>().apply { jpaHints = this })
+    private fun lazyParams() = (params ?: mutableMapOf<ColumnSpec<*>, Any?>().apply { params = this })
 
     override fun select(distinct: Boolean, expression: ExpressionSpec<T>): SingleSelectClause<T> {
         return SingleSelectClause(
@@ -80,12 +89,12 @@ open class ReactiveQueryDslImpl<T>(
     }
 
     override fun <T, R> join(left: EntitySpec<T>, right: EntitySpec<R>, relation: Relation<T, R?>, joinType: JoinType) {
-        joins.value.add(SimpleJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
+        lazyJoins().add(SimpleJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
     override fun <T> join(entity: EntitySpec<T>, predicate: PredicateSpec) {
-        joins.value.add(CrossJoinSpec(entity))
-        wheres.value.add(predicate)
+        lazyJoins().add(CrossJoinSpec(entity))
+        lazyWheres().add(predicate)
     }
 
     override fun <T, R> associate(
@@ -94,7 +103,7 @@ open class ReactiveQueryDslImpl<T>(
         relation: Relation<T, R?>,
         joinType: JoinType
     ) {
-        joins.value.add(SimpleAssociatedJoinSpec(left = left, right = right, path = relation.path))
+        lazyJoins().add(SimpleAssociatedJoinSpec(left = left, right = right, path = relation.path))
     }
 
     override fun <T, R> fetch(
@@ -103,23 +112,23 @@ open class ReactiveQueryDslImpl<T>(
         relation: Relation<T, R?>,
         joinType: JoinType
     ) {
-        joins.value.add(FetchJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
+        lazyJoins().add(FetchJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
     override fun where(predicate: PredicateSpec) {
-        wheres.value.add(predicate)
+        lazyWheres().add(predicate)
     }
 
     override fun groupBy(columns: List<ExpressionSpec<*>>) {
-        groupBys.value.addAll(columns)
+        lazyGroupBys().addAll(columns)
     }
 
     override fun having(predicate: PredicateSpec) {
-        havings.value.add(predicate)
+        lazyHavings().add(predicate)
     }
 
     override fun orderBy(orders: List<OrderSpec>) {
-        orderBys.value.addAll(orders)
+        lazyOrderBys().addAll(orders)
     }
 
     override fun offset(offset: Int) {
@@ -131,19 +140,19 @@ open class ReactiveQueryDslImpl<T>(
     }
 
     override fun sqlHints(hints: List<String>) {
-        sqlHints.value.addAll(hints)
+        lazySqlHints().addAll(hints)
     }
 
     override fun hints(hints: Map<String, Any>) {
-        jpaHints.value.putAll(hints)
+        lazyJpaHints().putAll(hints)
     }
 
     override fun setParams(params: Map<ColumnSpec<*>, Any?>) {
-        this.params.value.putAll(params)
+        lazyParams().putAll(params)
     }
 
     override fun set(column: ColumnSpec<*>, value: Any?) {
-        params.value[column] = value
+        lazyParams()[column] = value
     }
 
     fun createCriteriaQuerySpec(): CriteriaQuerySpec<T, ReactiveQuery<T>> {
@@ -348,7 +357,4 @@ open class ReactiveQueryDslImpl<T>(
         override val groupBy: SubqueryGroupByClause,
         override val having: SubqueryHavingClause
     ) : SubquerySpec<T>
-
-    private fun <T> Lazy<List<T>>.orEmpty() = if (isInitialized()) value else emptyList()
-    private fun <K, V> Lazy<Map<K, V>>.orEmpty() = if (isInitialized()) value else emptyMap()
 }

--- a/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
+++ b/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
@@ -40,6 +40,7 @@ import javax.persistence.criteria.JoinType
  *
  * Don't use this directly because it's an <string>INTERNAL</strong> class.
  * It does not support backward compatibility.
+ * This class should be used with the understanding that it is not thread safe and therefore not suitable for parallel processing.
  */
 open class ReactiveQueryDslImpl<T>(
     private val returnType: Class<T>,
@@ -47,16 +48,16 @@ open class ReactiveQueryDslImpl<T>(
     private var singleSelectClause: SingleSelectClause<T>? = null
     private var multiSelectClause: MultiSelectClause<T>? = null
     private var fromClause: FromClause<*>? = null
-    private var joins: MutableList<JoinSpec<*>> = mutableListOf()
-    private var wheres: MutableList<PredicateSpec> = mutableListOf()
-    private var groupBys: MutableList<ExpressionSpec<*>> = mutableListOf()
-    private var havings: MutableList<PredicateSpec> = mutableListOf()
-    private var orderBys: MutableList<OrderSpec> = mutableListOf()
+    private var joins: Lazy<MutableList<JoinSpec<*>>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
+    private var wheres: Lazy<MutableList<PredicateSpec>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
+    private var groupBys: Lazy<MutableList<ExpressionSpec<*>>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
+    private var havings: Lazy<MutableList<PredicateSpec>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
+    private var orderBys: Lazy<MutableList<OrderSpec>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
     private var offset: Int? = null
     private var maxResults: Int? = null
-    private var sqlHints: MutableList<String> = mutableListOf()
-    private var jpaHints: MutableMap<String, Any> = mutableMapOf()
-    private var params: MutableMap<ColumnSpec<*>, Any?> = mutableMapOf()
+    private var sqlHints: Lazy<MutableList<String>> = lazy(LazyThreadSafetyMode.NONE) { mutableListOf() }
+    private var jpaHints: Lazy<MutableMap<String, Any>> = lazy(LazyThreadSafetyMode.NONE) { mutableMapOf() }
+    private var params: Lazy<MutableMap<ColumnSpec<*>, Any?>> = lazy(LazyThreadSafetyMode.NONE) { mutableMapOf() }
 
     override fun select(distinct: Boolean, expression: ExpressionSpec<T>): SingleSelectClause<T> {
         return SingleSelectClause(
@@ -79,12 +80,12 @@ open class ReactiveQueryDslImpl<T>(
     }
 
     override fun <T, R> join(left: EntitySpec<T>, right: EntitySpec<R>, relation: Relation<T, R?>, joinType: JoinType) {
-        joins.add(SimpleJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
+        joins.value.add(SimpleJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
     override fun <T> join(entity: EntitySpec<T>, predicate: PredicateSpec) {
-        joins.add(CrossJoinSpec(entity))
-        wheres.add(predicate)
+        joins.value.add(CrossJoinSpec(entity))
+        wheres.value.add(predicate)
     }
 
     override fun <T, R> associate(
@@ -93,7 +94,7 @@ open class ReactiveQueryDslImpl<T>(
         relation: Relation<T, R?>,
         joinType: JoinType
     ) {
-        joins.add(SimpleAssociatedJoinSpec(left = left, right = right, path = relation.path))
+        joins.value.add(SimpleAssociatedJoinSpec(left = left, right = right, path = relation.path))
     }
 
     override fun <T, R> fetch(
@@ -102,23 +103,23 @@ open class ReactiveQueryDslImpl<T>(
         relation: Relation<T, R?>,
         joinType: JoinType
     ) {
-        joins.add(FetchJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
+        joins.value.add(FetchJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
     override fun where(predicate: PredicateSpec) {
-        wheres.add(predicate)
+        wheres.value.add(predicate)
     }
 
     override fun groupBy(columns: List<ExpressionSpec<*>>) {
-        groupBys.addAll(columns)
+        groupBys.value.addAll(columns)
     }
 
     override fun having(predicate: PredicateSpec) {
-        havings.add(predicate)
+        havings.value.add(predicate)
     }
 
     override fun orderBy(orders: List<OrderSpec>) {
-        orderBys.addAll(orders)
+        orderBys.value.addAll(orders)
     }
 
     override fun offset(offset: Int) {
@@ -130,19 +131,19 @@ open class ReactiveQueryDslImpl<T>(
     }
 
     override fun sqlHints(hints: List<String>) {
-        sqlHints.addAll(hints)
+        sqlHints.value.addAll(hints)
     }
 
     override fun hints(hints: Map<String, Any>) {
-        jpaHints.putAll(hints)
+        jpaHints.value.putAll(hints)
     }
 
     override fun setParams(params: Map<ColumnSpec<*>, Any?>) {
-        this.params.putAll(params)
+        this.params.value.putAll(params)
     }
 
     override fun set(column: ColumnSpec<*>, value: Any?) {
-        params[column] = value
+        params.value[column] = value
     }
 
     fun createCriteriaQuerySpec(): CriteriaQuerySpec<T, ReactiveQuery<T>> {
@@ -169,9 +170,12 @@ open class ReactiveQueryDslImpl<T>(
             where = getWhereClause(),
             sqlHint = getSqlQueryHintClause(),
             jpaHint = getJpaQueryHintClause(),
-            set = SetClause(params)
+            set = getSetClause()
         )
     }
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    protected fun getSetClause() = SetClause(params.orEmpty())
 
     @Suppress("UNCHECKED_CAST")
     fun createCriteriaDeleteQuerySpec(): CriteriaDeleteQuerySpec<T, ReactiveQuery<T>> {
@@ -220,17 +224,19 @@ open class ReactiveQueryDslImpl<T>(
 
     @Suppress("MemberVisibilityCanBePrivate")
     protected fun getJoinClause(): JoinClause {
-        return JoinClause(joins)
+        return JoinClause(joins.orEmpty())
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
     protected fun getJoinClauseDoesNotHaveFetch(): JoinClause {
-        mustBe(joins.filterIsInstance<FetchJoinSpec<*, *>>().isEmpty()) { "This query does not support fetch" }
+        mustBe(joins.orEmpty().filterIsInstance<FetchJoinSpec<*, *>>().isEmpty()) { "This query does not support fetch" }
 
         return getJoinClause()
     }
 
+    @Suppress("MemberVisibilityCanBePrivate")
     protected fun getSimpleAssociatedJoinClauseOnly(): SimpleAssociatedJoinClause {
+        val joins = joins.orEmpty()
         return joins.filterIsInstance<SimpleAssociatedJoinSpec<*, *>>().let {
             mustBe(it.size == joins.size) { "This query only support associate" }
             SimpleAssociatedJoinClause(it)
@@ -238,12 +244,12 @@ open class ReactiveQueryDslImpl<T>(
     }
 
     protected fun getWhereClause(): WhereClause {
-        return WhereClause(wheres.merge())
+        return WhereClause(wheres.orEmpty().merge())
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
     protected fun getGroupByClause(): GroupByClause {
-        return GroupByClause(groupBys)
+        return GroupByClause(groupBys.orEmpty())
     }
 
     protected fun getEmptyGroupByClause(): GroupByClause {
@@ -252,7 +258,7 @@ open class ReactiveQueryDslImpl<T>(
 
     @Suppress("MemberVisibilityCanBePrivate")
     protected fun getHavingClause(): HavingClause {
-        return HavingClause(havings.merge())
+        return HavingClause(havings.orEmpty().merge())
     }
 
     protected fun getEmptyHavingClause(): HavingClause {
@@ -261,7 +267,7 @@ open class ReactiveQueryDslImpl<T>(
 
     @Suppress("MemberVisibilityCanBePrivate")
     protected fun getOrderByClause(): CriteriaQueryOrderByClause {
-        return OrderByClause(orderBys)
+        return OrderByClause(orderBys.orEmpty())
     }
 
     protected fun getEmptyOrderByClause(): CriteriaQueryOrderByClause {
@@ -279,11 +285,11 @@ open class ReactiveQueryDslImpl<T>(
     }
 
     protected fun getJpaQueryHintClause(): JpaQueryHintClause<ReactiveQuery<T>> {
-        return JpaReactiveQueryHintClauseImpl(jpaHints)
+        return JpaReactiveQueryHintClauseImpl(jpaHints.orEmpty())
     }
 
     protected fun getSqlQueryHintClause(): SqlQueryHintClause<ReactiveQuery<T>> {
-        return SqlReactiveQueryHintClauseProvider.provide(sqlHints)
+        return SqlReactiveQueryHintClauseProvider.provide(sqlHints.orEmpty())
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
@@ -342,4 +348,7 @@ open class ReactiveQueryDslImpl<T>(
         override val groupBy: SubqueryGroupByClause,
         override val having: SubqueryHavingClause
     ) : SubquerySpec<T>
+
+    private fun <T> Lazy<List<T>>.orEmpty() = if (isInitialized()) value else emptyList()
+    private fun <K, V> Lazy<Map<K, V>>.orEmpty() = if (isInitialized()) value else emptyMap()
 }


### PR DESCRIPTION
# Motivation:

Please refer to #49 
-- korean
#49 이슈를 참고해주세요

# Modifications:
* Each lazy clause of QueryDslImpl and ReactiveQueryDslImpl is modified to be a null, and it is modified to be loaded only when necessary so that it is created as an emptyList or emptyMap if it is not used in the methods that generate the spec.

-- korean
* QueryDslImpl, ReactiveQueryDslImpl 의 각 lazy 하게 사용될 수 있는 clause 들을 null  수정하고 필요할때만 로드되도록 spec 을 생성하는 메소드들에서 사용되지 않았을 경우 emptyList or emptyMap 으로 생성되게 수정하였습니다.

# Result:
Users can use a little more memory resources efficiently when creating each query.
There is no change that users can directly feel.

-- korean
각 쿼리를 생성할때 조금 더 메모리 자원을 효율적으로 사용할 수 있습니다.
사용자가 직접 체감할 수 있는 변화는 없습니다.