### PR TITLE
docs: add explanation on left and right join

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,13 +188,23 @@ val condition = and(
 )
 ```
 
-### Join
+### (Inner) Join
 
 ```kotlin
 val books = queryFactory.listQuery<Book> {
     select(entity(Book::class))
     from(entity(Book::class))
     join(Book::author)
+    // ...
+}
+```
+
+### Left or Right Join
+```kotlin
+val books = queryFactory.listQuery<Book> {
+    select(entity(Book::class))
+    from(entity(Book::class))
+    join(entity(Book::class), entity(Author::class), on(Book::author), JoinType.LEFT) //Change JoinType
     // ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -188,23 +188,15 @@ val condition = and(
 )
 ```
 
-### (Inner) Join
+### Join
 
 ```kotlin
 val books = queryFactory.listQuery<Book> {
     select(entity(Book::class))
     from(entity(Book::class))
-    join(Book::author)
-    // ...
-}
-```
-
-### Left or Right Join
-```kotlin
-val books = queryFactory.listQuery<Book> {
-    select(entity(Book::class))
-    from(entity(Book::class))
-    join(entity(Book::class), entity(Author::class), on(Book::author), JoinType.LEFT) //Change JoinType
+    join(Book::author) //Default is `JoinType.INNER`
+    join(Book::publisher, JoinType.LEFT)
+    join(Book::seller, JoinType.RIGHT)
     // ...
 }
 ```


### PR DESCRIPTION
# Motivation:

There was no explanation about how to use left and right join on the `join` section, so the user is hard to find how to join them in different directions.

# Modifications:

Add more explanation about using the `join` extension method.

# Closes #. (If this resolves the issue.)

#60
