### PR TITLE
Support Treat

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,7 @@ val employees = queryFactory.listQuery<Employee> {
     from(entity(Employee::class))
     treat<Employee, PartTimeEmployee>()
     where(
-        or(
-            col(PartTimeEmployee::weeklySalary).lessThan(1000.toBigDecimal()),
-        )
+        col(PartTimeEmployee::weeklySalary).lessThan(1000.toBigDecimal()),
     )
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group = "com.linecorp.kotlin-jdsl"
-    version = "2.0.1.RELEASE"
+    version = "2.0.2.RELEASE"
 
     repositories {
         mavenCentral()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,11 +3,11 @@
 import org.gradle.api.artifacts.dsl.DependencyHandler
 
 object Dependencies {
-    const val kotlinVersion = "1.6.10"
-    const val springCoreVersion = "5.3.16"
-    const val springBootVersion = "2.6.4"
-    const val springDataJpaVersion = "2.6.2"
-    const val coroutineVersion = "1.6.0"
+    const val kotlinVersion = "1.6.21"
+    const val springCoreVersion = "5.3.19"
+    const val springBootVersion = "2.6.7"
+    const val springDataJpaVersion = "2.6.4"
+    const val coroutineVersion = "1.6.1"
 
     // kotlin
     const val koltin = "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
@@ -16,13 +16,13 @@ object Dependencies {
     // Common
     const val javaPersistenceApi = "javax.persistence:javax.persistence-api:2.2"
     const val slf4j = "org.slf4j:slf4j-api:1.7.36"
-    const val logback = "ch.qos.logback:logback-classic:1.2.10"
-    const val hibernate = "org.hibernate:hibernate-core:5.6.5.Final"
-    const val hibernateReactive = "org.hibernate.reactive:hibernate-reactive-core:1.1.3.Final"
+    const val logback = "ch.qos.logback:logback-classic:1.2.11"
+    const val hibernate = "org.hibernate:hibernate-core:5.6.8.Final"
+    const val hibernateReactive = "org.hibernate.reactive:hibernate-reactive-core:1.1.4.Final"
     const val eclipselink = "org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.10"
     const val jacksonKotlinModule = "com.fasterxml.jackson.module:jackson-module-kotlin"
     const val agroalPool = "io.agroal:agroal-pool:1.14"
-    const val vertxJdbcClient = "io.vertx:vertx-jdbc-client:4.2.5"
+    const val vertxJdbcClient = "io.vertx:vertx-jdbc-client:4.2.7"
     const val coroutineJdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutineVersion"
     const val coroutineReactor = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$coroutineVersion"
 
@@ -47,7 +47,7 @@ object Dependencies {
     // Test
     const val junit = "org.junit.jupiter:junit-jupiter:5.8.2"
     const val assertJ = "org.assertj:assertj-core:3.22.0"
-    const val mockk = "io.mockk:mockk:1.12.2"
+    const val mockk = "io.mockk:mockk:1.12.3"
 
     const val h2 = "com.h2database:h2:1.4.200"
 

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -111,6 +111,15 @@ open class QueryDslImpl<T>(
         lazyJoins().add(SimpleAssociatedJoinSpec(left = left, right = right, path = relation.path))
     }
 
+    override fun <P, C : P> treat(
+        root: ColumnSpec<*>,
+        parent: EntitySpec<P>,
+        child: EntitySpec<C>,
+        parentJoinType: JoinType
+    ) {
+        lazyJoins().add(TreatJoinSpec(parent, child, parentJoinType, root))
+    }
+
     override fun <T, R> fetch(
         left: EntitySpec<T>,
         right: EntitySpec<R>,

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/CriteriaQueryCreatorImplTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/CriteriaQueryCreatorImplTest.kt
@@ -90,7 +90,7 @@ internal class CriteriaQueryCreatorImplTest : WithKotlinJdslAssertions {
         every { em.criteriaBuilder } returns criteriaBuilder
         every { em.createQuery(createdQuery) } returns typedQuery
         every { criteriaBuilder.createQuery(Int::class.java) } returns createdQuery
-        every { from.join(join, createdQuery) } returns froms
+        every { from.join(join, createdQuery, criteriaBuilder) } returns froms
         every { select.apply(froms, createdQuery, criteriaBuilder) } just runs
         every { where.apply(froms, createdQuery, criteriaBuilder) } just runs
         every { groupBy.apply(froms, createdQuery, criteriaBuilder) } just runs
@@ -110,7 +110,7 @@ internal class CriteriaQueryCreatorImplTest : WithKotlinJdslAssertions {
             em.criteriaBuilder
             em.createQuery(createdQuery)
             criteriaBuilder.createQuery(Int::class.java)
-            from.join(join, createdQuery)
+            from.join(join, createdQuery, criteriaBuilder)
             select.returnType
             select.apply(froms, createdQuery, criteriaBuilder)
             where.apply(froms, createdQuery, criteriaBuilder)

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/from/QueryDslImplJoinTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/from/QueryDslImplJoinTest.kt
@@ -6,13 +6,19 @@ import com.linecorp.kotlinjdsl.query.clause.where.WhereClause
 import com.linecorp.kotlinjdsl.query.spec.CrossJoinSpec
 import com.linecorp.kotlinjdsl.query.spec.SimpleAssociatedJoinSpec
 import com.linecorp.kotlinjdsl.query.spec.SimpleJoinSpec
+import com.linecorp.kotlinjdsl.query.spec.TreatJoinSpec
+import com.linecorp.kotlinjdsl.query.spec.expression.ColumnSpec
 import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.AndSpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
 import com.linecorp.kotlinjdsl.querydsl.QueryDslImpl
 import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
+import com.linecorp.kotlinjdsl.test.entity.employee.Employee
+import com.linecorp.kotlinjdsl.test.entity.employee.FullTimeEmployee
+import com.linecorp.kotlinjdsl.test.entity.employee.Project
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 import javax.persistence.criteria.JoinType
 
 internal class QueryDslImplJoinTest : WithKotlinJdslAssertions {
@@ -104,6 +110,49 @@ internal class QueryDslImplJoinTest : WithKotlinJdslAssertions {
 
         assertThat(subquerySpec.join).isEqualTo(
             JoinClause(listOf(joinSpec, joinSpec, joinSpec, joinSpec))
+        )
+    }
+
+    @Test
+    fun treat() {
+        // when
+        val actual = QueryDslImpl(FullTimeEmployee::class.java).apply {
+            val project: EntitySpec<Project> = Project::class.alias("project")
+            val fullTimeEmployee = FullTimeEmployee::class.alias("fe")
+            val employee = Employee::class.alias("e")
+
+            selectDistinct(fullTimeEmployee)
+            from(project)
+            treat(
+                root = ColumnSpec<FullTimeEmployee>(entity = project, path = Project::employees.name),
+                parent = employee,
+                child = fullTimeEmployee,
+                parentJoinType = JoinType.RIGHT
+            )
+            where(
+                ColumnSpec<BigDecimal>(fullTimeEmployee, FullTimeEmployee::annualSalary.name)
+                    .greaterThan(100000.toBigDecimal())
+            )
+        }
+
+        // then
+        val joinSpec = TreatJoinSpec(
+            left = EntitySpec(Employee::class.java, "e"),
+            right = EntitySpec(FullTimeEmployee::class.java, "fe"),
+            joinType = JoinType.RIGHT,
+            root = ColumnSpec<FullTimeEmployee>(EntitySpec(Project::class.java, "project"), Project::employees.name),
+        )
+
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.join).isEqualTo(
+            JoinClause(listOf(joinSpec))
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.join).isEqualTo(
+            JoinClause(listOf(joinSpec))
         )
     }
 

--- a/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/from/EclipselinkCriteriaQueryDslFromTreatIntegrationTest.kt
+++ b/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/eclipselink/integration/querydsl/from/EclipselinkCriteriaQueryDslFromTreatIntegrationTest.kt
@@ -1,0 +1,17 @@
+package com.linecorp.kotlinjdsl.eclipselink.integration.querydsl.from
+
+import com.linecorp.kotlinjdsl.test.integration.querydsl.from.AbstractCriteriaQueryDslFromTreatIntegrationTest
+import org.eclipse.persistence.exceptions.QueryException
+import org.junit.jupiter.api.Test
+
+internal class EclipselinkCriteriaQueryDslFromTreatIntegrationTest :
+    AbstractCriteriaQueryDslFromTreatIntegrationTest() {
+    /**
+     * except Hibernate, select downcasting entity is prohibited
+     */
+    @Test
+    override fun getProjectByFullTimeEmployeesSalarySelectFullTimeEmployee() {
+        assertThatThrownBy { super.getProjectByFullTimeEmployeesSalarySelectFullTimeEmployee() }
+            .hasRootCauseExactlyInstanceOf(QueryException::class.java)
+    }
+}

--- a/eclipselink/src/test/resources/META-INF/persistence.xml
+++ b/eclipselink/src/test/resources/META-INF/persistence.xml
@@ -5,6 +5,12 @@
         http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
 
     <persistence-unit name="order">
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.ContractEmployee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.Employee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.FullTimeEmployee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.PartTimeEmployee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.Project</class>
+
         <class>com.linecorp.kotlinjdsl.test.entity.Address</class>
 
         <class>com.linecorp.kotlinjdsl.test.entity.order.Order</class>
@@ -18,7 +24,8 @@
         <class>com.linecorp.kotlinjdsl.test.entity.test.TestTable</class>
 
         <properties>
-            <property name="eclipselink.logging.level" value="FINE" />
+            <property name="eclipselink.logging.level" value="INFO" />
+            <property name="eclipselink.logging.level.sql" value="FINE" />
             <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:test;MODE=MYSQL"/>
             <property name="javax.persistence.jdbc.user" value="sa"/>
             <property name="javax.persistence.jdbc.password" value=""/>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/MutinyReactiveCriteriaQueryCreatorTest.kt
+++ b/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/MutinyReactiveCriteriaQueryCreatorTest.kt
@@ -85,7 +85,7 @@ internal class MutinyReactiveCriteriaQueryCreatorTest : WithKotlinJdslAssertions
 
         every { session.createQuery(createdQuery) } returns stageQuery
         every { criteriaBuilder.createQuery(Int::class.java) } returns createdQuery
-        every { from.join(join, createdQuery) } returns froms
+        every { from.join(join, createdQuery, criteriaBuilder) } returns froms
         every { select.apply(froms, createdQuery, criteriaBuilder) } just runs
         every { where.apply(froms, createdQuery, criteriaBuilder) } just runs
         every { groupBy.apply(froms, createdQuery, criteriaBuilder) } just runs
@@ -104,7 +104,7 @@ internal class MutinyReactiveCriteriaQueryCreatorTest : WithKotlinJdslAssertions
         verify(exactly = 1) {
             session.createQuery(createdQuery)
             criteriaBuilder.createQuery(Int::class.java)
-            from.join(join, createdQuery)
+            from.join(join, createdQuery, criteriaBuilder)
             select.returnType
             select.apply(froms, createdQuery, criteriaBuilder)
             where.apply(froms, createdQuery, criteriaBuilder)

--- a/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/MutinyStatelessReactiveCriteriaQueryCreatorTest.kt
+++ b/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/MutinyStatelessReactiveCriteriaQueryCreatorTest.kt
@@ -85,7 +85,7 @@ internal class MutinyStatelessReactiveCriteriaQueryCreatorTest : WithKotlinJdslA
 
         every { session.createQuery(createdQuery) } returns stageQuery
         every { criteriaBuilder.createQuery(Int::class.java) } returns createdQuery
-        every { from.join(join, createdQuery) } returns froms
+        every { from.join(join, createdQuery, criteriaBuilder) } returns froms
         every { select.apply(froms, createdQuery, criteriaBuilder) } just runs
         every { where.apply(froms, createdQuery, criteriaBuilder) } just runs
         every { groupBy.apply(froms, createdQuery, criteriaBuilder) } just runs
@@ -104,7 +104,7 @@ internal class MutinyStatelessReactiveCriteriaQueryCreatorTest : WithKotlinJdslA
         verify(exactly = 1) {
             session.createQuery(createdQuery)
             criteriaBuilder.createQuery(Int::class.java)
-            from.join(join, createdQuery)
+            from.join(join, createdQuery, criteriaBuilder)
             select.returnType
             select.apply(froms, createdQuery, criteriaBuilder)
             where.apply(froms, createdQuery, criteriaBuilder)

--- a/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/test/reactive/integration/querydsl/from/HibernateCriteriaQueryDslFromTreatIntegrationTest.kt
+++ b/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/test/reactive/integration/querydsl/from/HibernateCriteriaQueryDslFromTreatIntegrationTest.kt
@@ -1,0 +1,33 @@
+package com.linecorp.kotlinjdsl.test.reactive.integration.querydsl.from
+
+import com.linecorp.kotlinjdsl.test.reactive.HibernateCriteriaIntegrationTest
+import com.linecorp.kotlinjdsl.test.reactive.querydsl.from.AbstractCriteriaQueryDslFromTreatIntegrationTest
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.Test
+import javax.persistence.EntityManagerFactory
+
+/**
+ * https://discourse.hibernate.org/t/jpa-downcast-criteria-treat-vs-jpql-treat/2231
+ *
+ * This isn't the case in all cases, and if the root and parent entities are the same when downcasting, there's no problem.
+ * However, if the root and parent entities are different and an attempt to downcast them to a child entity is not used,
+ * however, an additional join occurs in the query statement.
+ * In this case, if you treat distinct as in the test example, there is no problem.
+ */
+internal class HibernateCriteriaQueryDslFromTreatIntegrationTest : HibernateCriteriaIntegrationTest,
+    AbstractCriteriaQueryDslFromTreatIntegrationTest<Mutiny.SessionFactory>() {
+    override lateinit var factory: Mutiny.SessionFactory
+    override lateinit var entityManagerFactory: EntityManagerFactory
+
+    /**
+     * https://discourse.hibernate.org/t/can-fetch-be-used-as-parameter-of-treat-for-downcasting/3301
+     * An UnsupportedOperationException is raised when fetching an entity intended for downcasting.
+     * The solution is to use the method in the link, Criteria API for Hibernate,
+     * but we use JPA standard Criteria API, so it is difficult to support until Hibernate fixes the bug.
+     */
+    @Test
+    override fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalaryWithFetch() {
+        assertThatThrownBy { super.getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalaryWithFetch() }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+    }
+}

--- a/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/hibernate/integration/querydsl/from/HibernateCriteriaQueryDslFromTreatIntegrationTest.kt
+++ b/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/hibernate/integration/querydsl/from/HibernateCriteriaQueryDslFromTreatIntegrationTest.kt
@@ -1,0 +1,27 @@
+package com.linecorp.kotlinjdsl.hibernate.integration.querydsl.from
+
+import com.linecorp.kotlinjdsl.test.integration.querydsl.from.AbstractCriteriaQueryDslFromTreatIntegrationTest
+import org.junit.jupiter.api.Test
+
+/**
+ * https://discourse.hibernate.org/t/jpa-downcast-criteria-treat-vs-jpql-treat/2231
+ *
+ * This isn't the case in all cases, and if the root and parent entities are the same when downcasting, there's no problem.
+ * However, if the root and parent entities are different and an attempt to downcast them to a child entity is not used,
+ * however, an additional join occurs in the query statement.
+ * In this case, if you treat distinct as in the test example, there is no problem.
+ */
+internal class HibernateCriteriaQueryDslFromTreatIntegrationTest : AbstractCriteriaQueryDslFromTreatIntegrationTest() {
+
+    /**
+     * https://discourse.hibernate.org/t/can-fetch-be-used-as-parameter-of-treat-for-downcasting/3301
+     * An UnsupportedOperationException is raised when fetching an entity intended for downcasting.
+     * The solution is to use the method in the link, Criteria API for Hibernate,
+     * but we use JPA standard Criteria API, so it is difficult to support until Hibernate fixes the bug.
+     */
+    @Test
+    override fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalaryWithFetch() {
+        assertThatThrownBy { super.getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalaryWithFetch() }
+            .isInstanceOf(UnsupportedOperationException::class.java)
+    }
+}

--- a/hibernate/src/test/resources/META-INF/persistence.xml
+++ b/hibernate/src/test/resources/META-INF/persistence.xml
@@ -5,6 +5,12 @@
         http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
 
     <persistence-unit name="order">
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.ContractEmployee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.Employee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.FullTimeEmployee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.PartTimeEmployee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.Project</class>
+
         <class>com.linecorp.kotlinjdsl.test.entity.Address</class>
 
         <class>com.linecorp.kotlinjdsl.test.entity.order.Order</class>

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClause.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.query.clause.from
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
 import javax.persistence.criteria.AbstractQuery
+import javax.persistence.criteria.CriteriaBuilder
 import javax.persistence.criteria.CriteriaDelete
 import javax.persistence.criteria.CriteriaUpdate
 
@@ -14,8 +15,8 @@ import javax.persistence.criteria.CriteriaUpdate
 data class FromClause<T>(
     private val entity: EntitySpec<T>,
 ) {
-    fun join(joinClause: JoinClause, query: AbstractQuery<*>): Froms {
-        return Joiner(entity, joinClause.joins, query).joinAll()
+    fun join(joinClause: JoinClause, query: AbstractQuery<*>, criteriaBuilder: CriteriaBuilder): Froms {
+        return Joiner(entity, joinClause.joins, query, criteriaBuilder).joinAll()
     }
 
     fun associate(joinClause: SimpleAssociatedJoinClause, query: CriteriaUpdate<T>): Froms {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/Joiner.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/Joiner.kt
@@ -7,8 +7,11 @@ import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
 import java.util.*
 import javax.persistence.criteria.*
 
-internal typealias ExplicitErasedParent = Number
-internal typealias ExplicitErasedChild = Int
+// In the case of Treat, Type should be clearly treated as a parent/child relationship,
+// but it was used because it needed a parent/child relationship that can be cast forcibly due to the current structure that receives JoinSpec as *.
+// Since it is used only internally, it is declared as a private alias.
+private typealias ExplicitErasedParent = Number
+private typealias ExplicitErasedChild = Int
 
 /**
  * Internal Only

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/JpaCriteriaQueryBuilder.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/JpaCriteriaQueryBuilder.kt
@@ -15,7 +15,7 @@ object JpaCriteriaQueryBuilder {
         queryBuilder: (CriteriaQuery<T>) -> Q
     ): Q {
         val query: CriteriaQuery<T> = criteriaBuilder.createQuery(spec.select.returnType)
-        val froms = spec.from.join(spec.join, query)
+        val froms = spec.from.join(spec.join, query, criteriaBuilder)
 
         spec.select.apply(froms, query, criteriaBuilder)
         spec.where.apply(froms, query, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/SubqueryCreatorImpl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/SubqueryCreatorImpl.kt
@@ -14,7 +14,7 @@ class SubqueryCreatorImpl : SubqueryCreator {
         criteriaBuilder: CriteriaBuilder
     ): Subquery<T> {
         val subquery = criteria.subquery(spec.select.returnType)
-        val subqueryFroms = spec.from.join(spec.join, subquery) + froms
+        val subqueryFroms = spec.from.join(spec.join, subquery, criteriaBuilder) + froms
 
         spec.select.apply(subqueryFroms, subquery, criteriaBuilder)
         spec.where.apply(subqueryFroms, subquery, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/JoinSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/JoinSpec.kt
@@ -1,5 +1,6 @@
 package com.linecorp.kotlinjdsl.query.spec
 
+import com.linecorp.kotlinjdsl.query.spec.expression.ColumnSpec
 import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
 import javax.persistence.criteria.JoinType
 
@@ -41,3 +42,12 @@ data class FetchJoinSpec<L, R>(
 data class CrossJoinSpec<T>(
     override val entity: EntitySpec<T>,
 ) : JoinSpec<T>
+
+data class TreatJoinSpec<P, T : P>(
+    override val left: EntitySpec<P>,
+    override val right: EntitySpec<T>,
+    override val joinType: JoinType,
+    val root: ColumnSpec<*>
+) : AssociatedJoinSpec<P, T> {
+    override val path: String = root.path
+}

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpec.kt
@@ -4,8 +4,8 @@ import com.linecorp.kotlinjdsl.query.spec.Froms
 import javax.persistence.criteria.*
 
 data class ColumnSpec<T>(
-    private val entity: EntitySpec<*>,
-    private val path: String
+    val entity: EntitySpec<*>,
+    val path: String
 ) : ExpressionSpec<T> {
     override fun toCriteriaExpression(
         froms: Froms,

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/EntitySpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/EntitySpec.kt
@@ -5,7 +5,7 @@ import javax.persistence.criteria.*
 
 data class EntitySpec<T>(
     val type: Class<T>,
-    private val alias: String = "$DEFAULT_ALIAS_TOKEN${type.name}"
+    private val alias: String? = null
 ) : ExpressionSpec<T> {
     companion object {
         private const val DEFAULT_ALIAS_TOKEN = "\\"
@@ -32,6 +32,6 @@ data class EntitySpec<T>(
     private fun path(froms: Froms) = froms[this].apply { applyAlias() }
 
     private fun Path<T>.applyAlias() {
-        this@EntitySpec.alias.takeIf { !it.startsWith(DEFAULT_ALIAS_TOKEN) }?.run { alias(this) }
+        this@EntitySpec.alias?.run { alias(this) }
     }
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/from/JoinDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/from/JoinDsl.kt
@@ -5,7 +5,7 @@ import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
 import javax.persistence.criteria.JoinType
 import kotlin.reflect.KClass
 
-interface JoinDsl : AssociateDsl {
+interface JoinDsl : AssociateDsl, TreatDsl {
     fun on(predicate: PredicateSpec): PredicateSpec = predicate
     fun on(predicate: () -> PredicateSpec): PredicateSpec = on(predicate())
 

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/from/TreatDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/from/TreatDsl.kt
@@ -1,0 +1,29 @@
+package com.linecorp.kotlinjdsl.querydsl.from
+
+import com.linecorp.kotlinjdsl.query.spec.expression.ColumnSpec
+import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
+import javax.persistence.criteria.JoinType
+import kotlin.reflect.KClass
+
+interface TreatDsl {
+    fun <P, C : P> treat(
+        root: ColumnSpec<*>,
+        parent: EntitySpec<P>,
+        child: EntitySpec<C>,
+        parentJoinType: JoinType = JoinType.INNER,
+    )
+
+    fun <P : Any, C : P> treat(
+        root: ColumnSpec<*>,
+        parent: EntitySpec<P>,
+        child: KClass<C>,
+        parentJoinType: JoinType = JoinType.INNER,
+    ) = treat(root, parent, EntitySpec(child.java), parentJoinType)
+
+    fun <P : Any, C : P> treat(
+        root: ColumnSpec<*>,
+        parent: KClass<P>,
+        child: KClass<C>,
+        parentJoinType: JoinType = JoinType.INNER,
+    ) = treat(root, EntitySpec(parent.java), EntitySpec(child.java), parentJoinType)
+}

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/from/TreatDslExtensions.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/from/TreatDslExtensions.kt
@@ -1,0 +1,16 @@
+package com.linecorp.kotlinjdsl.querydsl.from
+
+import com.linecorp.kotlinjdsl.query.spec.expression.ColumnSpec
+import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
+import javax.persistence.criteria.JoinType
+
+inline fun <reified P : Any, reified T : P> TreatDsl.treat(parentJoinType: JoinType = JoinType.INNER) {
+    treat(ColumnSpec<P>(EntitySpec(P::class.java), ""), P::class, T::class, parentJoinType)
+}
+
+inline fun <reified P : Any, reified T : P> TreatDsl.treat(
+    root: ColumnSpec<*>,
+    parentJoinType: JoinType = JoinType.INNER
+) {
+    treat(root, EntitySpec(P::class.java), T::class, parentJoinType)
+}

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClauseTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClauseTest.kt
@@ -1,14 +1,15 @@
 package com.linecorp.kotlinjdsl.query.clause.from
 
 import com.linecorp.kotlinjdsl.query.spec.*
+import com.linecorp.kotlinjdsl.query.spec.expression.ColumnSpec
 import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
 import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
-import io.mockk.confirmVerified
-import io.mockk.every
+import com.linecorp.kotlinjdsl.test.entity.employee.Employee
+import com.linecorp.kotlinjdsl.test.entity.employee.FullTimeEmployee
+import com.linecorp.kotlinjdsl.test.entity.employee.PartTimeEmployee
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import io.mockk.mockk
-import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import javax.persistence.criteria.*
@@ -23,6 +24,9 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
 
     @MockK
     private lateinit var deleteQuery: CriteriaDelete<Data1>
+
+    @MockK
+    private lateinit var criteriaBuilder: CriteriaBuilder
 
     private val entitySpec1 = EntitySpec(Data1::class.java)
     private val entitySpec2 = EntitySpec(Data2::class.java)
@@ -53,7 +57,7 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
         every { query.from(Data4::class.java) } returns crossJoin1
 
         // when
-        val actual = fromClause.join(joinClause, query)
+        val actual = fromClause.join(joinClause, query, criteriaBuilder)
 
         // then
         assertThat(actual).usingRecursiveComparison().isEqualTo(
@@ -68,7 +72,7 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
             )
         )
 
-        verify(exactly = 1) {
+        verifyOrder {
             query.from(Data1::class.java)
             root.join<Any, Any>("data2", JoinType.INNER)
             join1.fetch<Any, Any>("data3", JoinType.LEFT)
@@ -83,6 +87,320 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
         }
 
         confirmVerified(root, join1, fetch1, crossJoin1, query)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun treatWithOtherRoot() {
+        // given
+        val fromEntitySpec = EntitySpec(RootOther::class.java, "root")
+        val outerParent = EntitySpec(Parent::class.java, "outerParent")
+        val innerParent = EntitySpec(Parent::class.java, "innerParent")
+        val fetchInnerParent = EntitySpec(Parent::class.java, "fetchInnerParent")
+        val fetchOuterParent = EntitySpec(Parent::class.java, "fetchOuterParent")
+
+        val treatInnerParent = EntitySpec(Parent::class.java, "treatInnerParent")
+        val treatOuterParent = EntitySpec(Parent::class.java, "treatOuterParent")
+        val child1Inner = EntitySpec(Child1::class.java, "child1Inner")
+        val child1Outer = EntitySpec(Child1::class.java, "child1Outer")
+        val child1FetchInner = EntitySpec(Child1::class.java, "child1FetchInner")
+        val child2FetchOuter = EntitySpec(Child2::class.java, "child2FetchOuter")
+        val child3 = EntitySpec(Child3::class.java, "child3")
+        val fromClause = FromClause(fromEntitySpec)
+
+        val joinSpec1 = SimpleJoinSpec(fromEntitySpec, outerParent, RootOther::outerChild1.name, JoinType.INNER)
+        // winner with joinSpec1
+        val joinSpec2 = SimpleJoinSpec(fromEntitySpec, outerParent, RootOther::outerChild1.name, JoinType.LEFT)
+
+        // winner
+        val joinSpec3 = SimpleJoinSpec(fromEntitySpec, innerParent, RootOther::innerChild2.name, JoinType.INNER)
+
+        // winner
+        val joinSpec4 = CrossJoinSpec(child3)
+
+        // winner
+        val joinSpec5 =
+            FetchJoinSpec(fromEntitySpec, fetchInnerParent, RootOther::fetchInnerChild1.name, JoinType.INNER)
+
+        val joinSpec6 =
+            FetchJoinSpec(fromEntitySpec, fetchOuterParent, RootOther::fetchOuterChild2.name, JoinType.INNER)
+        // winner with joinSpec6
+        val joinSpec7 = FetchJoinSpec(fromEntitySpec, fetchOuterParent, RootOther::fetchOuterChild2.name, JoinType.LEFT)
+
+        // winner
+        val joinSpec8 = TreatJoinSpec(
+            left = innerParent,
+            right = child1Inner,
+            joinType = JoinType.INNER,
+            root = ColumnSpec<Child1>(fromEntitySpec, RootOther::treatChildrenInner.name),
+        )
+
+        val joinSpec9 = TreatJoinSpec(
+            left = outerParent,
+            right = child1Outer,
+            joinType = JoinType.INNER,
+            root = ColumnSpec<Child1>(fromEntitySpec, RootOther::treatChildrenOuter.name),
+        )
+        // winner with joinSpec9
+        val joinSpec10 = TreatJoinSpec(
+            left = outerParent,
+            right = child1Outer,
+            joinType = JoinType.LEFT,
+            root = ColumnSpec<Child1>(fromEntitySpec, RootOther::treatChildrenOuter.name),
+        )
+
+        // winner
+        val joinSpec11 = TreatJoinSpec(
+            left = treatInnerParent,
+            right = child1FetchInner,
+            joinType = JoinType.INNER,
+            root = ColumnSpec<Child1>(fromEntitySpec, RootOther::treatFetchInnerChild1.name),
+        )
+
+        val joinSpec12 = TreatJoinSpec(
+            left = treatOuterParent,
+            right = child2FetchOuter,
+            joinType = JoinType.INNER,
+            root = ColumnSpec<Child2>(fromEntitySpec, RootOther::treatFetchOuterChild2.name),
+        )
+        // winner with joinSpec12
+        val joinSpec13 = TreatJoinSpec(
+            left = treatOuterParent,
+            right = child2FetchOuter,
+            joinType = JoinType.LEFT,
+            root = ColumnSpec<Child2>(fromEntitySpec, RootOther::treatFetchOuterChild2.name),
+        )
+
+
+        val joinClause = JoinClause(
+            listOf(
+                joinSpec1,
+                joinSpec2,
+                joinSpec3,
+                joinSpec4,
+                joinSpec5,
+                joinSpec6,
+                joinSpec7,
+                joinSpec8,
+                joinSpec9,
+                joinSpec10,
+                joinSpec11,
+                joinSpec12,
+                joinSpec13,
+            )
+        )
+
+        val root = mockk<Root<RootOther>>()
+        val outerJoin1 = mockk<Join<RootOther, Parent>>()
+        val innerJoin1 = mockk<Join<RootOther, Parent>>()
+        val crossJoin1 = mockk<Root<Child3>>()
+
+        val fetchInnerJoin1 = mockk<MockFetch<RootOther, Parent>>()
+        val fetchOuterJoin1 = mockk<MockFetch<RootOther, Parent>>()
+
+        val treatInnerParentJoin1 = mockk<Join<RootOther, Parent>>()
+        val treatOuterParentJoin1 = mockk<Join<RootOther, Parent>>()
+
+        val treatJoin1 = mockk<Join<ExplicitErasedParent, ExplicitErasedChild>>()
+        val treatJoin2 = mockk<Join<ExplicitErasedParent, ExplicitErasedChild>>()
+        val treatJoin3 = mockk<Join<ExplicitErasedParent, ExplicitErasedChild>>()
+        val treatJoin4 = mockk<Join<ExplicitErasedParent, ExplicitErasedChild>>()
+
+        every { query.from(RootOther::class.java) } returns root
+        every { root.join<RootOther, Parent>(RootOther::outerChild1.name, JoinType.LEFT) } returns outerJoin1
+        every { root.join<RootOther, Parent>(RootOther::innerChild2.name, JoinType.INNER) } returns innerJoin1
+        every { query.from(Child3::class.java) } returns crossJoin1
+
+        every {
+            root.fetch<RootOther, Parent>(
+                RootOther::fetchInnerChild1.name,
+                JoinType.INNER
+            )
+        } returns fetchInnerJoin1
+        every { root.fetch<RootOther, Parent>(RootOther::fetchOuterChild2.name, JoinType.LEFT) } returns fetchOuterJoin1
+
+        every {
+            criteriaBuilder.treat(
+                innerJoin1 as Join<ExplicitErasedParent, ExplicitErasedChild>,
+                Child1::class.java as Class<ExplicitErasedChild>
+            )
+        } returns treatJoin1
+        every {
+            criteriaBuilder.treat(
+                outerJoin1 as Join<ExplicitErasedParent, ExplicitErasedChild>,
+                Child1::class.java as Class<ExplicitErasedChild>
+            )
+        } returns treatJoin2
+
+        every {
+            root.join<RootOther, Parent>(
+                RootOther::treatFetchInnerChild1.name,
+                JoinType.INNER
+            )
+        } returns treatInnerParentJoin1
+        every {
+            root.join<RootOther, Parent>(
+                RootOther::treatFetchOuterChild2.name,
+                JoinType.LEFT
+            )
+        } returns treatOuterParentJoin1
+
+        every {
+            criteriaBuilder.treat(
+                treatInnerParentJoin1 as Join<ExplicitErasedParent, ExplicitErasedChild>,
+                Child1::class.java as Class<ExplicitErasedChild>
+            )
+        } returns treatJoin3
+        every {
+            criteriaBuilder.treat(
+                treatOuterParentJoin1 as Join<ExplicitErasedParent, ExplicitErasedChild>,
+                Child2::class.java as Class<ExplicitErasedChild>
+            )
+        } returns treatJoin4
+
+        // when
+        val actual = fromClause.join(joinClause, query, criteriaBuilder)
+
+        // then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(
+            Froms(
+                root = root,
+                map = mapOf(
+                    fromEntitySpec to root,
+                    fetchOuterParent to fetchOuterJoin1,
+                    fetchInnerParent to fetchInnerJoin1,
+                    outerParent to outerJoin1,
+                    innerParent to innerJoin1,
+                    child3 to crossJoin1,
+                    treatOuterParent to treatOuterParentJoin1,
+                    treatInnerParent to treatInnerParentJoin1,
+                    child1Inner to treatJoin1,
+                    child1Outer to treatJoin2,
+                    child1FetchInner to treatJoin3,
+                    child2FetchOuter to treatJoin4,
+                )
+            )
+        )
+
+        verify {
+            query.from(RootOther::class.java)
+            root.join<RootOther, Parent>(RootOther::outerChild1.name, JoinType.LEFT)
+            root.join<RootOther, Parent>(RootOther::innerChild2.name, JoinType.INNER)
+            query.from(Child3::class.java)
+            root.fetch<RootOther, Parent>(
+                RootOther::fetchInnerChild1.name,
+                JoinType.INNER
+            )
+            root.fetch<RootOther, Parent>(RootOther::fetchOuterChild2.name, JoinType.LEFT)
+            criteriaBuilder.treat(
+                innerJoin1 as Join<ExplicitErasedParent, ExplicitErasedChild>,
+                Child1::class.java as Class<ExplicitErasedChild>
+            )
+            criteriaBuilder.treat(
+                outerJoin1 as Join<ExplicitErasedParent, ExplicitErasedChild>,
+                Child1::class.java as Class<ExplicitErasedChild>
+            )
+            root.join<RootOther, Parent>(
+                RootOther::treatFetchInnerChild1.name,
+                JoinType.INNER
+            )
+
+            root.join<RootOther, Parent>(
+                RootOther::treatFetchOuterChild2.name,
+                JoinType.LEFT
+            )
+            criteriaBuilder.treat(
+                treatInnerParentJoin1 as Join<ExplicitErasedParent, ExplicitErasedChild>,
+                Child1::class.java as Class<ExplicitErasedChild>
+            )
+            criteriaBuilder.treat(
+                treatOuterParentJoin1 as Join<ExplicitErasedParent, ExplicitErasedChild>,
+                Child2::class.java as Class<ExplicitErasedChild>
+            )
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun treatJoinRoot() {
+        // given
+        val fromEntitySpec = EntitySpec(Employee::class.java)
+        val entitySpec1 = EntitySpec(FullTimeEmployee::class.java, "fe")
+        val entitySpec2 = EntitySpec(PartTimeEmployee::class.java, "pe")
+        val fromClause = FromClause(fromEntitySpec)
+
+        val joinSpec0 = TreatJoinSpec(
+            left = fromEntitySpec,
+            right = entitySpec1,
+            joinType = JoinType.INNER,
+            root = ColumnSpec<FullTimeEmployee>(fromEntitySpec, "fe"),
+        )
+
+        val joinSpec1 = TreatJoinSpec(
+            left = fromEntitySpec,
+            right = entitySpec2,
+            joinType = JoinType.LEFT,
+            root = ColumnSpec<PartTimeEmployee>(fromEntitySpec, "pe"),
+        )
+
+        val joinClause = JoinClause(
+            listOf(
+                joinSpec0,
+                joinSpec1
+            )
+        )
+
+        val root = mockk<Root<Employee>>()
+        val join0 = mockk<Root<FullTimeEmployee>>()
+        val join1 = mockk<Root<PartTimeEmployee>>()
+
+        every { root.javaType } returns Employee::class.java
+        every { query.from(Employee::class.java) } returns root
+        every {
+            criteriaBuilder.treat(
+                root as Root<ExplicitErasedParent>,
+                joinSpec0.right.type as Class<ExplicitErasedChild>
+            )
+        } returns join0 as Root<ExplicitErasedChild>
+        every {
+            criteriaBuilder.treat(
+                root as Root<ExplicitErasedParent>,
+                joinSpec1.right.type as Class<ExplicitErasedChild>
+            )
+        } returns join0 as Root<ExplicitErasedChild>
+
+        // when
+        val actual = fromClause.join(joinClause, query, criteriaBuilder)
+
+        // then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(
+            Froms(
+                root = root,
+                map = mapOf(
+                    fromEntitySpec to root,
+                    entitySpec1 to join0,
+                    entitySpec2 to join1,
+                )
+            )
+        )
+
+        verify {
+            query.from(Employee::class.java)
+            root.javaType
+            criteriaBuilder.treat(
+                root as Root<ExplicitErasedParent>,
+                joinSpec0.right.type as Class<ExplicitErasedChild>
+            )
+            criteriaBuilder.treat(
+                root as Root<ExplicitErasedParent>,
+                joinSpec1.right.type as Class<ExplicitErasedChild>
+            )
+            root.hashCode()
+            join0.hashCode()
+            join1.hashCode()
+        }
+
+        confirmVerified(root, join0, join1, query)
     }
 
     @Test
@@ -100,7 +418,7 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
 
         // when
         val exception = catchThrowable(IllegalStateException::class) {
-            fromClause.join(joinClause, query)
+            fromClause.join(joinClause, query, criteriaBuilder)
         }
 
         // then
@@ -220,6 +538,23 @@ internal class FromClauseTest : WithKotlinJdslAssertions {
     private class Data2
     private class Data3
     private class Data4
+
+    private class RootOther(
+        val id: Long,
+        val treatChildrenInner: List<Parent>,
+        val treatChildrenOuter: List<Parent>,
+        val innerChild2: Parent,
+        val outerChild1: Parent,
+        val fetchInnerChild1: Parent,
+        val fetchOuterChild2: Parent,
+        val treatFetchInnerChild1: Parent,
+        val treatFetchOuterChild2: Parent
+    )
+
+    private open class Parent(val id: Long, val rootId: Long)
+    private class Child1(parentId: Long, rootId: Long) : Parent(parentId, rootId)
+    private class Child2(parentId: Long, rootId: Long) : Parent(parentId, rootId)
+    private class Child3(parentId: Long, rootId: Long) : Parent(parentId, rootId)
 
     private interface MockFetch<T, R> : Join<T, R>, Fetch<T, R>
 }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClauseTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClauseTest.kt
@@ -14,6 +14,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import javax.persistence.criteria.*
 
+
+private typealias ExplicitErasedParent = Number
+private typealias ExplicitErasedChild = Int
+
 @ExtendWith(MockKExtension::class)
 internal class FromClauseTest : WithKotlinJdslAssertions {
     @MockK

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/JpaCriteriaQueryBuilderTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/JpaCriteriaQueryBuilderTest.kt
@@ -86,7 +86,7 @@ internal class JpaCriteriaQueryBuilderTest : WithKotlinJdslAssertions {
 
         every { em.createQuery(createdQuery) } returns typedQuery
         every { criteriaBuilder.createQuery(Int::class.java) } returns createdQuery
-        every { from.join(join, createdQuery) } returns froms
+        every { from.join(join, createdQuery, criteriaBuilder) } returns froms
         every { select.apply(froms, createdQuery, criteriaBuilder) } just runs
         every { where.apply(froms, createdQuery, criteriaBuilder) } just runs
         every { groupBy.apply(froms, createdQuery, criteriaBuilder) } just runs
@@ -105,7 +105,7 @@ internal class JpaCriteriaQueryBuilderTest : WithKotlinJdslAssertions {
         verify(exactly = 1) {
             em.createQuery(createdQuery)
             criteriaBuilder.createQuery(Int::class.java)
-            from.join(join, createdQuery)
+            from.join(join, createdQuery, criteriaBuilder)
             select.returnType
             select.apply(froms, createdQuery, criteriaBuilder)
             where.apply(froms, createdQuery, criteriaBuilder)

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/SubqueryCreatorImplTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/SubqueryCreatorImplTest.kt
@@ -74,7 +74,7 @@ internal class SubqueryCreatorImplTest : WithAssertions {
         )
 
         every { criteriaQuery.subquery(Int::class.java) } returns createdQuery
-        every { from.join(join, createdQuery) } returns createdFroms
+        every { from.join(join, createdQuery, criteriaBuilder) } returns createdFroms
         every { createdFroms + froms } returns mergedFroms
         every { select.apply(mergedFroms, createdQuery, criteriaBuilder) } just runs
         every { where.apply(mergedFroms, createdQuery, criteriaBuilder) } just runs
@@ -89,7 +89,7 @@ internal class SubqueryCreatorImplTest : WithAssertions {
 
         verify(exactly = 1) {
             criteriaQuery.subquery(Int::class.java)
-            from.join(join, createdQuery)
+            from.join(join, createdQuery, criteriaBuilder)
             createdFroms + froms
             select.returnType
             select.apply(mergedFroms, createdQuery, criteriaBuilder)
@@ -133,7 +133,7 @@ internal class SubqueryCreatorImplTest : WithAssertions {
         )
 
         every { criteriaUpdate.subquery(Int::class.java) } returns createdQuery
-        every { from.join(join, createdQuery) } returns createdFroms
+        every { from.join(join, createdQuery, criteriaBuilder) } returns createdFroms
         every { createdFroms + froms } returns mergedFroms
         every { select.apply(mergedFroms, createdQuery, criteriaBuilder) } just runs
         every { where.apply(mergedFroms, createdQuery, criteriaBuilder) } just runs
@@ -148,7 +148,7 @@ internal class SubqueryCreatorImplTest : WithAssertions {
 
         verify(exactly = 1) {
             criteriaUpdate.subquery(Int::class.java)
-            from.join(join, createdQuery)
+            from.join(join, createdQuery, criteriaBuilder)
             createdFroms + froms
             select.returnType
             select.apply(mergedFroms, createdQuery, criteriaBuilder)

--- a/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
+++ b/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
@@ -106,6 +106,15 @@ open class ReactiveQueryDslImpl<T>(
         lazyJoins().add(SimpleAssociatedJoinSpec(left = left, right = right, path = relation.path))
     }
 
+    override fun <P, C : P> treat(
+        root: ColumnSpec<*>,
+        parent: EntitySpec<P>,
+        child: EntitySpec<C>,
+        parentJoinType: JoinType
+    ) {
+        lazyJoins().add(TreatJoinSpec(parent, child, parentJoinType, root))
+    }
+
     override fun <T, R> fetch(
         left: EntitySpec<T>,
         right: EntitySpec<R>,

--- a/spring/data-reactive-core/README.md
+++ b/spring/data-reactive-core/README.md
@@ -63,7 +63,7 @@ For more detailed usage, see [more](../../reactive-core/README.md#Quick-Start)
 class Service(
     private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory,
 ) {
-    suspend fun findById(id: Long): Entity {
+    suspend fun findById(id: Long): Book {
         return queryFactory.singleQuery {
             select(entity(Book::class))
             from(entity(Book::class))

--- a/test-fixture/entity/src/main/kotlin/com/linecorp/kotlinjdsl/test/entity/EntityDsl.kt
+++ b/test-fixture/entity/src/main/kotlin/com/linecorp/kotlinjdsl/test/entity/EntityDsl.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.test.entity
 import com.linecorp.kotlinjdsl.test.entity.delivery.DeliveryAddressTestBuilder
 import com.linecorp.kotlinjdsl.test.entity.delivery.DeliveryItemTestBuilder
 import com.linecorp.kotlinjdsl.test.entity.delivery.DeliveryTestBuilder
+import com.linecorp.kotlinjdsl.test.entity.employee.*
 import com.linecorp.kotlinjdsl.test.entity.order.OrderAddressTestBuilder
 import com.linecorp.kotlinjdsl.test.entity.order.OrderGroupTestBuilder
 import com.linecorp.kotlinjdsl.test.entity.order.OrderItemTestBuilder
@@ -20,4 +21,10 @@ interface EntityDsl {
 
     fun deliveryAddress(customize: DeliveryAddressTestBuilder.() -> Unit) =
         DeliveryAddressTestBuilder().apply(customize).build()
+
+    fun employee(customize: EmployeeTestBuilder.() -> Unit) = EmployeeTestBuilder().apply(customize).build()
+    fun partTimeEmployee(customize: PartTimeEmployeeTestBuilder.() -> Unit) = PartTimeEmployeeTestBuilder().apply(customize).build()
+    fun contractEmployee(customize: ContractEmployeeTestBuilder.() -> Unit) = ContractEmployeeTestBuilder().apply(customize).build()
+    fun fullTimeEmployee(customize: FullTimeEmployeeTestBuilder.() -> Unit) = FullTimeEmployeeTestBuilder().apply(customize).build()
+    fun project(customize: ProjectTestBuilder.() -> Unit) = ProjectTestBuilder().apply(customize).build()
 }

--- a/test-fixture/entity/src/main/kotlin/com/linecorp/kotlinjdsl/test/entity/employee/Employee.kt
+++ b/test-fixture/entity/src/main/kotlin/com/linecorp/kotlinjdsl/test/entity/employee/Employee.kt
@@ -1,0 +1,137 @@
+package com.linecorp.kotlinjdsl.test.entity.employee
+
+import java.math.BigDecimal
+import java.util.*
+import javax.persistence.*
+
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@Entity
+@Table(name = "employee")
+@DiscriminatorColumn(name = "EMP_TYPE")
+class Employee(
+    @Id
+    @GeneratedValue
+    val id: Long,
+    val name: String
+) {
+    override fun equals(other: Any?) = Objects.equals(id, (other as? Employee)?.id)
+    override fun hashCode() = Objects.hashCode(id)
+}
+
+@Entity
+@Table(name = "fulltime_employee")
+@DiscriminatorValue("F")
+class FullTimeEmployee(
+    val annualSalary: BigDecimal,
+    override val id: Long,
+    override val name: String
+) : Employee(id, name) {
+    override fun equals(other: Any?) = Objects.equals(id, (other as? FullTimeEmployee)?.id)
+    override fun hashCode() = Objects.hashCode(id)
+}
+
+@Entity
+@Table(name = "parttime_employee")
+@DiscriminatorValue("P")
+class PartTimeEmployee(
+    val weeklySalary: BigDecimal,
+    override val id: Long,
+    override val name: String
+) : Employee(id, name) {
+    override fun equals(other: Any?) = Objects.equals(id, (other as? PartTimeEmployee)?.id)
+    override fun hashCode() = Objects.hashCode(id)
+}
+
+@Entity
+@Table(name = "contract_employee")
+@DiscriminatorValue("C")
+class ContractEmployee(
+    val hourlyRate: BigDecimal,
+    override val id: Long,
+    override val name: String
+) : Employee(id, name) {
+    override fun equals(other: Any?) = Objects.equals(id, (other as? ContractEmployee)?.id)
+    override fun hashCode() = Objects.hashCode(id)
+}
+
+@Entity
+@Table(name = "project")
+class Project(
+    @Id
+    @GeneratedValue
+    val id: Long = 0,
+    val name: String,
+
+    @OneToMany(cascade = [CascadeType.ALL])
+    val employees: List<Employee>,
+
+    @OneToOne(cascade = [CascadeType.ALL], optional = false, fetch = FetchType.LAZY)
+    val supervisor: Employee
+) {
+    override fun equals(other: Any?) = Objects.equals(id, (other as? Project)?.id)
+    override fun hashCode() = Objects.hashCode(id)
+}
+
+data class EmployeeTestBuilder(
+    var id: Long = 0,
+    var name: String = "name"
+) {
+    fun build() = Employee(
+        id = id,
+        name = name
+    )
+}
+
+data class PartTimeEmployeeTestBuilder(
+    var id: Long = 0,
+    var name: String = "name",
+    var weeklySalary: BigDecimal = 100.toBigDecimal()
+) {
+    fun build() = PartTimeEmployee(
+        id = id,
+        name = name,
+        weeklySalary = weeklySalary
+    )
+}
+
+data class FullTimeEmployeeTestBuilder(
+    var id: Long = 0,
+    var name: String = "name",
+    var annualSalary: BigDecimal = 10000.toBigDecimal()
+) {
+    fun build() = FullTimeEmployee(
+        id = id,
+        name = name,
+        annualSalary = annualSalary
+    )
+}
+
+data class ContractEmployeeTestBuilder(
+    var id: Long = 0,
+    var name: String = "name",
+    var hourlyRate: BigDecimal = 50.toBigDecimal()
+) {
+    fun build() = ContractEmployee(
+        id = id,
+        name = name,
+        hourlyRate = hourlyRate
+    )
+}
+
+data class ProjectTestBuilder(
+    var id: Long = 0,
+    var name: String = "name",
+    var employees: List<Employee> = listOf(
+        FullTimeEmployeeTestBuilder().build(),
+        PartTimeEmployeeTestBuilder().build(),
+        ContractEmployeeTestBuilder().build()
+    ),
+    var supervisor: Employee = EmployeeTestBuilder().build()
+) {
+    fun build() = Project(
+        id = id,
+        name = name,
+        employees = employees,
+        supervisor = supervisor
+    )
+}

--- a/test-fixture/hibernate-reactive/src/main/resources/META-INF/persistence.xml
+++ b/test-fixture/hibernate-reactive/src/main/resources/META-INF/persistence.xml
@@ -6,6 +6,12 @@
 
     <persistence-unit name="order">
         <provider>org.hibernate.reactive.provider.ReactivePersistenceProvider</provider>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.ContractEmployee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.Employee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.FullTimeEmployee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.PartTimeEmployee</class>
+        <class>com.linecorp.kotlinjdsl.test.entity.employee.Project</class>
+        
         <class>com.linecorp.kotlinjdsl.test.entity.Address</class>
 
         <class>com.linecorp.kotlinjdsl.test.entity.order.Order</class>

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
@@ -27,6 +27,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
     @Test
     fun getByPartTimeEmployeesWeeklySalary() = runBlocking {
         withFactory { queryFactory ->
+            // when
             val employees = queryFactory.listQuery<Employee> {
                 selectDistinct(entity(Employee::class))
                 from(entity(Employee::class))
@@ -35,6 +36,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
                 where(col(PartTimeEmployee::weeklySalary).lessThan(1000.toBigDecimal()))
             }
 
+            // then
             assertThat(employees).containsExactlyInAnyOrder(
                 *persistProjects.asSequence().flatMap { it.employees + it.supervisor }
                     .filter { it is PartTimeEmployee }
@@ -42,13 +44,13 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
                     .toList().toTypedArray()
             )
         }
-        // when
     }
 
     @Test
     fun getByPartTimeAndContractEmployeesBySalary() = runBlocking {
         // when
         withFactory { queryFactory ->
+            // when
             val employees = queryFactory.listQuery<Employee> {
                 selectDistinct(entity(Employee::class))
                 from(entity(Employee::class))
@@ -62,6 +64,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
                 )
             }
 
+            // then
             assertThat(employees).containsExactlyInAnyOrder(
                 *persistProjects.asSequence().flatMap { it.employees + it.supervisor }
                     .filter {
@@ -93,6 +96,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
                 )
             }
 
+            // then
             assertThat(employees).containsExactlyInAnyOrder(*persistProjects.asSequence().flatMap { it.employees }
                 .filter { it is FullTimeEmployee }
                 .filter { (it as FullTimeEmployee).annualSalary > 100000.toBigDecimal() }
@@ -114,6 +118,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
                 where(col(FullTimeEmployee::annualSalary).greaterThan(100000.toBigDecimal()))
             }
 
+            // then
             assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
                 .filter { it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() } }
                 .toList().toTypedArray())
@@ -138,6 +143,8 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
                     )
                 )
             }
+
+            // then
             assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
                 .filter {
                     it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() }
@@ -191,6 +198,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
                 )
             }
 
+            // then
             assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
                 .filter {
                     it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() }

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
@@ -1,0 +1,251 @@
+package com.linecorp.kotlinjdsl.test.reactive.querydsl.from
+
+import com.linecorp.kotlinjdsl.listQuery
+import com.linecorp.kotlinjdsl.query.spec.expression.ColumnSpec
+import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.querydsl.from.treat
+import com.linecorp.kotlinjdsl.subquery
+import com.linecorp.kotlinjdsl.test.entity.employee.*
+import com.linecorp.kotlinjdsl.test.reactive.CriteriaQueryDslIntegrationTest
+import com.linecorp.kotlinjdsl.test.reactive.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/**
+ * implement https://www.logicbig.com/tutorials/java-ee-tutorial/jpa/criteria-api-downcasting-with-treat-method.html
+ */
+abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQueryDslIntegrationTest<S> {
+    private val persistProjects = createProjects()
+
+    @BeforeEach
+    fun setUp() = runBlocking {
+        persistAll(*persistProjects.toTypedArray())
+    }
+
+    @Test
+    fun getByPartTimeEmployeesWeeklySalary() = runBlocking {
+        withFactory { queryFactory ->
+            val employees = queryFactory.listQuery<Employee> {
+                selectDistinct(entity(Employee::class))
+                from(entity(Employee::class))
+                treat<Employee, PartTimeEmployee>()
+                treat<Employee, ContractEmployee>()
+                where(col(PartTimeEmployee::weeklySalary).lessThan(1000.toBigDecimal()))
+            }
+
+            assertThat(employees).containsExactlyInAnyOrder(
+                *persistProjects.asSequence().flatMap { it.employees + it.supervisor }
+                    .filter { it is PartTimeEmployee }
+                    .filter { (it as PartTimeEmployee).weeklySalary < 1000.toBigDecimal() }
+                    .toList().toTypedArray()
+            )
+        }
+        // when
+    }
+
+    @Test
+    fun getByPartTimeAndContractEmployeesBySalary() = runBlocking {
+        // when
+        withFactory { queryFactory ->
+            val employees = queryFactory.listQuery<Employee> {
+                selectDistinct(entity(Employee::class))
+                from(entity(Employee::class))
+                treat<Employee, PartTimeEmployee>()
+                treat<Employee, ContractEmployee>()
+                where(
+                    or(
+                        col(PartTimeEmployee::weeklySalary).greaterThan(1000.toBigDecimal()),
+                        col(ContractEmployee::hourlyRate).lessThan(75.toBigDecimal()),
+                    )
+                )
+            }
+
+            assertThat(employees).containsExactlyInAnyOrder(
+                *persistProjects.asSequence().flatMap { it.employees + it.supervisor }
+                    .filter {
+                        (it as? PartTimeEmployee)?.weeklySalary
+                            ?.let { weeklySalary -> weeklySalary > 1000.toBigDecimal() } ?: false ||
+                            (it as? ContractEmployee)?.hourlyRate
+                                ?.let { hourlyRate -> hourlyRate < 75.toBigDecimal() } ?: false
+                    }
+                    .toList().toTypedArray()
+            )
+        }
+    }
+
+    @Test
+    fun getProjectByFullTimeEmployeesSalarySelectFullTimeEmployee() = runBlocking {
+        withFactory { queryFactory ->
+            // when
+            val employees = queryFactory.listQuery<FullTimeEmployee> {
+                val project: EntitySpec<Project> = Project::class.alias("project")
+                val fullTimeEmployee = FullTimeEmployee::class.alias("employee")
+                val employee = Employee::class.alias("employee")
+
+                selectDistinct(fullTimeEmployee)
+                from(project)
+                treat(ColumnSpec<FullTimeEmployee>(project, Project::employees.name), employee, fullTimeEmployee)
+                where(
+                    ColumnSpec<BigDecimal>(fullTimeEmployee, FullTimeEmployee::annualSalary.name)
+                        .greaterThan(100000.toBigDecimal())
+                )
+            }
+
+            assertThat(employees).containsExactlyInAnyOrder(*persistProjects.asSequence().flatMap { it.employees }
+                .filter { it is FullTimeEmployee }
+                .filter { (it as FullTimeEmployee).annualSalary > 100000.toBigDecimal() }
+                .map { it as FullTimeEmployee }
+                .toList().toTypedArray())
+        }
+    }
+
+    @Test
+    fun getProjectByFullTimeEmployeesSalaryWithFetch() = runBlocking {
+        withFactory { queryFactory ->
+            // when
+            val projects = queryFactory.listQuery<Project> {
+                selectDistinct(entity(Project::class))
+                from(entity(Project::class))
+
+                treat<Employee, FullTimeEmployee>(col(Project::employees))
+                fetch(entity(Project::class), entity(Employee::class, "emp"), on(Project::supervisor))
+                where(col(FullTimeEmployee::annualSalary).greaterThan(100000.toBigDecimal()))
+            }
+
+            assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
+                .filter { it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() } }
+                .toList().toTypedArray())
+        }
+    }
+
+    @Test
+    fun getProjectByFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalaryWithFetch() = runBlocking {
+        withFactory { queryFactory ->
+            // when
+            val projects = queryFactory.listQuery<Project> {
+                selectDistinct(entity(Project::class))
+                from(entity(Project::class))
+
+                treat<Employee, FullTimeEmployee>(col(Project::employees))
+                treat<Employee, PartTimeEmployee>(col(Project::employees))
+                fetch(entity(Project::class), entity(Employee::class, "emp"), on(Project::supervisor))
+                where(
+                    or(
+                        col(FullTimeEmployee::annualSalary).greaterThan(100000.toBigDecimal()),
+                        col(PartTimeEmployee::weeklySalary).greaterThan(1000.toBigDecimal()),
+                    )
+                )
+            }
+            assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
+                .filter {
+                    it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() }
+                        || it.employees.any { e -> e is PartTimeEmployee && e.weeklySalary > 1000.toBigDecimal() }
+                }
+                .toList().toTypedArray())
+        }
+    }
+
+    @Test
+    fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary() {
+        getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary(false)
+    }
+
+    @Test
+    open fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalaryWithFetch() {
+        getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary(true)
+    }
+
+    fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary(fetch: Boolean) = runBlocking {
+        withFactory { queryFactory ->
+            // when
+            val sub = queryFactory.subquery<Long> {
+                select(col(Project::id))
+                from(entity(Project::class))
+
+                treat<Employee, FullTimeEmployee>(col(Project::employees))
+                treat<Employee, PartTimeEmployee>(col(Project::employees))
+                where(
+                    or(
+                        col(FullTimeEmployee::annualSalary).greaterThan(100000.toBigDecimal()),
+                        col(PartTimeEmployee::weeklySalary).greaterThan(1000.toBigDecimal()),
+                    )
+                )
+            }
+            val projects = queryFactory.listQuery<Project> {
+                val project = Project::class.alias("dedupeProject")
+                selectDistinct(project)
+                from(project)
+                val supervisor = Employee::class.alias("super")
+                val partTimeSuper = PartTimeEmployee::class.alias("partSuper")
+                if (fetch) {
+                    fetch(project, supervisor, on(Project::supervisor))
+                }
+                treat(ColumnSpec<PartTimeEmployee>(project, Project::supervisor.name), supervisor, partTimeSuper)
+                where(
+                    and(
+                        col(project, Project::id).`in`(sub),
+                        col(partTimeSuper, PartTimeEmployee::weeklySalary).equal(900.toBigDecimal()),
+                    )
+                )
+            }
+
+            assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
+                .filter {
+                    it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() }
+                        || it.employees.any { e -> e is PartTimeEmployee && e.weeklySalary > 1000.toBigDecimal() }
+                }
+                .filter {
+                    it.supervisor is PartTimeEmployee && (it.supervisor as PartTimeEmployee).weeklySalary == 900.toBigDecimal()
+                }
+                .toList().toTypedArray())
+        }
+    }
+
+    private fun createProjects(): List<Project> {
+        val e1 = fullTimeEmployee {
+            name = "Sara"
+            annualSalary = 120000.toBigDecimal()
+        }
+        val e2 = partTimeEmployee {
+            name = "Jon"
+            weeklySalary = 900.toBigDecimal()
+        }
+        val e3 = contractEmployee {
+            name = "Tom"
+            hourlyRate = 60.toBigDecimal()
+        }
+        val supervisor1 = partTimeEmployee {
+            name = "Tina"
+            weeklySalary = 1300.toBigDecimal()
+        }
+
+        val e4 = fullTimeEmployee {
+            name = "Mike"
+            annualSalary = 80000.toBigDecimal()
+        }
+        val e5 = partTimeEmployee {
+            name = "Jackie"
+            weeklySalary = 1200.toBigDecimal()
+        }
+        val e6 = contractEmployee {
+            name = "Aly"
+            hourlyRate = 90.toBigDecimal()
+        }
+        val supervisor2 = partTimeEmployee {
+            name = "Trish"
+            weeklySalary = 900.toBigDecimal()
+        }
+
+        return listOf(project {
+            name = "Trade UI"
+            supervisor = supervisor1
+            employees = listOf(e1, e2, e3)
+        }, project {
+            name = "Broker UI"
+            supervisor = supervisor2
+            employees = listOf(e4, e5, e6)
+        })
+    }
+}

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
@@ -48,7 +48,6 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
 
     @Test
     fun getByPartTimeAndContractEmployeesBySalary() = runBlocking {
-        // when
         withFactory { queryFactory ->
             // when
             val employees = queryFactory.listQuery<Employee> {

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
@@ -1,0 +1,246 @@
+package com.linecorp.kotlinjdsl.test.integration.querydsl.from
+
+import com.linecorp.kotlinjdsl.listQuery
+import com.linecorp.kotlinjdsl.query.spec.expression.ColumnSpec
+import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
+import com.linecorp.kotlinjdsl.querydsl.expression.col
+import com.linecorp.kotlinjdsl.querydsl.from.treat
+import com.linecorp.kotlinjdsl.subquery
+import com.linecorp.kotlinjdsl.test.entity.employee.*
+import com.linecorp.kotlinjdsl.test.integration.AbstractCriteriaQueryDslIntegrationTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+
+/**
+ * implement https://www.logicbig.com/tutorials/java-ee-tutorial/jpa/criteria-api-downcasting-with-treat-method.html
+ */
+abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriteriaQueryDslIntegrationTest() {
+    private val persistProjects = createProjects()
+
+    @BeforeEach
+    fun setUp() {
+        entityManager.persistAll(persistProjects)
+        entityManager.flushAndClear()
+    }
+
+    @Test
+    fun getByPartTimeEmployeesWeeklySalary() {
+        // when
+        val employees = queryFactory.listQuery<Employee> {
+            selectDistinct(entity(Employee::class))
+            from(entity(Employee::class))
+            treat<Employee, PartTimeEmployee>()
+            where(
+                or(
+                    col(PartTimeEmployee::weeklySalary).lessThan(1000.toBigDecimal()),
+                )
+            )
+        }
+
+        assertThat(employees).containsExactlyInAnyOrder(
+            *persistProjects.asSequence().flatMap { it.employees + it.supervisor }
+                .filter { it is PartTimeEmployee }
+                .filter { (it as PartTimeEmployee).weeklySalary < 1000.toBigDecimal() }
+                .toList().toTypedArray()
+        )
+    }
+
+    @Test
+    fun getByPartTimeAndContractEmployeesBySalary() {
+        // when
+        val employees = queryFactory.listQuery<Employee> {
+            selectDistinct(entity(Employee::class))
+            from(entity(Employee::class))
+            treat<Employee, PartTimeEmployee>()
+            treat<Employee, ContractEmployee>()
+            where(
+                or(
+                    col(PartTimeEmployee::weeklySalary).greaterThan(1000.toBigDecimal()),
+                    col(ContractEmployee::hourlyRate).lessThan(75.toBigDecimal()),
+                )
+            )
+        }
+
+        assertThat(employees).containsExactlyInAnyOrder(
+            *persistProjects.asSequence().flatMap { it.employees + it.supervisor }
+                .filter {
+                    (it as? PartTimeEmployee)?.weeklySalary
+                        ?.let { weeklySalary -> weeklySalary > 1000.toBigDecimal() } ?: false ||
+                        (it as? ContractEmployee)?.hourlyRate
+                            ?.let { hourlyRate -> hourlyRate < 75.toBigDecimal() } ?: false
+                }
+                .toList().toTypedArray()
+        )
+    }
+
+    @Test
+    open fun getProjectByFullTimeEmployeesSalarySelectFullTimeEmployee() {
+        // when
+        val employees = queryFactory.listQuery<FullTimeEmployee> {
+            val project: EntitySpec<Project> = Project::class.alias("project")
+            val fullTimeEmployee = FullTimeEmployee::class.alias("fe")
+            val employee = Employee::class.alias("e")
+
+            selectDistinct(fullTimeEmployee)
+            from(project)
+            treat(ColumnSpec<FullTimeEmployee>(project, Project::employees.name), employee, fullTimeEmployee)
+            where(
+                ColumnSpec<BigDecimal>(fullTimeEmployee, FullTimeEmployee::annualSalary.name)
+                    .greaterThan(100000.toBigDecimal())
+            )
+        }
+
+        assertThat(employees).containsExactlyInAnyOrder(*persistProjects.asSequence().flatMap { it.employees }
+            .filter { it is FullTimeEmployee }
+            .filter { (it as FullTimeEmployee).annualSalary > 100000.toBigDecimal() }
+            .map { it as FullTimeEmployee }
+            .toList().toTypedArray())
+    }
+
+    @Test
+    fun getProjectByFullTimeEmployeesSalaryWithFetch() {
+        // when
+        val projects = queryFactory.listQuery<Project> {
+            selectDistinct(entity(Project::class))
+            from(entity(Project::class))
+
+            treat<Employee, FullTimeEmployee>(col(Project::employees))
+            fetch(entity(Project::class), entity(Employee::class, "emp"), on(Project::supervisor))
+            where(
+                col(FullTimeEmployee::annualSalary).greaterThan(100000.toBigDecimal())
+            )
+        }
+
+        assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
+            .filter { it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() } }
+            .toList().toTypedArray())
+    }
+
+    @Test
+    fun getProjectByFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalaryWithFetch() {
+        // when
+        val projects = queryFactory.listQuery<Project> {
+            selectDistinct(entity(Project::class))
+            from(entity(Project::class))
+
+            treat<Employee, FullTimeEmployee>(col(Project::employees))
+            treat<Employee, PartTimeEmployee>(col(Project::employees))
+            fetch(entity(Project::class), entity(Employee::class, "emp"), on(Project::supervisor))
+            where(
+                or(
+                    col(FullTimeEmployee::annualSalary).greaterThan(100000.toBigDecimal()),
+                    col(PartTimeEmployee::weeklySalary).greaterThan(1000.toBigDecimal()),
+                )
+            )
+        }
+
+        assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
+            .filter {
+                it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() }
+                    || it.employees.any { e -> e is PartTimeEmployee && e.weeklySalary > 1000.toBigDecimal() }
+            }
+            .toList().toTypedArray())
+    }
+
+    @Test
+    fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary() {
+        // when
+        getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary(false)
+    }
+
+    @Test
+    open fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalaryWithFetch() {
+        getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary(true)
+    }
+
+    private fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary(fetch: Boolean) {
+        val sub = queryFactory.subquery<Long> {
+            select(col(Project::id))
+            from(entity(Project::class))
+
+            treat<Employee, FullTimeEmployee>(col(Project::employees))
+            treat<Employee, PartTimeEmployee>(col(Project::employees))
+            where(
+                or(
+                    col(FullTimeEmployee::annualSalary).greaterThan(100000.toBigDecimal()),
+                    col(PartTimeEmployee::weeklySalary).greaterThan(1000.toBigDecimal()),
+                )
+            )
+        }
+        val projects = queryFactory.listQuery<Project> {
+            val project = Project::class.alias("dedupeProject")
+            selectDistinct(project)
+            from(project)
+            val supervisor = Employee::class.alias("super")
+            val partTimeSuper = PartTimeEmployee::class.alias("partSuper")
+            if (fetch) {
+                fetch(project, supervisor, on(Project::supervisor))
+            }
+            treat(ColumnSpec<PartTimeEmployee>(project, Project::supervisor.name), supervisor, partTimeSuper)
+            where(
+                and(
+                    col(project, Project::id).`in`(sub),
+                    col(partTimeSuper, PartTimeEmployee::weeklySalary).equal(900.toBigDecimal()),
+                )
+            )
+        }
+
+        assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
+            .filter {
+                it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() }
+                    || it.employees.any { e -> e is PartTimeEmployee && e.weeklySalary > 1000.toBigDecimal() }
+            }
+            .filter {
+                it.supervisor is PartTimeEmployee && (it.supervisor as PartTimeEmployee).weeklySalary == 900.toBigDecimal()
+            }
+            .toList().toTypedArray())
+    }
+
+    private fun createProjects(): List<Project> {
+        val e1 = fullTimeEmployee {
+            name = "Sara"
+            annualSalary = 120000.toBigDecimal()
+        }
+        val e2 = partTimeEmployee {
+            name = "Jon"
+            weeklySalary = 900.toBigDecimal()
+        }
+        val e3 = contractEmployee {
+            name = "Tom"
+            hourlyRate = 60.toBigDecimal()
+        }
+        val supervisor1 = partTimeEmployee {
+            name = "Tina"
+            weeklySalary = 1300.toBigDecimal()
+        }
+
+        val e4 = fullTimeEmployee {
+            name = "Mike"
+            annualSalary = 80000.toBigDecimal()
+        }
+        val e5 = partTimeEmployee {
+            name = "Jackie"
+            weeklySalary = 1200.toBigDecimal()
+        }
+        val e6 = contractEmployee {
+            name = "Aly"
+            hourlyRate = 90.toBigDecimal()
+        }
+        val supervisor2 = partTimeEmployee {
+            name = "Trish"
+            weeklySalary = 900.toBigDecimal()
+        }
+
+        return listOf(project {
+            name = "Trade UI"
+            supervisor = supervisor1
+            employees = listOf(e1, e2, e3)
+        }, project {
+            name = "Broker UI"
+            supervisor = supervisor2
+            employees = listOf(e4, e5, e6)
+        })
+    }
+}

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
@@ -39,6 +39,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriter
             )
         }
 
+        // then
         assertThat(employees).containsExactlyInAnyOrder(
             *persistProjects.asSequence().flatMap { it.employees + it.supervisor }
                 .filter { it is PartTimeEmployee }
@@ -63,6 +64,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriter
             )
         }
 
+        // then
         assertThat(employees).containsExactlyInAnyOrder(
             *persistProjects.asSequence().flatMap { it.employees + it.supervisor }
                 .filter {
@@ -92,6 +94,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriter
             )
         }
 
+        // then
         assertThat(employees).containsExactlyInAnyOrder(*persistProjects.asSequence().flatMap { it.employees }
             .filter { it is FullTimeEmployee }
             .filter { (it as FullTimeEmployee).annualSalary > 100000.toBigDecimal() }
@@ -113,6 +116,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriter
             )
         }
 
+        // then
         assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
             .filter { it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() } }
             .toList().toTypedArray())
@@ -136,6 +140,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriter
             )
         }
 
+        // then
         assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
             .filter {
                 it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() }
@@ -156,6 +161,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriter
     }
 
     private fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary(fetch: Boolean) {
+        // when
         val sub = queryFactory.subquery<Long> {
             select(col(Project::id))
             from(entity(Project::class))
@@ -187,6 +193,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriter
             )
         }
 
+        // then
         assertThat(projects).containsExactlyInAnyOrder(*persistProjects.asSequence()
             .filter {
                 it.employees.any { e -> e is FullTimeEmployee && e.annualSalary > 100000.toBigDecimal() }


### PR DESCRIPTION
# Motivation:
Please refer to issue #51.
We should support treat .

-- korean
#51 이슈를 참고해주세요.
우리는 treat 을 지원해야 합니다.

# Modifications:
Added treat method.
Dependencies have been upgraded.
Removed the String used for equal comparison in alias and modified it to be nullable.

-- korean
treat 메소드를 추가 하였습니다.
dependency 업그레이드를 진행했습니다.
alias 에서 equal 비교를 위해 사용하던 String 을 제거하여 nullable 하게 수정했습니다.

# Result:
Users can handle downcasting via treat as shown below.

-- korean
사용자는 아래와 같이 treat 을 통해 downcasting 을 처리할 수 있습니다.

```kotlin
val employees = queryFactory.listQuery<Employee> {
    selectDistinct(entity(Employee::class))
    from(entity(Employee::class))
    treat<Employee, PartTimeEmployee>()
    treat<Employee, ContractEmployee>()
    where(
        or(
            col(PartTimeEmployee::weeklySalary).greaterThan(1000.toBigDecimal()),
            col(ContractEmployee::hourlyRate).lessThan(75.toBigDecimal()),
        )
    )
}

val projects = queryFactory.listQuery<Project> {
    selectDistinct(entity(Project::class))
    from(entity(Project::class))

    treat<Employee, FullTimeEmployee>(col(Project::employees))
    fetch(entity(Project::class), entity(Employee::class, "emp"), on(Project::supervisor))
    where(
        col(FullTimeEmployee::annualSalary).greaterThan(100000.toBigDecimal())
    )
}
```
