### PR TITLE
Correct typo and Unify code style

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,15 +11,15 @@
 * Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
 * This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)
 
-| Commit type | Description               |
-|-------------|---------------------------|
-| feat        | New Feature               |
-| fix         | Fix bug                   |
-| docs        | Documenation only changed |
-| ci          |Change CI configuration|
-| refactor    |Not a bug fix or add feature, just refactoring code|
-| test        |Add Test case or fix wrong test case|
-| style       |Only change the code style(ex. white-space, formatting)|
+| Commit type | Description                                             |
+|-------------|---------------------------------------------------------|
+| feat        | New Feature                                             |
+| fix         | Fix bug                                                 |
+| docs        | Documentation only changed                              |
+| ci          | Change CI configuration                                 |
+| refactor    | Not a bug fix or add feature, just refactoring code     |
+| test        | Add Test case or fix wrong test case                    |
+| style       | Only change the code style(ex. white-space, formatting) |
 
 * If you want to add some more `commit type` please describe it on the **Pull Request**
 

--- a/examples/spring-boot-hibernate-reactive-2.6/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/example/QueryFactoryConfiguration.kt
+++ b/examples/spring-boot-hibernate-reactive-2.6/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/example/QueryFactoryConfiguration.kt
@@ -11,10 +11,10 @@ import javax.persistence.Persistence
 @Configuration
 class QueryFactoryConfiguration {
     @Bean
-    fun entityManagerFactory() = Persistence.createEntityManagerFactory("book")
+    fun entityManagerFactory(): EntityManagerFactory = Persistence.createEntityManagerFactory("book")
 
     @Bean
-    fun mutinySessionFactory(entityManagerFactory: EntityManagerFactory) =
+    fun mutinySessionFactory(entityManagerFactory: EntityManagerFactory): SessionFactory =
         entityManagerFactory.unwrap(SessionFactory::class.java)
             .apply {
                 withSession {

--- a/examples/spring-boot-hibernate-reactive-2.7/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/example/QueryFactoryConfiguration.kt
+++ b/examples/spring-boot-hibernate-reactive-2.7/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/example/QueryFactoryConfiguration.kt
@@ -11,10 +11,10 @@ import javax.persistence.Persistence
 @Configuration
 class QueryFactoryConfiguration {
     @Bean
-    fun entityManagerFactory() = Persistence.createEntityManagerFactory("book")
+    fun entityManagerFactory(): EntityManagerFactory = Persistence.createEntityManagerFactory("book")
 
     @Bean
-    fun mutinySessionFactory(entityManagerFactory: EntityManagerFactory) =
+    fun mutinySessionFactory(entityManagerFactory: EntityManagerFactory): SessionFactory =
         entityManagerFactory.unwrap(SessionFactory::class.java)
             .apply {
                 withSession {

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/expression/ExpressionDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/expression/ExpressionDsl.kt
@@ -16,7 +16,7 @@ interface ExpressionDsl {
     fun <T, R> col(entity: EntitySpec<T>, property: KProperty1<T, R>) = column(entity, property)
     fun <T, R> column(entity: EntitySpec<T>, property: KProperty1<T, R>) = ColumnSpec<R>(entity, property.name)
 
-    fun <N : Number?> max(expresssion: ExpressionSpec<N>) = MaxSpec(expresssion)
+    fun <N : Number?> max(expression: ExpressionSpec<N>) = MaxSpec(expression)
     fun <N : Number?> min(expression: ExpressionSpec<N>) = MinSpec(expression)
     fun <N : Number?> avg(expression: ExpressionSpec<N>) = AvgSpec(expression)
     fun <N : Number?> sum(expression: ExpressionSpec<N>) = SumSpec(expression)

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/JpaCriteriaQueryBuilderTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/creator/JpaCriteriaQueryBuilderTest.kt
@@ -29,7 +29,7 @@ import javax.persistence.criteria.*
 
 @ExtendWith(MockKExtension::class)
 internal class JpaCriteriaQueryBuilderTest : WithKotlinJdslAssertions {
-    val sut = JpaCriteriaQueryBuilder
+    private val sut = JpaCriteriaQueryBuilder
 
     @MockK
     private lateinit var em: EntityManager

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -145,7 +145,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest<S> : CriteriaQueryD
     }
 
     @Test
-    fun `function - substring function, mutliple parameters`() = runBlocking {
+    fun `function - substring function, mulltiple parameters`() = runBlocking {
         val result = withFactory { queryFactory ->
             queryFactory.singleQuery<String> {
                 select(function("substring", col(OrderItem::productName), literal(1), literal(2)))

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -145,7 +145,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest<S> : CriteriaQueryD
     }
 
     @Test
-    fun `function - substring function, mulltiple parameters`() = runBlocking {
+    fun `function - substring function, multiple parameters`() = runBlocking {
         val result = withFactory { queryFactory ->
             queryFactory.singleQuery<String> {
                 select(function("substring", col(OrderItem::productName), literal(1), literal(2)))

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
@@ -27,7 +27,7 @@ abstract class AbstractCriteriaDeleteIntegrationTest : AbstractCriteriaQueryDslI
         val query = queryFactory.selectQuery<OrderAddress> {
             select(entity(OrderAddress::class))
             from(entity(OrderAddress::class))
-            where(col(OrderAddress::id).equal(address1.id),)
+            where(col(OrderAddress::id).equal(address1.id))
             associate(OrderAddress::class, Address::class, on(OrderAddress::address))
         }
 

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -132,7 +132,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
     }
 
     @Test
-    fun `function - substring function, mutliple parameters`() {
+    fun `function - substring function, multiple parameters`() {
         val result = queryFactory.singleQuery<String> {
             select(function("substring", col(OrderItem::productName), literal(1), literal(2)))
             from(entity(OrderItem::class))


### PR DESCRIPTION
# Motivation:

* Found some typos when running the tests.
* Wanted to improve the example.

# Modifications:

* correct typo in some files
  * Test files
  * Released Method's Parameter name
  * PR Template, typo is being applied in this conversation 🙂
* modifications to unify code style
  * In the test code, `sut` is using private but it's not private in `JpaCriteriaQueryBuilderTest`
  * Remove one trailing commas
* change example code to not use platform type
  Platform type requires unnecessary boilerplate(`!!`, `let trick`, ...)
  I think it should be best practice because many people can copy & paste that. Please review.

# Result:
There is no change that users can feel.