### PR TITLE
support nested column fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,26 @@ val authors: List<Author> = queryFactory.listQuery {
 }
 ```
 
+#### NestedColumn(Foreign Key)
+
+You can use the `nestedCol` function to get the `foreign Key` value.
+
+```kotlin
+val orderIdsInOrderGroupTable = queryFactory.listQuery {
+    select(nestedCol(col(OrderGroup::order), Order::id))
+    from(entity(OrderGroup::class))
+}
+```
+
+You can get the value of `foreign Key` using `nested`, an extension function in `ColumnSpec`.
+
+```kotlin
+val orderIdsInOrderGroupTable = queryFactory.listQuery<Long> {
+    select(col(OrderGroup::order).nested(Order::id))
+    from(entity(OrderGroup::class))
+}
+```
+
 ### Predicate
 
 Kotlin JDSL supports various predicates.

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpec.kt
@@ -2,7 +2,6 @@ package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import javax.persistence.criteria.*
-import kotlin.reflect.KProperty1
 
 data class ColumnSpec<T>(
     val entity: EntitySpec<*>,
@@ -34,9 +33,4 @@ data class ColumnSpec<T>(
 
     private fun path(froms: Froms): Path<T> =
         froms[entity].get(path)
-
-    fun <NT> nested(property: KProperty1<T, NT>): NestedColumnSpec<NT> = NestedColumnSpec(
-        this,
-        property.name
-    )
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpec.kt
@@ -32,7 +32,7 @@ data class ColumnSpec<T>(
         return path(froms)
     }
 
-    fun path(froms: Froms): Path<T> =
+    private fun path(froms: Froms): Path<T> =
         froms[entity].get(path)
 
     fun <NT> nested(property: KProperty1<T, NT>): NestedColumnSpec<NT> = NestedColumnSpec(

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/ColumnSpec.kt
@@ -2,6 +2,7 @@ package com.linecorp.kotlinjdsl.query.spec.expression
 
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import javax.persistence.criteria.*
+import kotlin.reflect.KProperty1
 
 data class ColumnSpec<T>(
     val entity: EntitySpec<*>,
@@ -33,4 +34,9 @@ data class ColumnSpec<T>(
 
     fun path(froms: Froms): Path<T> =
         froms[entity].get(path)
+
+    fun <NT> nested(property: KProperty1<T, NT>): NestedColumnSpec<NT> = NestedColumnSpec(
+        this,
+        property.name
+    )
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NestedColumnSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NestedColumnSpec.kt
@@ -3,8 +3,8 @@ package com.linecorp.kotlinjdsl.query.spec.expression
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import javax.persistence.criteria.*
 
-data class ColumnSpec<T>(
-    val entity: EntitySpec<*>,
+data class NestedColumnSpec<T>(
+    val nestedColumnSpec: ColumnSpec<*>,
     val path: String
 ) : ExpressionSpec<T> {
     override fun toCriteriaExpression(
@@ -12,7 +12,7 @@ data class ColumnSpec<T>(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return path(froms)
+        return nestedColumnSpec.path(froms).get(path)
     }
 
     override fun toCriteriaExpression(
@@ -20,7 +20,7 @@ data class ColumnSpec<T>(
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return path(froms)
+        return nestedColumnSpec.path(froms).get(path)
     }
 
     override fun toCriteriaExpression(
@@ -28,9 +28,6 @@ data class ColumnSpec<T>(
         query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return path(froms)
+        return nestedColumnSpec.path(froms).get(path)
     }
-
-    fun path(froms: Froms): Path<T> =
-        froms[entity].get(path)
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NestedColumnSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NestedColumnSpec.kt
@@ -3,8 +3,6 @@ package com.linecorp.kotlinjdsl.query.spec.expression
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import javax.persistence.criteria.*
 
-private fun <T> ColumnSpec<T>.outerPath(froms: Froms): Path<T> = froms[entity].get(path)
-
 data class NestedColumnSpec<T>(
     val nestedColumnSpec: ColumnSpec<*>,
     val path: String
@@ -14,7 +12,7 @@ data class NestedColumnSpec<T>(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return nestedColumnSpec.outerPath(froms).get(path)
+        return nestedColumnSpec.nestedPath(froms).get(path)
     }
 
     override fun toCriteriaExpression(
@@ -22,7 +20,7 @@ data class NestedColumnSpec<T>(
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return nestedColumnSpec.outerPath(froms).get(path)
+        return nestedColumnSpec.nestedPath(froms).get(path)
     }
 
     override fun toCriteriaExpression(
@@ -30,6 +28,9 @@ data class NestedColumnSpec<T>(
         query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return nestedColumnSpec.outerPath(froms).get(path)
+        return nestedColumnSpec.nestedPath(froms).get(path)
     }
+
+    private fun <T> ColumnSpec<T>.nestedPath(froms: Froms): Path<T> =
+        froms[entity].get(path)
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NestedColumnSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NestedColumnSpec.kt
@@ -3,6 +3,8 @@ package com.linecorp.kotlinjdsl.query.spec.expression
 import com.linecorp.kotlinjdsl.query.spec.Froms
 import javax.persistence.criteria.*
 
+private fun <T> ColumnSpec<T>.outerPath(froms: Froms): Path<T> = froms[entity].get(path)
+
 data class NestedColumnSpec<T>(
     val nestedColumnSpec: ColumnSpec<*>,
     val path: String
@@ -12,7 +14,7 @@ data class NestedColumnSpec<T>(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return nestedColumnSpec.path(froms).get(path)
+        return nestedColumnSpec.outerPath(froms).get(path)
     }
 
     override fun toCriteriaExpression(
@@ -20,7 +22,7 @@ data class NestedColumnSpec<T>(
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return nestedColumnSpec.path(froms).get(path)
+        return nestedColumnSpec.outerPath(froms).get(path)
     }
 
     override fun toCriteriaExpression(
@@ -28,6 +30,6 @@ data class NestedColumnSpec<T>(
         query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Expression<T> {
-        return nestedColumnSpec.path(froms).get(path)
+        return nestedColumnSpec.outerPath(froms).get(path)
     }
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/expression/ExpressionDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/expression/ExpressionDsl.kt
@@ -15,7 +15,7 @@ interface ExpressionDsl {
     fun <R> nullLiteral(type: Class<R>) = NullLiteralSpec(type)
     fun <T, R> col(entity: EntitySpec<T>, property: KProperty1<T, R>) = column(entity, property)
     fun <T, R> column(entity: EntitySpec<T>, property: KProperty1<T, R>) = ColumnSpec<R>(entity, property.name)
-
+    fun <C, R> nestedCol(columnSpec: ColumnSpec<C>, property: KProperty1<C, R>) = NestedColumnSpec<R>(columnSpec, property.name)
     fun <N : Number?> max(expression: ExpressionSpec<N>) = MaxSpec(expression)
     fun <N : Number?> min(expression: ExpressionSpec<N>) = MinSpec(expression)
     fun <N : Number?> avg(expression: ExpressionSpec<N>) = AvgSpec(expression)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/expression/ExpressionDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/expression/ExpressionDsl.kt
@@ -10,11 +10,16 @@ interface ExpressionDsl {
     fun <T : Any, R : T?> entity(entity: KClass<T>) = EntitySpec(entity.java as Class<R>)
     fun <T : Any> entity(entity: KClass<T>, alias: String) = EntitySpec(entity.java, alias)
     fun <T : Any> KClass<T>.alias(alias: String) = EntitySpec(this.java, alias)
+    fun <T, R> ColumnSpec<T>.nested(property: KProperty1<T, R>): NestedColumnSpec<R> = NestedColumnSpec(
+        this,
+        property.name
+    )
 
     fun <R : Any> literal(value: R) = LiteralSpec(value)
     fun <R> nullLiteral(type: Class<R>) = NullLiteralSpec(type)
     fun <T, R> col(entity: EntitySpec<T>, property: KProperty1<T, R>) = column(entity, property)
     fun <T, R> column(entity: EntitySpec<T>, property: KProperty1<T, R>) = ColumnSpec<R>(entity, property.name)
+
     fun <C, R> nestedCol(columnSpec: ColumnSpec<C>, property: KProperty1<C, R>) = NestedColumnSpec<R>(columnSpec, property.name)
     fun <N : Number?> max(expression: ExpressionSpec<N>) = MaxSpec(expression)
     fun <N : Number?> min(expression: ExpressionSpec<N>) = MinSpec(expression)

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NestedColumnSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/expression/NestedColumnSpecTest.kt
@@ -1,0 +1,132 @@
+package com.linecorp.kotlinjdsl.query.spec.expression
+
+import com.linecorp.kotlinjdsl.query.spec.Froms
+import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.criteria.*
+
+@ExtendWith(MockKExtension::class)
+class NestedColumnSpecTest : WithKotlinJdslAssertions {
+    @MockK
+    private lateinit var froms: Froms
+
+    @MockK
+    private lateinit var query: AbstractQuery<*>
+
+    @MockK
+    private lateinit var updateQuery: CriteriaUpdate<*>
+
+    @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
+    private lateinit var criteriaBuilder: CriteriaBuilder
+
+    @Test
+    fun toCriteriaExpression() {
+        // given
+        val from = mockk<From<*, Data>>()
+        val path = mockk<Path<NestedData>>()
+        val nestedPath = mockk<Path<Long>>()
+
+        every { froms[any<EntitySpec<Data>>()] } returns from
+        every { from.get<NestedData>(any<String>()) } returns path
+        every { path.get<Long>(any<String>()) } returns nestedPath
+
+        // when
+        val spec = NestedColumnSpec<Long>(
+            ColumnSpec<NestedData>(EntitySpec(Data::class.java), "nestedData"),
+            "nestedId"
+        )
+
+        val actual = spec.toCriteriaExpression(froms, query, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(nestedPath)
+
+        verify {
+            froms[EntitySpec(Data::class.java)]
+            from.get<NestedData>("nestedData")
+            path.get<Long>("nestedId")
+        }
+
+        confirmVerified(from, froms, query, criteriaBuilder)
+    }
+
+    @Test
+    fun `update toCriteriaExpression`() {
+        // given
+        val from = mockk<From<*, Data>>()
+        val path = mockk<Path<NestedData>>()
+        val nestedPath = mockk<Path<Long>>()
+
+        every { froms[any<EntitySpec<Data>>()] } returns from
+        every { from.get<NestedData>(any<String>()) } returns path
+        every { path.get<Long>(any<String>()) } returns nestedPath
+
+        // when
+        val spec = NestedColumnSpec<Long>(
+            ColumnSpec<NestedData>(EntitySpec(Data::class.java), "nestedData"),
+            "nestedId"
+        )
+
+        val actual = spec.toCriteriaExpression(froms, updateQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(nestedPath)
+
+        verify {
+            froms[EntitySpec(Data::class.java)]
+            from.get<NestedData>("nestedData")
+            path.get<Long>("nestedId")
+        }
+
+        confirmVerified(from, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaExpression`() {
+        // given
+        val from = mockk<From<*, Data>>()
+        val path = mockk<Path<NestedData>>()
+        val nestedPath = mockk<Path<Long>>()
+
+        every { froms[any<EntitySpec<Data>>()] } returns from
+        every { from.get<NestedData>(any<String>()) } returns path
+        every { path.get<Long>(any<String>()) } returns nestedPath
+
+        // when
+        val spec = NestedColumnSpec<Long>(
+            ColumnSpec<NestedData>(EntitySpec(Data::class.java), "nestedData"),
+            "nestedId"
+        )
+
+        val actual = spec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(nestedPath)
+
+        verify {
+            froms[EntitySpec(Data::class.java)]
+            from.get<NestedData>("nestedData")
+            path.get<Long>("nestedId")
+        }
+
+        confirmVerified(from, froms, deleteQuery, criteriaBuilder)
+    }
+
+    private class Data {
+        val nestedData = NestedData()
+    }
+
+    private class NestedData {
+        val nestedId: Long = 0L
+    }
+}

--- a/test-fixture/entity/src/main/kotlin/com/linecorp/kotlinjdsl/test/entity/order/OrderGroup.kt
+++ b/test-fixture/entity/src/main/kotlin/com/linecorp/kotlinjdsl/test/entity/order/OrderGroup.kt
@@ -10,6 +10,8 @@ class OrderGroup(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
+    val orderGroupName: String,
+
     @OneToMany(mappedBy = "group", cascade = [CascadeType.PERSIST], orphanRemoval = true)
     val items: Set<OrderItem>,
 
@@ -45,10 +47,12 @@ class OrderGroup(
 
 data class OrderGroupTestBuilder(
     var items: Set<OrderItem> = hashSetOf(OrderItemTestBuilder().build()),
-    var address: OrderAddress = OrderAddressTestBuilder().build()
+    var address: OrderAddress = OrderAddressTestBuilder().build(),
+    var orderGroupName: String = "orderGroupName",
 ) {
     fun build() = OrderGroup(
         items = items,
         address = address,
+        orderGroupName = orderGroupName,
     )
 }

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.querydsl.expression.max
 import com.linecorp.kotlinjdsl.singleQuery
 import com.linecorp.kotlinjdsl.subquery
 import com.linecorp.kotlinjdsl.test.entity.order.Order
+import com.linecorp.kotlinjdsl.test.entity.order.OrderGroup
 import com.linecorp.kotlinjdsl.test.entity.order.OrderItem
 import com.linecorp.kotlinjdsl.test.reactive.CriteriaQueryDslIntegrationTest
 import com.linecorp.kotlinjdsl.test.reactive.runBlocking
@@ -156,5 +157,18 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest<S> : CriteriaQueryD
 
         // then
         assertThat(result).isEqualTo(order1.groups.first().items.first().productName.take(2))
+    }
+
+    @Test
+    fun `nestedCol - ref key fetch`() = runBlocking {
+        val result = withFactory { queryFactory ->
+            queryFactory.listQuery {
+                select(nestedCol(col(OrderGroup::order), Order::id))
+                from(entity(OrderGroup::class))
+            }
+        }
+
+        // then
+        assertThat(result).isEqualTo(listOf(order1.id, order2.id, order3.id).sorted())
     }
 }

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
@@ -3,9 +3,12 @@ package com.linecorp.kotlinjdsl.test.reactive.querydsl.where
 import com.linecorp.kotlinjdsl.listQuery
 import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.querydsl.from.fetch
+import com.linecorp.kotlinjdsl.querydsl.from.join
 import com.linecorp.kotlinjdsl.singleQuery
 import com.linecorp.kotlinjdsl.subquery
+import com.linecorp.kotlinjdsl.test.entity.Address
 import com.linecorp.kotlinjdsl.test.entity.order.Order
+import com.linecorp.kotlinjdsl.test.entity.order.OrderAddress
 import com.linecorp.kotlinjdsl.test.entity.order.OrderGroup
 import com.linecorp.kotlinjdsl.test.reactive.CriteriaQueryDslIntegrationTest
 import com.linecorp.kotlinjdsl.test.reactive.runBlocking
@@ -14,9 +17,20 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 
 abstract class AbstractCriteriaQueryDslWhereIntegrationTest<S> : CriteriaQueryDslIntegrationTest<S> {
+    private val orderItem1 = orderItem { }
+    private val orderItem2 = orderItem { }
+
     private val order1 = order { purchaserId = 1000 }
     private val order2 = order { purchaserId = 2000 }
-    private val order3 = order { purchaserId = 3000 }
+    private val order3 = order {
+        purchaserId = 3000
+        groups = hashSetOf(orderGroup {
+            items = hashSetOf(orderItem1, orderItem2)
+            address = orderAddress {
+                zipCode = "zipCode1"
+            }
+        })
+    }
 
     @BeforeEach
     fun setUp() = runBlocking {
@@ -64,5 +78,28 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest<S> : CriteriaQueryDs
 
         // then
         assertThat(orderIds).isEqualTo(listOf(order1.id))
+    }
+
+    @Test
+    fun `where using subquery with ref key`() = runBlocking {
+        // when
+        val orderIds = withFactory { queryFactory ->
+            val subQuery = queryFactory.subquery<Long> {
+                select(nestedCol(col(OrderGroup::order), Order::id))
+                from(entity(OrderGroup::class))
+                join(OrderGroup::address)
+                associate(OrderAddress::class, Address::class, on(OrderAddress::address))
+                where(col(Address::zipCode).equal("zipCode1"))
+            }
+
+            queryFactory.listQuery<Long> {
+                select(col(Order::id))
+                from(entity(Order::class))
+                where(col(Order::id).`in`(subQuery))
+            }
+        }
+
+        // then
+        assertThat(orderIds).isEqualTo(listOf(order3.id).sorted())
     }
 }

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.querydsl.expression.count
 import com.linecorp.kotlinjdsl.querydsl.expression.function
 import com.linecorp.kotlinjdsl.querydsl.expression.max
+import com.linecorp.kotlinjdsl.querydsl.from.join
 import com.linecorp.kotlinjdsl.singleQuery
 import com.linecorp.kotlinjdsl.subquery
 import com.linecorp.kotlinjdsl.test.entity.order.Order
@@ -149,9 +150,24 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
         val result = queryFactory.listQuery {
             select(nestedCol(col(OrderGroup::order), Order::id))
             from(entity(OrderGroup::class))
+            orderBy(nestedCol(col(OrderGroup::order), Order::id).asc())
         }
 
         // then
         assertThat(result).isEqualTo(listOf(order1.id, order2.id, order3.id).sorted())
+    }
+
+    @Test
+    fun `nestedCol - implicit join and fetch column value`() {
+        // when
+        val result = queryFactory.listQuery<Long> {
+            select(nestedCol(col(OrderGroup::order), Order::purchaserId))
+            from(entity(OrderGroup::class))
+            join(OrderGroup::address)
+            orderBy(nestedCol(col(OrderGroup::order), Order::purchaserId).asc())
+        }
+
+        // then
+        assertThat(result).isEqualTo(listOf(order1.purchaserId, order2.purchaserId, order3.purchaserId).sorted())
     }
 }

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.querydsl.expression.max
 import com.linecorp.kotlinjdsl.singleQuery
 import com.linecorp.kotlinjdsl.subquery
 import com.linecorp.kotlinjdsl.test.entity.order.Order
+import com.linecorp.kotlinjdsl.test.entity.order.OrderGroup
 import com.linecorp.kotlinjdsl.test.entity.order.OrderItem
 import com.linecorp.kotlinjdsl.test.integration.AbstractCriteriaQueryDslIntegrationTest
 import org.junit.jupiter.api.BeforeEach
@@ -141,5 +142,16 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
 
         // then
         assertThat(result).isEqualTo(order1.groups.first().items.first().productName.take(2))
+    }
+
+    @Test
+    fun `nestedCol - ref key fetch`() {
+        val result = queryFactory.listQuery {
+            select(nestedCol(col(OrderGroup::order), Order::id))
+            from(entity(OrderGroup::class))
+        }
+
+        // then
+        assertThat(result).isEqualTo(listOf(order1.id, order2.id, order3.id).sorted())
     }
 }

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -158,6 +158,18 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
     }
 
     @Test
+    fun `nestedCol - ref key fetch nested function`() {
+        val result = queryFactory.listQuery {
+            select(col(OrderGroup::order).nested(Order::id))
+            from(entity(OrderGroup::class))
+            orderBy(nestedCol(col(OrderGroup::order), Order::id).asc())
+        }
+
+        // then
+        assertThat(result).isEqualTo(listOf(order1.id, order2.id, order3.id).sorted())
+    }
+
+    @Test
     fun `nestedCol - implicit join and fetch column value`() {
         // when
         val result = queryFactory.listQuery<Long> {


### PR DESCRIPTION
# Motivation:

* it's impossible query only the ref key without a join, if there was a associated relationship between entity classes

# Modifications:

* Add NestedCol data class which implement `ExpressionSpec` and can fetch reference key.
* you can use this stmt for implicit join(example: https://github.com/kihwankim/kotlin-jdsl/commit/96f5b76003ab349c0759612ae2aa6a501af715e1)

# Commit Convention Rule

* Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)

| Commit type | Description                                             |
|-------------|---------------------------------------------------------|
| feat        | New Feature                                             |
| fix         | Fix bug                                                 |
| docs        | Documentation only changed                              |
| ci          | Change CI configuration                                 |
| refactor    | Not a bug fix or add feature, just refactoring code     |
| test        | Add Test case or fix wrong test case                    |
| style       | Only change the code style(ex. white-space, formatting) |

Closes #79