### PR TITLE
allow null input and no need to use and() at WhereDsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ val books: List<Book> = queryFactory.listQuery {
 
 #### with nullable condition
 
+Kotlin JDSL converts `null` in `where condition` to `EmptyPredicateSpec` object.
+
+_note that `EmptyPredicateSpec` turns into `1=1` sql_
+
 ```kotlin
 val books: List<Book> = queryFactory.listQuery {
         select(entity(Book::class))
@@ -96,6 +100,10 @@ val books: List<Book> = queryFactory.listQuery {
 ```
 
 #### with multi conditions
+
+You can chain conditions using the `whereAnd` or `whereOr` method.
+* `whereAnd` connects each condition with `and`, `whereOr` connects with `or`.
+* Each method is connected by `and`.
 
 ```kotlin
 val books: List<Book> = queryFactory.listQuery {

--- a/README.md
+++ b/README.md
@@ -83,6 +83,35 @@ val books: List<Book> = queryFactory.listQuery {
 }
 ```
 
+#### with nullable condition
+
+```kotlin
+val books: List<Book> = queryFactory.listQuery {
+        select(entity(Book::class))
+        from(entity(Book::class))
+        where(
+            name?.run { column(Book::author).equal(this) }
+        )
+    }
+```
+
+#### with multi conditions
+
+```kotlin
+val books: List<Book> = queryFactory.listQuery {
+    select(entity(Book::class))
+    from(entity(Book::class))
+    whereOr(
+        column(Book::author).equal("Dan Brown"),
+        column(Book::author).equal("Hemingway")
+    )
+    whereAnd(
+        column(Book::viewCount).greaterThan(10000L),
+        column(Book::isBorrowed).isFalse()
+    )
+}
+```
+
 ### DTO Projections
 If you want to select the DTO, select columns in the order of constructor parameters.
 

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -134,6 +134,18 @@ open class QueryDslImpl<T>(
         predicate?.let { lazyWheres().add(it) }
     }
 
+    override fun whereAnd(predicates: List<PredicateSpec?>) {
+        predicates.filterNotNull()
+            .takeIf { it.isNotEmpty() }
+            ?.run { where(AndSpec(this)) }
+    }
+
+    override fun whereOr(predicates: List<PredicateSpec?>) {
+        predicates.filterNotNull()
+            .takeIf { it.isNotEmpty() }
+            ?.run { where(OrSpec(this)) }
+    }
+
     override fun groupBy(columns: List<ExpressionSpec<*>>) {
         lazyGroupBys().addAll(columns)
     }

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -129,8 +129,8 @@ open class QueryDslImpl<T>(
         lazyJoins().add(FetchJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
-    override fun where(predicate: PredicateSpec) {
-        lazyWheres().add(predicate)
+    override fun where(predicate: PredicateSpec?) {
+        predicate?.let { lazyWheres().add(it) }
     }
 
     override fun groupBy(columns: List<ExpressionSpec<*>>) {

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -133,6 +133,10 @@ open class QueryDslImpl<T>(
         predicate?.let { lazyWheres().add(it) }
     }
 
+    override fun where(predicates: List<PredicateSpec?>) {
+        for (p in predicates) p?.let { lazyWheres().add(it) }
+    }
+
     override fun groupBy(columns: List<ExpressionSpec<*>>) {
         lazyGroupBys().addAll(columns)
     }

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -33,6 +33,7 @@ import com.linecorp.kotlinjdsl.query.spec.expression.ColumnSpec
 import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.AndSpec
+import com.linecorp.kotlinjdsl.query.spec.predicate.OrSpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
 import com.linecorp.kotlinjdsl.querydsl.from.Relation
 import com.linecorp.kotlinjdsl.querydsl.hint.SqlQueryHintClauseProvider
@@ -129,8 +130,8 @@ open class QueryDslImpl<T>(
         lazyJoins().add(FetchJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
-    override fun where(vararg predicates: PredicateSpec?) {
-        for (p in predicates) p?.let { lazyWheres().add(it) }
+    override fun where(predicate: PredicateSpec?) {
+        predicate?.let { lazyWheres().add(it) }
     }
 
     override fun groupBy(columns: List<ExpressionSpec<*>>) {

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -131,7 +131,7 @@ open class QueryDslImpl<T>(
     }
 
     override fun where(predicate: PredicateSpec?) {
-        predicate?.let { lazyWheres().add(it) }
+        predicate?.run { lazyWheres().add(this) }
     }
 
     override fun whereAnd(predicates: List<PredicateSpec?>) {

--- a/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
+++ b/core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/QueryDslImpl.kt
@@ -129,11 +129,7 @@ open class QueryDslImpl<T>(
         lazyJoins().add(FetchJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
-    override fun where(predicate: PredicateSpec?) {
-        predicate?.let { lazyWheres().add(it) }
-    }
-
-    override fun where(predicates: List<PredicateSpec?>) {
+    override fun where(vararg predicates: PredicateSpec?) {
         for (p in predicates) p?.let { lazyWheres().add(it) }
     }
 

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/QueryDslImplWhereTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/QueryDslImplWhereTest.kt
@@ -67,7 +67,7 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
-            where(listOf(predicateSpec1,predicateSpec2))
+            where(predicateSpec1,predicateSpec2)
         }
 
         // then
@@ -95,7 +95,7 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
-            where(listOf(predicateSpec1,predicateSpec2,predicateSpec3))
+            where(predicateSpec1,predicateSpec2,predicateSpec3)
         }
 
         // then

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/QueryDslImplWhereTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/QueryDslImplWhereTest.kt
@@ -67,8 +67,7 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
-            where(predicateSpec1)
-            where(predicateSpec2)
+            where(listOf(predicateSpec1,predicateSpec2))
         }
 
         // then
@@ -82,6 +81,34 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
 
         assertThat(subquerySpec.where).isEqualTo(
             WhereClause(AndSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+    }
+
+    @Test
+    fun nullInFirstWheres() {
+        // given
+        val predicateSpec1: PredicateSpec? = null
+        val predicateSpec2: PredicateSpec = mockk()
+        val predicateSpec3: PredicateSpec = mockk()
+
+        // when
+        val actual = QueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            where(listOf(predicateSpec1,predicateSpec2,predicateSpec3))
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(AndSpec(listOf(predicateSpec2, predicateSpec3)))
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(AndSpec(listOf(predicateSpec2, predicateSpec3)))
         )
     }
 

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/QueryDslImplWhereTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/QueryDslImplWhereTest.kt
@@ -2,6 +2,7 @@ package com.linecorp.kotlinjdsl.querydsl.where
 
 import com.linecorp.kotlinjdsl.query.clause.where.WhereClause
 import com.linecorp.kotlinjdsl.query.spec.predicate.AndSpec
+import com.linecorp.kotlinjdsl.query.spec.predicate.OrSpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
 import com.linecorp.kotlinjdsl.querydsl.QueryDslImpl
 import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
@@ -15,6 +16,32 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(PredicateSpec.empty)
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(PredicateSpec.empty)
+        )
+    }
+
+    @Test
+    fun nullInWhere() {
+        // given
+        val predicateSpec: PredicateSpec? = null
+
+        // when
+        val actual = QueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            where(predicateSpec)
         }
 
         // then
@@ -58,8 +85,9 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
     }
 
     @Test
-    fun wheres() {
+    fun whereAndVararg() {
         // given
+        val nullPredicateSpec: PredicateSpec? = null
         val predicateSpec1: PredicateSpec = mockk()
         val predicateSpec2: PredicateSpec = mockk()
 
@@ -67,6 +95,119 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
+            whereAnd(nullPredicateSpec, predicateSpec1,predicateSpec2)
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(AndSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(AndSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+    }
+
+    @Test
+    fun whereAndList() {
+        // given
+        val nullPredicateSpec: PredicateSpec? = null
+        val predicateSpec1: PredicateSpec = mockk()
+        val predicateSpec2: PredicateSpec = mockk()
+
+        // when
+        val actual = QueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            whereAnd(listOf(nullPredicateSpec, predicateSpec1,predicateSpec2))
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(AndSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(AndSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+    }
+
+    @Test
+    fun whereOrVararg() {
+        // given
+        val nullPredicateSpec: PredicateSpec? = null
+        val predicateSpec1: PredicateSpec = mockk()
+        val predicateSpec2: PredicateSpec = mockk()
+
+        // when
+        val actual = QueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            whereOr(nullPredicateSpec, predicateSpec1,predicateSpec2)
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(OrSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(OrSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+    }
+
+    @Test
+    fun whereOrList() {
+        // given
+        val nullPredicateSpec: PredicateSpec? = null
+        val predicateSpec1: PredicateSpec = mockk()
+        val predicateSpec2: PredicateSpec = mockk()
+
+        // when
+        val actual = QueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            whereOr(listOf(nullPredicateSpec, predicateSpec1,predicateSpec2))
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(OrSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(OrSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+    }
+
+    @Test
+    fun wheres() {
+        // given
+        val nullPredicateSpec: PredicateSpec? = null
+        val predicateSpec1: PredicateSpec = mockk()
+        val predicateSpec2: PredicateSpec = mockk()
+
+        // when
+        val actual = QueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            where(nullPredicateSpec)
             where(predicateSpec1)
             where(predicateSpec2)
         }
@@ -86,30 +227,49 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
     }
 
     @Test
-    fun nullInFirstWheres() {
+    fun allTypeWheres() {
         // given
-        val predicateSpec1: PredicateSpec? = null
+        val nullPredicateSpec: PredicateSpec? = null
+        val predicateSpec1: PredicateSpec = mockk()
         val predicateSpec2: PredicateSpec = mockk()
-        val predicateSpec3: PredicateSpec = mockk()
 
         // when
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
-            where(predicateSpec1,predicateSpec2,predicateSpec3)
+            where(nullPredicateSpec)
+            where(predicateSpec1)
+            whereAnd(nullPredicateSpec, predicateSpec1, predicateSpec2)
+            whereOr(nullPredicateSpec, predicateSpec1, predicateSpec2)
         }
 
         // then
         val criteriaQuerySpec = actual.createCriteriaQuerySpec()
 
         assertThat(criteriaQuerySpec.where).isEqualTo(
-            WhereClause(AndSpec(listOf(predicateSpec2, predicateSpec3)))
+            WhereClause(
+                AndSpec(
+                    listOf(
+                        predicateSpec1,
+                        AndSpec(listOf(predicateSpec1, predicateSpec2)),
+                        OrSpec(listOf(predicateSpec1, predicateSpec2))
+                    )
+                )
+            )
         )
 
         val subquerySpec = actual.createSubquerySpec()
 
         assertThat(subquerySpec.where).isEqualTo(
-            WhereClause(AndSpec(listOf(predicateSpec2, predicateSpec3)))
+            WhereClause(
+                AndSpec(
+                    listOf(
+                        predicateSpec1,
+                        AndSpec(listOf(predicateSpec1, predicateSpec2)),
+                        OrSpec(listOf(predicateSpec1, predicateSpec2))
+                    )
+                )
+            )
         )
     }
 

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/QueryDslImplWhereTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/QueryDslImplWhereTest.kt
@@ -95,7 +95,7 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
-            whereAnd(nullPredicateSpec, predicateSpec1,predicateSpec2)
+            whereAnd(nullPredicateSpec, predicateSpec1, predicateSpec2)
         }
 
         // then
@@ -123,7 +123,7 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
-            whereAnd(listOf(nullPredicateSpec, predicateSpec1,predicateSpec2))
+            whereAnd(listOf(nullPredicateSpec, predicateSpec1, predicateSpec2))
         }
 
         // then
@@ -151,7 +151,7 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
-            whereOr(nullPredicateSpec, predicateSpec1,predicateSpec2)
+            whereOr(nullPredicateSpec, predicateSpec1, predicateSpec2)
         }
 
         // then
@@ -179,7 +179,7 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
-            whereOr(listOf(nullPredicateSpec, predicateSpec1,predicateSpec2))
+            whereOr(listOf(nullPredicateSpec, predicateSpec1, predicateSpec2))
         }
 
         // then

--- a/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/QueryDslImplWhereTest.kt
+++ b/core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/QueryDslImplWhereTest.kt
@@ -67,7 +67,8 @@ internal class QueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = QueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
-            where(predicateSpec1,predicateSpec2)
+            where(predicateSpec1)
+            where(predicateSpec2)
         }
 
         // then

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
@@ -6,4 +6,6 @@ import com.linecorp.kotlinjdsl.querydsl.predicate.PredicateDsl
 
 interface WhereDsl : ExpressionDsl, PredicateDsl {
     fun where(predicate: PredicateSpec?)
+
+    fun where(predicates: List<PredicateSpec?>)
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
@@ -5,7 +5,5 @@ import com.linecorp.kotlinjdsl.querydsl.expression.ExpressionDsl
 import com.linecorp.kotlinjdsl.querydsl.predicate.PredicateDsl
 
 interface WhereDsl : ExpressionDsl, PredicateDsl {
-    fun where(predicate: PredicateSpec?)
-
-    fun where(predicates: List<PredicateSpec?>)
+    fun where(vararg predicates: PredicateSpec?)
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
@@ -5,5 +5,5 @@ import com.linecorp.kotlinjdsl.querydsl.expression.ExpressionDsl
 import com.linecorp.kotlinjdsl.querydsl.predicate.PredicateDsl
 
 interface WhereDsl : ExpressionDsl, PredicateDsl {
-    fun where(vararg predicates: PredicateSpec?)
+    fun where(predicate: PredicateSpec?)
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
@@ -6,4 +6,10 @@ import com.linecorp.kotlinjdsl.querydsl.predicate.PredicateDsl
 
 interface WhereDsl : ExpressionDsl, PredicateDsl {
     fun where(predicate: PredicateSpec?)
+
+    fun whereAnd(vararg predicates: PredicateSpec?) = whereAnd(predicates.toList())
+    fun whereAnd(predicates: List<PredicateSpec?>)
+
+    fun whereOr(vararg predicates: PredicateSpec?) = whereOr(predicates.toList())
+    fun whereOr(predicates: List<PredicateSpec?>)
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/where/WhereDsl.kt
@@ -5,5 +5,5 @@ import com.linecorp.kotlinjdsl.querydsl.expression.ExpressionDsl
 import com.linecorp.kotlinjdsl.querydsl.predicate.PredicateDsl
 
 interface WhereDsl : ExpressionDsl, PredicateDsl {
-    fun where(predicate: PredicateSpec)
+    fun where(predicate: PredicateSpec?)
 }

--- a/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
+++ b/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
@@ -129,6 +129,18 @@ open class ReactiveQueryDslImpl<T>(
         predicate?.let { lazyWheres().add(it) }
     }
 
+    override fun whereAnd(predicates: List<PredicateSpec?>) {
+        predicates.filterNotNull()
+            .takeIf { it.isNotEmpty() }
+            ?.run { where(AndSpec(this)) }
+    }
+
+    override fun whereOr(predicates: List<PredicateSpec?>) {
+        predicates.filterNotNull()
+            .takeIf { it.isNotEmpty() }
+            ?.run { where(OrSpec(this)) }
+    }
+
     override fun groupBy(columns: List<ExpressionSpec<*>>) {
         lazyGroupBys().addAll(columns)
     }

--- a/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
+++ b/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
@@ -126,7 +126,7 @@ open class ReactiveQueryDslImpl<T>(
     }
 
     override fun where(predicate: PredicateSpec?) {
-        predicate?.let { lazyWheres().add(it) }
+        predicate?.run { lazyWheres().add(this) }
     }
 
     override fun whereAnd(predicates: List<PredicateSpec?>) {

--- a/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
+++ b/reactive-core/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/ReactiveQueryDslImpl.kt
@@ -30,6 +30,7 @@ import com.linecorp.kotlinjdsl.query.spec.expression.ColumnSpec
 import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.AndSpec
+import com.linecorp.kotlinjdsl.query.spec.predicate.OrSpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
 import com.linecorp.kotlinjdsl.querydsl.from.Relation
 import com.linecorp.kotlinjdsl.querydsl.hint.SqlReactiveQueryHintClauseProvider
@@ -124,8 +125,8 @@ open class ReactiveQueryDslImpl<T>(
         lazyJoins().add(FetchJoinSpec(left = left, right = right, path = relation.path, joinType = joinType))
     }
 
-    override fun where(predicate: PredicateSpec) {
-        lazyWheres().add(predicate)
+    override fun where(predicate: PredicateSpec?) {
+        predicate?.let { lazyWheres().add(it) }
     }
 
     override fun groupBy(columns: List<ExpressionSpec<*>>) {

--- a/reactive-core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/ReactiveQueryDslImplWhereTest.kt
+++ b/reactive-core/src/test/kotlin/com/linecorp/kotlinjdsl/querydsl/where/ReactiveQueryDslImplWhereTest.kt
@@ -2,6 +2,7 @@ package com.linecorp.kotlinjdsl.querydsl.where
 
 import com.linecorp.kotlinjdsl.query.clause.where.WhereClause
 import com.linecorp.kotlinjdsl.query.spec.predicate.AndSpec
+import com.linecorp.kotlinjdsl.query.spec.predicate.OrSpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.PredicateSpec
 import com.linecorp.kotlinjdsl.querydsl.ReactiveQueryDslImpl
 import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
@@ -15,6 +16,32 @@ internal class ReactiveQueryDslImplWhereTest : WithKotlinJdslAssertions {
         val actual = ReactiveQueryDslImpl(Data1::class.java).apply {
             select(distinct = true, Data1::class.java)
             from(entity(Data1::class))
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(PredicateSpec.empty)
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(PredicateSpec.empty)
+        )
+    }
+
+    @Test
+    fun nullInWhere() {
+        // given
+        val predicateSpec: PredicateSpec? = null
+
+        // when
+        val actual = ReactiveQueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            where(predicateSpec)
         }
 
         // then
@@ -58,8 +85,121 @@ internal class ReactiveQueryDslImplWhereTest : WithKotlinJdslAssertions {
     }
 
     @Test
+    fun whereAndVararg() {
+        // given
+        val nullPredicateSpec: PredicateSpec? = null
+        val predicateSpec1: PredicateSpec = mockk()
+        val predicateSpec2: PredicateSpec = mockk()
+
+        // when
+        val actual = ReactiveQueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            whereAnd(nullPredicateSpec, predicateSpec1, predicateSpec2)
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(AndSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(AndSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+    }
+
+    @Test
+    fun whereAndList() {
+        // given
+        val nullPredicateSpec: PredicateSpec? = null
+        val predicateSpec1: PredicateSpec = mockk()
+        val predicateSpec2: PredicateSpec = mockk()
+
+        // when
+        val actual = ReactiveQueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            whereAnd(listOf(nullPredicateSpec, predicateSpec1, predicateSpec2))
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(AndSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(AndSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+    }
+
+    @Test
+    fun whereOrVararg() {
+        // given
+        val nullPredicateSpec: PredicateSpec? = null
+        val predicateSpec1: PredicateSpec = mockk()
+        val predicateSpec2: PredicateSpec = mockk()
+
+        // when
+        val actual = ReactiveQueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            whereOr(nullPredicateSpec, predicateSpec1, predicateSpec2)
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(OrSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(OrSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+    }
+
+    @Test
+    fun whereOrList() {
+        // given
+        val nullPredicateSpec: PredicateSpec? = null
+        val predicateSpec1: PredicateSpec = mockk()
+        val predicateSpec2: PredicateSpec = mockk()
+
+        // when
+        val actual = ReactiveQueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            whereOr(listOf(nullPredicateSpec, predicateSpec1, predicateSpec2))
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(OrSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(OrSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+    }
+
+    @Test
     fun wheres() {
         // given
+        val nullPredicateSpec: PredicateSpec? = null
         val predicateSpec1: PredicateSpec = mockk()
         val predicateSpec2: PredicateSpec = mockk()
 
@@ -82,6 +222,53 @@ internal class ReactiveQueryDslImplWhereTest : WithKotlinJdslAssertions {
 
         assertThat(subquerySpec.where).isEqualTo(
             WhereClause(AndSpec(listOf(predicateSpec1, predicateSpec2)))
+        )
+    }
+
+    @Test
+    fun allTypeWheres() {
+        // given
+        val nullPredicateSpec: PredicateSpec? = null
+        val predicateSpec1: PredicateSpec = mockk()
+        val predicateSpec2: PredicateSpec = mockk()
+
+        // when
+        val actual = ReactiveQueryDslImpl(Data1::class.java).apply {
+            select(distinct = true, Data1::class.java)
+            from(entity(Data1::class))
+            where(nullPredicateSpec)
+            where(predicateSpec1)
+            whereAnd(nullPredicateSpec, predicateSpec1, predicateSpec2)
+            whereOr(nullPredicateSpec, predicateSpec1, predicateSpec2)
+        }
+
+        // then
+        val criteriaQuerySpec = actual.createCriteriaQuerySpec()
+
+        assertThat(criteriaQuerySpec.where).isEqualTo(
+            WhereClause(
+                AndSpec(
+                    listOf(
+                        predicateSpec1,
+                        AndSpec(listOf(predicateSpec1, predicateSpec2)),
+                        OrSpec(listOf(predicateSpec1, predicateSpec2))
+                    )
+                )
+            )
+        )
+
+        val subquerySpec = actual.createSubquerySpec()
+
+        assertThat(subquerySpec.where).isEqualTo(
+            WhereClause(
+                AndSpec(
+                    listOf(
+                        predicateSpec1,
+                        AndSpec(listOf(predicateSpec1, predicateSpec2)),
+                        OrSpec(listOf(predicateSpec1, predicateSpec2))
+                    )
+                )
+            )
         )
     }
 


### PR DESCRIPTION
# Motivation: 

https://github.com/line/kotlin-jdsl/issues/74

# Modifications:

- allow nullable predicates in where()
- support multi 'and conditions' with whereAnd(), whereOr()
- add test cases of changes
- add examples of changes

# Commit Convention Rule

* Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)

| Commit type | Description                                             |
|-------------|---------------------------------------------------------|
| feat        | New Feature                                             |
| fix         | Fix bug                                                 |
| docs        | Documentation only changed                              |
| ci          | Change CI configuration                                 |
| refactor    | Not a bug fix or add feature, just refactoring code     |
| test        | Add Test case or fix wrong test case                    |
| style       | Only change the code style(ex. white-space, formatting) |


# Result:
we can
- use nullable predicates in where()
- use whereAnd(), whereOr() for multi 'and conditions'
- test the changes
- refer examples of changes

# Closes #. (If this resolves the issue.)
* Describe the consequences that a user will face after this PR is merged.
