### PR TITLE
chore: typo fix (mitiny -> mutiny), mutiny version 1.7.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@
 | refactor    | Not a bug fix or add feature, just refactoring code     |
 | test        | Add Test case or fix wrong test case                    |
 | style       | Only change the code style(ex. white-space, formatting) |
+| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |
 
 * If you want to add some more `commit type` please describe it on the **Pull Request**
 

--- a/examples/spring-boot-hibernate-reactive-2.6/build.gradle.kts
+++ b/examples/spring-boot-hibernate-reactive-2.6/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation(libs.hibernate.reactive)
     implementation(libs.coroutine.jdk8)
     implementation(libs.coroutine.reactor)
-    implementation(libs.bundles.mitiny)
+    implementation(libs.bundles.mutiny)
 
     implementation(Modules.testFixtureHibernateReactive)
 

--- a/examples/spring-boot-hibernate-reactive-2.7/build.gradle.kts
+++ b/examples/spring-boot-hibernate-reactive-2.7/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation(libs.hibernate.reactive)
     implementation(libs.coroutine.jdk8)
     implementation(libs.coroutine.reactor)
-    implementation(libs.bundles.mitiny)
+    implementation(libs.bundles.mutiny)
 
     implementation(Modules.testFixtureHibernateReactive)
 

--- a/hibernate-reactive/build.gradle.kts
+++ b/hibernate-reactive/build.gradle.kts
@@ -5,9 +5,9 @@ dependencies {
 
     compileOnly(libs.hibernate.reactive)
     compileOnly(libs.slf4j)
-    compileOnly(libs.bundles.mitiny)
+    compileOnly(libs.bundles.mutiny)
 
-    testImplementation(libs.bundles.mitiny)
+    testImplementation(libs.bundles.mutiny)
     testImplementation(libs.coroutine.jdk8)
     testImplementation(Modules.testFixtureIntegrationReactive)
     testImplementation(Modules.testFixtureHibernateReactive)

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -4,7 +4,7 @@ spring-core = "5.3.23"
 spring-boot = "2.7.3"
 spring-data-jpa = "2.7.3"
 coroutine = "1.6.4"
-mutiny = "1.6.0"
+mutiny = "1.7.0"
 
 [libraries]
 # kotlin
@@ -51,7 +51,7 @@ mutiny-core = { module = "io.smallrye.reactive:mutiny", version.ref = "mutiny" }
 mutiny-kotlin = { module = "io.smallrye.reactive:mutiny-kotlin", version.ref = "mutiny" }
 
 [bundles]
-mitiny = ["mutiny-core", "mutiny-kotlin"]
+mutiny = ["mutiny-core", "mutiny-kotlin"]
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/spring/data-hibernate-reactive/build.gradle.kts
+++ b/spring/data-hibernate-reactive/build.gradle.kts
@@ -3,7 +3,7 @@ apply<PublishPlugin>()
 dependencies {
     compileOnly(libs.spring.jpa)
     compileOnly(libs.hibernate.reactive)
-    compileOnly(libs.bundles.mitiny)
+    compileOnly(libs.bundles.mutiny)
 
     api(Modules.reactiveCore)
     api(Modules.hibernateReactive)
@@ -14,7 +14,7 @@ dependencies {
     testImplementation(Modules.testFixtureEntity)
     testImplementation(Modules.testFixtureHibernateReactive)
     testImplementation(Modules.testFixtureIntegrationReactive)
-    testImplementation(libs.bundles.mitiny)
+    testImplementation(libs.bundles.mutiny)
     testImplementation(libs.spring.boot.test)
     testImplementation(libs.spring.jpa)
     testImplementation(libs.hibernate.reactive)


### PR DESCRIPTION
# Motivation:

* The mutiny bundle name is incorrect, we need fix it. mutiny 1.7.0 has been upgraded. modified the PR template.

-- korean
* mutiny bundle 이름이 잘못되어 수정합니다. mutiny 1.7.0 이 업그레이드 되었습니다. PR 템플릿을 수정했습니다.

# Modifications:

* Fixed the Mutiny typo in lib.versions.toml and upgraded the version.
* Added chore item to PR template.

-- korean
* lib.versions.toml 에서 Mutiny 오타를 수정하고 버전업을 진행했습니다.
* PR template 에 chore 항목을 추가했습니다.

# Commit Convention Rule

* Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)

| Commit type | Description                                             |
|-------------|---------------------------------------------------------|
| feat        | New Feature                                             |
| fix         | Fix bug                                                 |
| docs        | Documentation only changed                              |
| ci          | Change CI configuration                                 |
| refactor    | Not a bug fix or add feature, just refactoring code     |
| test        | Add Test case or fix wrong test case                    |
| style       | Only change the code style(ex. white-space, formatting) |

* If you want to add some more `commit type` please describe it on the **Pull Request**


# Result:
The mutiny version is upgraded.

-- korean
mutiny version 이 업그레이드 됩니다.