### PR TITLE
Change Strong tag to Markdown syntax in doc comment

### DIFF
--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -43,7 +43,7 @@ import javax.persistence.criteria.JoinType
 /**
  * Internal DSL Implementation
  *
- * Don't use this directly because it's an <string>INTERNAL</strong> class.
+ * Don't use this directly because it's an **INTERNAL** class.
  * It does not support backward compatibility.
  * This class should be used with the understanding that it is not thread safe and therefore not suitable for parallel processing.
  */

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensionsTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensionsTest.kt
@@ -91,10 +91,10 @@ internal class QueryFactoryExtensionsTest : WithKotlinJdslAssertions {
         }
 
         // when
-        queryFactory.streamQuery(dsl).use { actual ->
-            // then
-            assertThat(actual).contains(Data1())
-        }
+        val actual = queryFactory.streamQuery(dsl).toList()
+
+        // then
+        assertThat(actual).contains(Data1())
 
         verify(exactly = 1) {
             queryFactory.selectQuery(Data1::class.java, dsl)

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensionsTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/QueryFactoryExtensionsTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import java.util.stream.Stream
 import javax.persistence.Query
 import javax.persistence.TypedQuery
+import kotlin.streams.toList
 
 @ExtendWith(MockKExtension::class)
 internal class QueryFactoryExtensionsTest : WithKotlinJdslAssertions {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/CriteriaDeleteQuerySpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/CriteriaDeleteQuerySpec.kt
@@ -8,7 +8,7 @@ import com.linecorp.kotlinjdsl.query.clause.where.CriteriaQueryWhereClause
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface CriteriaDeleteQuerySpec<T, Q> {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/CriteriaQuerySpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/CriteriaQuerySpec.kt
@@ -13,7 +13,7 @@ import com.linecorp.kotlinjdsl.query.clause.where.CriteriaQueryWhereClause
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface CriteriaQuerySpec<T, Q> {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/CriteriaUpdateQuerySpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/CriteriaUpdateQuerySpec.kt
@@ -9,7 +9,7 @@ import com.linecorp.kotlinjdsl.query.clause.where.CriteriaQueryWhereClause
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface CriteriaUpdateQuerySpec<T, Q> {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/SubquerySpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/SubquerySpec.kt
@@ -9,7 +9,7 @@ import com.linecorp.kotlinjdsl.query.clause.where.SubqueryWhereClause
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface SubquerySpec<T> {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/FromClause.kt
@@ -9,7 +9,7 @@ import javax.persistence.criteria.CriteriaUpdate
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class FromClause<T>(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/JoinClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/JoinClause.kt
@@ -4,7 +4,7 @@ import com.linecorp.kotlinjdsl.query.spec.JoinSpec
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class JoinClause(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/Joiner.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/Joiner.kt
@@ -15,7 +15,7 @@ private typealias ExplicitErasedChild = Int
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 class Joiner(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/SimpleAssociatedJoinClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/SimpleAssociatedJoinClause.kt
@@ -4,7 +4,7 @@ import com.linecorp.kotlinjdsl.query.spec.SimpleAssociatedJoinSpec
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 @JvmInline

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/SimpleAssociator.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/from/SimpleAssociator.kt
@@ -10,7 +10,7 @@ import javax.persistence.criteria.Root
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 class SimpleAssociator(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/groupby/CriteriaQueryGroupByClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/groupby/CriteriaQueryGroupByClause.kt
@@ -6,7 +6,7 @@ import javax.persistence.criteria.CriteriaQuery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface CriteriaQueryGroupByClause {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/groupby/GroupByClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/groupby/GroupByClause.kt
@@ -9,7 +9,7 @@ import javax.persistence.criteria.Subquery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class GroupByClause(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/groupby/SubqueryGroupByClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/groupby/SubqueryGroupByClause.kt
@@ -6,7 +6,7 @@ import javax.persistence.criteria.Subquery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface SubqueryGroupByClause {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/having/CriteriaQueryHavingClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/having/CriteriaQueryHavingClause.kt
@@ -6,7 +6,7 @@ import javax.persistence.criteria.CriteriaQuery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface CriteriaQueryHavingClause {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/having/HavingClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/having/HavingClause.kt
@@ -9,7 +9,7 @@ import javax.persistence.criteria.Subquery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class HavingClause(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/having/SubqueryHavingClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/having/SubqueryHavingClause.kt
@@ -6,7 +6,7 @@ import javax.persistence.criteria.Subquery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface SubqueryHavingClause {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/hint/JpaQueryHintClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/hint/JpaQueryHintClause.kt
@@ -2,7 +2,7 @@ package com.linecorp.kotlinjdsl.query.clause.hint
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface JpaQueryHintClause<Q> {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/hint/SqlQueryHintClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/hint/SqlQueryHintClause.kt
@@ -2,7 +2,7 @@ package com.linecorp.kotlinjdsl.query.clause.hint
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface SqlQueryHintClause<Q> {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/limit/QueryLimitClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/limit/QueryLimitClause.kt
@@ -2,7 +2,7 @@ package com.linecorp.kotlinjdsl.query.clause.limit
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface QueryLimitClause<Q> {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/orderby/CriteriaQueryOrderByClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/orderby/CriteriaQueryOrderByClause.kt
@@ -6,7 +6,7 @@ import javax.persistence.criteria.CriteriaQuery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface CriteriaQueryOrderByClause {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/orderby/OrderByClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/orderby/OrderByClause.kt
@@ -7,7 +7,7 @@ import javax.persistence.criteria.CriteriaQuery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class OrderByClause(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/CountMultiSelectClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/CountMultiSelectClause.kt
@@ -7,7 +7,7 @@ import javax.persistence.criteria.CriteriaQuery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class CountMultiSelectClause(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/CountSingleSelectClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/CountSingleSelectClause.kt
@@ -7,7 +7,7 @@ import javax.persistence.criteria.CriteriaQuery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class CountSingleSelectClause(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/CriteriaQuerySelectClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/CriteriaQuerySelectClause.kt
@@ -6,7 +6,7 @@ import javax.persistence.criteria.CriteriaQuery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface CriteriaQuerySelectClause<T> {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/MultiSelectClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/MultiSelectClause.kt
@@ -7,7 +7,7 @@ import javax.persistence.criteria.CriteriaQuery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class MultiSelectClause<T>(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/SingleSelectClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/SingleSelectClause.kt
@@ -8,7 +8,7 @@ import javax.persistence.criteria.Subquery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class SingleSelectClause<T>(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/SubquerySelectClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/select/SubquerySelectClause.kt
@@ -6,7 +6,7 @@ import javax.persistence.criteria.Subquery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface SubquerySelectClause<T> {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/set/SetClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/set/SetClause.kt
@@ -8,7 +8,7 @@ import javax.persistence.criteria.Path
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class SetClause(private val params: Map<ColumnSpec<*>, Any?>) {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/where/CriteriaQueryWhereClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/where/CriteriaQueryWhereClause.kt
@@ -8,7 +8,7 @@ import javax.persistence.criteria.CriteriaUpdate
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface CriteriaQueryWhereClause {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/where/SubqueryWhereClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/where/SubqueryWhereClause.kt
@@ -6,7 +6,7 @@ import javax.persistence.criteria.Subquery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface SubqueryWhereClause {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/where/WhereClause.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/clause/where/WhereClause.kt
@@ -6,7 +6,7 @@ import javax.persistence.criteria.*
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 data class WhereClause(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/SubqueryCreator.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/creator/SubqueryCreator.kt
@@ -8,7 +8,7 @@ import javax.persistence.criteria.Subquery
 
 /**
  * Internal Only
- * Don't use this directly because it's an <string>INTERNAL</strong>.
+ * Don't use this directly because it's an **INTERNAL**.
  * It does not support backward compatibility.
  */
 interface SubqueryCreator {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/select/MultiSelectDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/select/MultiSelectDsl.kt
@@ -6,7 +6,7 @@ import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
 /**
  * This is Dsl which is used to select multiple column.
  *
- * <strong>notice</strong>: vararg is not supported with method name: select.
+ * **notice**: vararg is not supported with method name: select.
  * This is because wrong type inference is made when SingleSelectDsl and MultiSelectDsl are used together.
  */
 interface MultiSelectDsl<T> {

--- a/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
+++ b/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
@@ -38,7 +38,7 @@ import javax.persistence.criteria.JoinType
 /**
  * Internal DSL Implementation
  *
- * Don't use this directly because it's an <string>INTERNAL</strong> class.
+ * Don't use this directly because it's an **INTERNAL** class.
  * It does not support backward compatibility.
  * This class should be used with the understanding that it is not thread safe and therefore not suitable for parallel processing.
  */

--- a/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/querydsl/SpringDataQueryDslImpl.kt
+++ b/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/querydsl/SpringDataQueryDslImpl.kt
@@ -14,7 +14,7 @@ import javax.persistence.TypedQuery
 /**
  * Internal DSL Implementation which is integrated Spring Data JPA
  *
- * Don't use this directly because it's an <string>INTERNAL</strong> class.
+ * Don't use this directly because it's an **INTERNAL** class.
  * It does not support backward compatibility.
  */
 class SpringDataQueryDslImpl<T>(

--- a/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
+++ b/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
@@ -19,7 +19,6 @@ import org.springframework.data.domain.PageRequest
 import java.util.stream.Stream
 import javax.persistence.Query
 import javax.persistence.TypedQuery
-import kotlin.streams.toList
 
 @ExtendWith(MockKExtension::class)
 internal class SpringDataQueryFactoryExtensionsTest : WithKotlinJdslAssertions {

--- a/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
+++ b/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
@@ -19,6 +19,7 @@ import org.springframework.data.domain.PageRequest
 import java.util.stream.Stream
 import javax.persistence.Query
 import javax.persistence.TypedQuery
+import kotlin.streams.toList
 
 @ExtendWith(MockKExtension::class)
 internal class SpringDataQueryFactoryExtensionsTest : WithKotlinJdslAssertions {

--- a/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
+++ b/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
@@ -211,8 +211,9 @@ internal class SpringDataQueryFactoryExtensionsTest : WithKotlinJdslAssertions {
             from(entity(Order::class))
             where(col(Order::purchaserId).equal(1000))
         }.toList()
+
         // then
-        assertThat(actual).containsExactlyInAnyOrder(3, 2, 1)
+        assertThat(actual).containsExactly(1L, 2L, 3L)
     }
 
     @Test

--- a/spring/data-hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/reactive/query/SpringDataHibernateMutinyReactiveQueryFactory.kt
+++ b/spring/data-hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/reactive/query/SpringDataHibernateMutinyReactiveQueryFactory.kt
@@ -8,7 +8,6 @@ import com.linecorp.kotlinjdsl.spring.reactive.SpringDataReactiveQueryFactory
 import com.linecorp.kotlinjdsl.spring.reactive.SpringDataReactiveQueryFactoryImpl
 import com.linecorp.kotlinjdsl.spring.reactive.querydsl.SpringDataReactiveReactiveQueryDslImpl
 import com.linecorp.kotlinjdsl.spring.reactive.querydsl.SpringDataReactiveSubqueryDsl
-import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.asUni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import kotlinx.coroutines.*

--- a/spring/data-reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/reactive/querydsl/SpringDataReactiveReactiveQueryDslImpl.kt
+++ b/spring/data-reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/reactive/querydsl/SpringDataReactiveReactiveQueryDslImpl.kt
@@ -16,7 +16,7 @@ import org.springframework.data.domain.Pageable
 /**
  * Internal DSL Implementation which is integrated Spring Data JPA
  *
- * Don't use this directly because it's an <string>INTERNAL</strong> class.
+ * Don't use this directly because it's an **INTERNAL** class.
  * It does not support backward compatibility.
  */
 class SpringDataReactiveReactiveQueryDslImpl<T>(


### PR DESCRIPTION
# Motivation:

I have found out there are some typo in comments. 
I think we can use markdown instead of correcting typo :)

# Modifications:

- Change `<strong>` tags to markdown syntax in comment.
- Remove unused import
- lint some test code
