### PR TITLE
fix publish unit test results path

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
-          files: test-results/**/*.xml
+          files: '**/TEST-*.xml'
       - name: Cleanup Gradle Cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
         # Restoring these files from a GitHub Actions cache might cause problems for future builds.


### PR DESCRIPTION
# Motivation:

Fix bug where Publish Unit Test Results does not work

# Modifications:

I modified the test xml path. This can only be confirmed when it is actually merged.

# Result:
There is no change perceived by users.
Merge immediately.