### PR TITLE
Add ExistsSpec to enable exists not exist sql stmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,54 @@ val books = queryFactory.listQuery<Book> {
 }
 ```
 
+#### Exists
+
+Subquery exists expression
+
+```kotlin
+val orders = queryFactory.listQuery {
+    val entity: EntitySpec<Order> = entity(Order::class)
+    select(entity)
+    from(entity)
+    where(
+        exists(queryFactory.subquery<Long> {
+            val orderGroupEntity = entity(OrderGroup::class)
+            select(literal(1))
+            from(orderGroupEntity)
+            where(
+                and(
+                    col(OrderGroup::orderGroupName).equal("orderGroup1"),
+                    col(OrderGroup::order).equal(entity)
+                )
+            )
+        })
+    )
+}
+```
+
+Subquery not exists expression
+
+```kotlin
+val orders = queryFactory.listQuery {
+    val entity: EntitySpec<Order> = entity(Order::class)
+    select(entity)
+    from(entity)
+    where(
+        notExists(queryFactory.subquery<Long> {
+            val orderGroupEntity = entity(OrderGroup::class)
+            select(literal(1))
+            from(orderGroupEntity)
+            where(
+                and(
+                    col(OrderGroup::orderGroupName).equal("orderGroup1"),
+                    col(OrderGroup::order).equal(entity)
+                )
+            )
+        })
+    )
+}
+```
+
 #### Alias
 
 There may be models with the two associations of same type. In this case, separate the Entity using alias.
@@ -312,6 +360,7 @@ val orders = queryFactory.listQuery<Order> {
 #### associate
 
 associate behaves similarly to join, and operates exactly the same as join in select, and since Join cannot be used in update/delete, use associate to associate the relationship with other internally mapped objects (ex: @Embedded) You can build it and run the query.
+
 ```kotlin
 val query = queryFactory.selectQuery<String> {
     select(col(Address::zipCode))

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/ExistsSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/ExistsSpec.kt
@@ -12,9 +12,8 @@ data class ExistsSpec<T>(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        val subQueryExpression = subqueryExpressionSpec.toCriteriaExpression(froms, query, criteriaBuilder)
-        subQueryExpression as Subquery<T>
-        return criteriaBuilder.exists(subQueryExpression)
+        val subqueryExpression = subqueryExpressionSpec.toCriteriaExpression(froms, query, criteriaBuilder)
+        return criteriaBuilder.exists(subqueryExpression as Subquery<T>)
     }
 
     override fun toCriteriaPredicate(
@@ -22,9 +21,8 @@ data class ExistsSpec<T>(
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        val subQueryExpression = subqueryExpressionSpec.toCriteriaExpression(froms, query, criteriaBuilder)
-        subQueryExpression as Subquery<T>
-        return criteriaBuilder.exists(subQueryExpression)
+        val subqueryExpression = subqueryExpressionSpec.toCriteriaExpression(froms, query, criteriaBuilder)
+        return criteriaBuilder.exists(subqueryExpression as Subquery<T>)
     }
 
     override fun toCriteriaPredicate(
@@ -32,8 +30,7 @@ data class ExistsSpec<T>(
         query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        val subQueryExpression = subqueryExpressionSpec.toCriteriaExpression(froms, query, criteriaBuilder)
-        subQueryExpression as Subquery<T>
-        return criteriaBuilder.exists(subQueryExpression)
+        val subqueryExpression = subqueryExpressionSpec.toCriteriaExpression(froms, query, criteriaBuilder)
+        return criteriaBuilder.exists(subqueryExpression as Subquery<T>)
     }
 }

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/ExistsSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/ExistsSpec.kt
@@ -1,0 +1,39 @@
+package com.linecorp.kotlinjdsl.query.spec.predicate
+
+import com.linecorp.kotlinjdsl.query.spec.Froms
+import com.linecorp.kotlinjdsl.query.spec.expression.SubqueryExpressionSpec
+import javax.persistence.criteria.*
+
+data class ExistsSpec<T>(
+    private val subqueryExpressionSpec: SubqueryExpressionSpec<T>,
+) : PredicateSpec {
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: AbstractQuery<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        val subQueryExpression = subqueryExpressionSpec.toCriteriaExpression(froms, query, criteriaBuilder)
+        subQueryExpression as Subquery<T>
+        return criteriaBuilder.exists(subQueryExpression)
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaUpdate<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        val subQueryExpression = subqueryExpressionSpec.toCriteriaExpression(froms, query, criteriaBuilder)
+        subQueryExpression as Subquery<T>
+        return criteriaBuilder.exists(subQueryExpression)
+    }
+
+    override fun toCriteriaPredicate(
+        froms: Froms,
+        query: CriteriaDelete<*>,
+        criteriaBuilder: CriteriaBuilder
+    ): Predicate {
+        val subQueryExpression = subqueryExpressionSpec.toCriteriaExpression(froms, query, criteriaBuilder)
+        subQueryExpression as Subquery<T>
+        return criteriaBuilder.exists(subQueryExpression)
+    }
+}

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/predicate/PredicateDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/predicate/PredicateDsl.kt
@@ -1,6 +1,7 @@
 package com.linecorp.kotlinjdsl.querydsl.predicate
 
 import com.linecorp.kotlinjdsl.query.spec.expression.ExpressionSpec
+import com.linecorp.kotlinjdsl.query.spec.expression.SubqueryExpressionSpec
 import com.linecorp.kotlinjdsl.query.spec.predicate.*
 
 @Suppress("RemoveExplicitTypeArguments")
@@ -12,6 +13,9 @@ interface PredicateDsl {
 
     fun or(vararg others: PredicateSpec?): PredicateSpec = or(others.toList())
     fun or(others: List<PredicateSpec?>): PredicateSpec = OrSpec(others)
+
+    fun <T> exists(subquery: SubqueryExpressionSpec<T>) = ExistsSpec(subquery)
+    fun <T> notExists(subQuery: SubqueryExpressionSpec<T>) = not(ExistsSpec(subQuery))
 
     fun <R> ExpressionSpec<R>.equal(value: R) = EqualValueSpec(this, value)
     fun <R> ExpressionSpec<R>.equal(expression: ExpressionSpec<R>) = EqualExpressionSpec(this, expression)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/predicate/PredicateDsl.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/querydsl/predicate/PredicateDsl.kt
@@ -14,8 +14,8 @@ interface PredicateDsl {
     fun or(vararg others: PredicateSpec?): PredicateSpec = or(others.toList())
     fun or(others: List<PredicateSpec?>): PredicateSpec = OrSpec(others)
 
-    fun <T> exists(subquery: SubqueryExpressionSpec<T>) = ExistsSpec(subquery)
-    fun <T> notExists(subQuery: SubqueryExpressionSpec<T>) = not(ExistsSpec(subQuery))
+    fun <T> exists(subqueryExpression: SubqueryExpressionSpec<T>) = ExistsSpec(subqueryExpression)
+    fun <T> notExists(subqueryExpression: SubqueryExpressionSpec<T>) = not(ExistsSpec(subqueryExpression))
 
     fun <R> ExpressionSpec<R>.equal(value: R) = EqualValueSpec(this, value)
     fun <R> ExpressionSpec<R>.equal(expression: ExpressionSpec<R>) = EqualExpressionSpec(this, expression)

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/ExistsSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/ExistsSpecTest.kt
@@ -1,0 +1,110 @@
+package com.linecorp.kotlinjdsl.query.spec.predicate
+
+import com.linecorp.kotlinjdsl.query.spec.Froms
+import com.linecorp.kotlinjdsl.query.spec.expression.SubqueryExpressionSpec
+import com.linecorp.kotlinjdsl.test.WithKotlinJdslAssertions
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import javax.persistence.criteria.*
+
+@ExtendWith(MockKExtension::class)
+internal class ExistsSpecTest : WithKotlinJdslAssertions {
+    @MockK
+    private lateinit var froms: Froms
+
+    @MockK
+    private lateinit var query: AbstractQuery<*>
+
+    @MockK
+    private lateinit var updateQuery: CriteriaUpdate<*>
+
+    @MockK
+    private lateinit var deleteQuery: CriteriaDelete<*>
+
+    @MockK
+    private lateinit var criteriaBuilder: CriteriaBuilder
+
+    @Test
+    fun toCriteriaPredicate() {
+        // given
+        val subqueryExpressionSpec: SubqueryExpressionSpec<Long> = mockk()
+
+        val subquery: Subquery<Long> = mockk()
+        val existsPredicate: Predicate = mockk()
+
+        every { subqueryExpressionSpec.toCriteriaExpression(any(), any<CriteriaQuery<*>>(), any()) } returns subquery
+        every { criteriaBuilder.exists(any<Subquery<Long>>()) } returns existsPredicate
+
+        // when
+        val actual = ExistsSpec(subqueryExpressionSpec)
+            .toCriteriaPredicate(froms, query, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(existsPredicate)
+
+        verify(exactly = 1) {
+            subqueryExpressionSpec.toCriteriaExpression(froms, query, criteriaBuilder)
+            criteriaBuilder.exists(subquery)
+        }
+
+        confirmVerified(subqueryExpressionSpec, froms, query, criteriaBuilder)
+    }
+
+    @Test
+    fun `update toCriteriaPredicate`() {
+        // given
+        val subqueryExpressionSpec: SubqueryExpressionSpec<Long> = mockk()
+
+        val subquery: Subquery<Long> = mockk()
+        val existsPredicate: Predicate = mockk()
+
+        every { subqueryExpressionSpec.toCriteriaExpression(any(), any<CriteriaUpdate<*>>(), any()) } returns subquery
+        every { criteriaBuilder.exists(any<Subquery<Long>>()) } returns existsPredicate
+
+        // when
+        val actual = ExistsSpec(subqueryExpressionSpec)
+            .toCriteriaPredicate(froms, updateQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(existsPredicate)
+
+        verify(exactly = 1) {
+            subqueryExpressionSpec.toCriteriaExpression(froms, updateQuery, criteriaBuilder)
+            criteriaBuilder.exists(subquery)
+        }
+
+        confirmVerified(subqueryExpressionSpec, froms, updateQuery, criteriaBuilder)
+    }
+
+    @Test
+    fun `delete toCriteriaPredicate`() {
+        // given
+        val subqueryExpressionSpec: SubqueryExpressionSpec<Long> = mockk()
+
+        val subquery: Subquery<Long> = mockk()
+        val existsPredicate: Predicate = mockk()
+
+        every { subqueryExpressionSpec.toCriteriaExpression(any(), any<CriteriaDelete<*>>(), any()) } returns subquery
+        every { criteriaBuilder.exists(any<Subquery<Long>>()) } returns existsPredicate
+
+        // when
+        val actual = ExistsSpec(subqueryExpressionSpec)
+            .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
+
+        // then
+        assertThat(actual).isEqualTo(existsPredicate)
+
+        verify(exactly = 1) {
+            subqueryExpressionSpec.toCriteriaExpression(froms, deleteQuery, criteriaBuilder)
+            criteriaBuilder.exists(subquery)
+        }
+
+        confirmVerified(subqueryExpressionSpec, froms, deleteQuery, criteriaBuilder)
+    }
+}

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/expression/AbstractCriteriaQueryDslExpressionIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/expression/AbstractCriteriaQueryDslExpressionIntegrationTest.kt
@@ -10,7 +10,6 @@ import com.linecorp.kotlinjdsl.test.reactive.CriteriaQueryDslIntegrationTest
 import com.linecorp.kotlinjdsl.test.reactive.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
 
 abstract class AbstractCriteriaQueryDslExpressionIntegrationTest<S> : CriteriaQueryDslIntegrationTest<S> {
     private val orderItem1 = orderItem { productName = "test1"; productImage = null; price = 10; claimed = true }
@@ -56,7 +55,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest<S> : CriteriaQu
     fun entityAlias() = runBlocking {
         // when
         val orders = withFactory { queryFactory ->
-            queryFactory.listQuery<Order> {
+            queryFactory.listQuery {
                 val entity = entity(Order::class, "orderAlias")
                 select(entity)
                 from(entity)
@@ -71,7 +70,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest<S> : CriteriaQu
     fun literal() = runBlocking {
         // when
         val literals = withFactory { queryFactory ->
-            queryFactory.listQuery<Int> {
+            queryFactory.listQuery {
                 select(literal(10))
                 from(entity(Order::class))
             }
@@ -85,7 +84,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest<S> : CriteriaQu
     fun nullLiteral() = runBlocking {
         // when
         val literals = withFactory { queryFactory ->
-            queryFactory.listQuery<Int?> {
+            queryFactory.listQuery {
                 select(nullLiteral(Int::class.java))
                 from(entity(Order::class))
             }
@@ -99,7 +98,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest<S> : CriteriaQu
     fun column() = runBlocking {
         // when
         val literals = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(column(Order::id))
                 from(entity(Order::class))
             }
@@ -113,7 +112,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest<S> : CriteriaQu
     fun max() = runBlocking {
         // when
         val max = withFactory { queryFactory ->
-            queryFactory.singleQuery<BigDecimal> {
+            queryFactory.singleQuery {
                 select(max(OrderItem::price))
                 from(entity(OrderItem::class))
             }
@@ -127,7 +126,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest<S> : CriteriaQu
     fun min() = runBlocking {
         // when
         val min = withFactory { queryFactory ->
-            queryFactory.singleQuery<BigDecimal> {
+            queryFactory.singleQuery {
                 select(min(OrderItem::price))
                 from(entity(OrderItem::class))
             }
@@ -141,7 +140,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest<S> : CriteriaQu
     fun avg() = runBlocking {
         // when
         val avg = withFactory { queryFactory ->
-            queryFactory.singleQuery<Double> {
+            queryFactory.singleQuery {
                 select(avg(OrderItem::price))
                 from(entity(OrderItem::class))
             }
@@ -155,7 +154,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest<S> : CriteriaQu
     fun sum() = runBlocking {
         // when
         val sum = withFactory { queryFactory ->
-            queryFactory.singleQuery<BigDecimal> {
+            queryFactory.singleQuery {
                 select(sum(OrderItem::price))
                 from(entity(OrderItem::class))
             }

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/from/AbstractCriteriaQueryDslFromIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/from/AbstractCriteriaQueryDslFromIntegrationTest.kt
@@ -39,7 +39,7 @@ abstract class AbstractCriteriaQueryDslFromIntegrationTest<S> : CriteriaQueryDsl
     fun join() = runBlocking {
         // when
         val purchaserIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 selectDistinct(col(Order::id))
                 from(entity(Order::class))
                 join(Order::groups)
@@ -64,7 +64,7 @@ abstract class AbstractCriteriaQueryDslFromIntegrationTest<S> : CriteriaQueryDsl
 
         // when
         val purchaserIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 selectDistinct(col(Delivery::id))
                 from(entity(Delivery::class))
                 join(Order::class, on { col(Delivery::orderId).equal(col(Order::id)) })
@@ -88,7 +88,7 @@ abstract class AbstractCriteriaQueryDslFromIntegrationTest<S> : CriteriaQueryDsl
 
         // when
         val zipCodes = withFactory { queryFactory ->
-            queryFactory.listQuery<String> {
+            queryFactory.listQuery {
                 selectDistinct(col(Address::zipCode))
                 from(entity(Delivery::class))
                 join(Order::class, on { col(Delivery::orderId).equal(col(Order::id)) })

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
@@ -81,7 +81,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
     fun getProjectByFullTimeEmployeesSalarySelectFullTimeEmployee() = runBlocking {
         withFactory { queryFactory ->
             // when
-            val employees = queryFactory.listQuery<FullTimeEmployee> {
+            val employees = queryFactory.listQuery {
                 val project: EntitySpec<Project> = Project::class.alias("project")
                 val fullTimeEmployee = FullTimeEmployee::class.alias("employee")
                 val employee = Employee::class.alias("employee")
@@ -166,7 +166,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
     fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary(fetch: Boolean) = runBlocking {
         withFactory { queryFactory ->
             // when
-            val sub = queryFactory.subquery<Long> {
+            val sub = queryFactory.subquery {
                 select(col(Project::id))
                 from(entity(Project::class))
 
@@ -179,7 +179,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest<S> : CriteriaQue
                     )
                 )
             }
-            val projects = queryFactory.listQuery<Project> {
+            val projects = queryFactory.listQuery {
                 val project = Project::class.alias("dedupeProject")
                 selectDistinct(project)
                 from(project)

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/groupby/AbstractCriteriaQueryDslGroupByIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/groupby/AbstractCriteriaQueryDslGroupByIntegrationTest.kt
@@ -23,7 +23,7 @@ abstract class AbstractCriteriaQueryDslGroupByIntegrationTest<S> : CriteriaQuery
     fun groupBy() = runBlocking {
         // when
         val purchaserIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::purchaserId))
                 from(entity(Order::class))
                 groupBy(col(Order::purchaserId))

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/having/AbstractCriteriaQueryDslHavingIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/having/AbstractCriteriaQueryDslHavingIntegrationTest.kt
@@ -24,7 +24,7 @@ abstract class AbstractCriteriaQueryDslHavingIntegrationTest<S> : CriteriaQueryD
     fun having() = runBlocking {
         // when
         val purchaserIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::purchaserId))
                 from(entity(Order::class))
                 groupBy(col(Order::purchaserId))

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/limit/AbstractCriteriaQueryDslLimitIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/limit/AbstractCriteriaQueryDslLimitIntegrationTest.kt
@@ -23,7 +23,7 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest<S> : CriteriaQueryDs
     fun offset() = runBlocking {
         // when
         val orderIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::id))
                 from(entity(Order::class))
                 orderBy(col(Order::id).asc())
@@ -39,7 +39,7 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest<S> : CriteriaQueryDs
     fun maxResults() = runBlocking {
         // when
         val orderIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::id))
                 from(entity(Order::class))
                 orderBy(col(Order::id).asc())
@@ -55,7 +55,7 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest<S> : CriteriaQueryDs
     fun limit() = runBlocking {
         // when
         val orderIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::id))
                 from(entity(Order::class))
                 orderBy(col(Order::id).asc())

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/orderby/AbstractCriteriaQueryDslOrderByIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/orderby/AbstractCriteriaQueryDslOrderByIntegrationTest.kt
@@ -22,7 +22,7 @@ abstract class AbstractCriteriaQueryDslOrderByIntegrationTest<S> : CriteriaQuery
     fun asc() = runBlocking {
         // when
         val orderIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::id))
                 from(entity(Order::class))
                 orderBy(col(Order::id).asc())
@@ -37,7 +37,7 @@ abstract class AbstractCriteriaQueryDslOrderByIntegrationTest<S> : CriteriaQuery
     fun desc() = runBlocking {
         // when
         val orderIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::id))
                 from(entity(Order::class))
                 orderBy(col(Order::id).desc())

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/predicate/AbstractCriteriaQueryDslPredicateIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/predicate/AbstractCriteriaQueryDslPredicateIntegrationTest.kt
@@ -1,9 +1,12 @@
 package com.linecorp.kotlinjdsl.test.reactive.querydsl.predicate
 
 import com.linecorp.kotlinjdsl.listQuery
+import com.linecorp.kotlinjdsl.query.spec.expression.EntitySpec
 import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.singleQuery
+import com.linecorp.kotlinjdsl.subquery
 import com.linecorp.kotlinjdsl.test.entity.order.Order
+import com.linecorp.kotlinjdsl.test.entity.order.OrderGroup
 import com.linecorp.kotlinjdsl.test.entity.order.OrderItem
 import com.linecorp.kotlinjdsl.test.reactive.CriteriaQueryDslIntegrationTest
 import com.linecorp.kotlinjdsl.test.reactive.runBlocking
@@ -18,15 +21,15 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
 
     private val order1 = order {
         purchaserId = 1000
-        groups = hashSetOf(orderGroup { items = hashSetOf(orderItem1, orderItem2) })
+        groups = hashSetOf(orderGroup { items = hashSetOf(orderItem1, orderItem2); orderGroupName = "orderGroup1" })
     }
     private val order2 = order {
         purchaserId = 1000
-        groups = hashSetOf(orderGroup { items = hashSetOf(orderItem3) })
+        groups = hashSetOf(orderGroup { items = hashSetOf(orderItem3);orderGroupName = "orderGroup2" })
     }
     private val order3 = order {
         purchaserId = 2000
-        groups = hashSetOf(orderGroup { items = hashSetOf(orderItem4) })
+        groups = hashSetOf(orderGroup { items = hashSetOf(orderItem4); orderGroupName = "orderGroup3" })
     }
 
     private val orders = listOf(order1, order2, order3)
@@ -301,5 +304,58 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
 
         // then
         assertThat(orderItemIds).isEmpty()
+    }
+
+    @Test
+    fun `exists - subquery`() = runBlocking {
+        val existFoundOrders = withFactory { queryFactory ->
+            queryFactory.listQuery<Order> {
+                val entity: EntitySpec<Order> = entity(Order::class)
+                select(entity)
+                from(entity)
+                where(
+                    exists(queryFactory.subquery<Long> {
+                        val orderGroupEntity = entity(OrderGroup::class)
+                        select(literal(1))
+                        from(orderGroupEntity)
+                        where(
+                            and(
+                                col(OrderGroup::orderGroupName).equal("orderGroup1"),
+                                col(OrderGroup::order).equal(entity)
+                            )
+                        )
+                    })
+                )
+            }
+        }
+
+        assertThat(existFoundOrders.map { it.id }).isEqualTo(listOf(order1.id))
+    }
+
+    @Test
+    fun `notExists - subquery`() = runBlocking {
+
+        val existFoundOrders = withFactory { queryFactory ->
+            queryFactory.listQuery<Order> {
+                val entity: EntitySpec<Order> = entity(Order::class)
+                select(entity)
+                from(entity)
+                where(
+                    notExists(queryFactory.subquery<Long> {
+                        val orderGroupEntity = entity(OrderGroup::class)
+                        select(literal(1))
+                        from(orderGroupEntity)
+                        where(
+                            and(
+                                col(OrderGroup::orderGroupName).equal("orderGroup1"),
+                                col(OrderGroup::order).equal(entity)
+                            )
+                        )
+                    })
+                )
+            }
+        }
+
+        assertThat(existFoundOrders.map { it.id }).isEqualTo(listOf(order2.id, order3.id))
     }
 }

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/predicate/AbstractCriteriaQueryDslPredicateIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/predicate/AbstractCriteriaQueryDslPredicateIntegrationTest.kt
@@ -44,7 +44,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun not() = runBlocking {
         // when
         val orderIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::id))
                 from(entity(Order::class))
                 where(not(col(Order::purchaserId).equal(1000)))
@@ -60,7 +60,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun and() = runBlocking {
         // when
         val orderItemId = withFactory { queryFactory ->
-            queryFactory.singleQuery<Long> {
+            queryFactory.singleQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(
@@ -80,7 +80,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun or() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(
@@ -100,7 +100,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun equal() = runBlocking {
         // when
         val orderItemId = withFactory { queryFactory ->
-            queryFactory.singleQuery<Long> {
+            queryFactory.singleQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::id).equal(orderItem1.id))
@@ -115,7 +115,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun notEqual() = runBlocking {
         // when
         val orderItemId = withFactory { queryFactory ->
-            queryFactory.singleQuery<Long> {
+            queryFactory.singleQuery {
                 select(col(Order::id))
                 from(entity(Order::class))
                 where(col(Order::purchaserId).notEqual(1000))
@@ -130,7 +130,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun `in`() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::id).`in`(orderItem1.id, orderItem2.id))
@@ -145,7 +145,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun lessThanOrEqualTo() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::price).lessThanOrEqualTo(20.toBigDecimal()))
@@ -160,7 +160,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun lessThan() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::price).lessThan(20.toBigDecimal()))
@@ -175,7 +175,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun greaterThanOrEqualTo() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::price).greaterThanOrEqualTo(20.toBigDecimal()))
@@ -190,7 +190,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun greaterThan() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::price).greaterThan(20.toBigDecimal()))
@@ -205,7 +205,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun between() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::price).between(20.toBigDecimal(), 40.toBigDecimal()))
@@ -220,7 +220,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun isTrue() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::claimed).isTrue())
@@ -235,7 +235,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun isFalse() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::claimed).isFalse())
@@ -250,7 +250,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun isNull() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::productImage).isNull())
@@ -265,7 +265,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun isNotNull() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::productImage).isNotNull())
@@ -280,7 +280,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun like() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::productName).like("test%"))
@@ -295,7 +295,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     fun notLike() = runBlocking {
         // when
         val orderItemIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(OrderItem::id))
                 from(entity(OrderItem::class))
                 where(col(OrderItem::productName).notLike("test%"))
@@ -307,9 +307,10 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     }
 
     @Test
-    fun `exists - subquery`() = runBlocking {
+    fun exists() = runBlocking {
+        // when
         val existFoundOrders = withFactory { queryFactory ->
-            queryFactory.listQuery<Order> {
+            queryFactory.listQuery {
                 val entity: EntitySpec<Order> = entity(Order::class)
                 select(entity)
                 from(entity)
@@ -329,14 +330,15 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
             }
         }
 
+        // then
         assertThat(existFoundOrders.map { it.id }).isEqualTo(listOf(order1.id))
     }
 
     @Test
-    fun `notExists - subquery`() = runBlocking {
-
+    fun notExists() = runBlocking {
+        // when
         val existFoundOrders = withFactory { queryFactory ->
-            queryFactory.listQuery<Order> {
+            queryFactory.listQuery {
                 val entity: EntitySpec<Order> = entity(Order::class)
                 select(entity)
                 from(entity)
@@ -356,6 +358,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
             }
         }
 
+        // then
         assertThat(existFoundOrders.map { it.id }).isEqualTo(listOf(order2.id, order3.id))
     }
 }

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/predicate/AbstractCriteriaQueryDslPredicateIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/predicate/AbstractCriteriaQueryDslPredicateIntegrationTest.kt
@@ -25,7 +25,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest<S> : CriteriaQue
     }
     private val order2 = order {
         purchaserId = 1000
-        groups = hashSetOf(orderGroup { items = hashSetOf(orderItem3);orderGroupName = "orderGroup2" })
+        groups = hashSetOf(orderGroup { items = hashSetOf(orderItem3); orderGroupName = "orderGroup2" })
     }
     private val order3 = order {
         purchaserId = 2000

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -37,7 +37,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest<S> : CriteriaQueryD
     fun `singleQuery - select single expression`() = runBlocking {
         // when
         val purchaserId = withFactory { queryFactory ->
-            queryFactory.singleQuery<Long> {
+            queryFactory.singleQuery {
                 select(max(Order::id))
                 from(entity(Order::class))
             }
@@ -66,7 +66,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest<S> : CriteriaQueryD
     fun `listQuery - select single column`() = runBlocking {
         // when
         val orderIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::id))
                 from(entity(Order::class))
                 orderBy(col(Order::id).asc())
@@ -81,7 +81,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest<S> : CriteriaQueryD
     fun `listQuery - select single expression`() = runBlocking {
         // when
         val counts = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(count(Order::id))
                 from(entity(Order::class))
                 groupBy(col(Order::purchaserId))
@@ -95,7 +95,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest<S> : CriteriaQueryD
     @Test
     fun `listQuery - select distinct single column`() = runBlocking {
         val purchaserIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 selectDistinct(col(Order::purchaserId))
                 from(entity(Order::class))
                 orderBy(col(Order::purchaserId).asc())
@@ -113,14 +113,14 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest<S> : CriteriaQueryD
     @Test
     open fun `listQuery - subquery in select, subquery in from`() = runBlocking {
         val counts = withFactory { queryFactory ->
-            val subquery = queryFactory.subquery<Long> {
+            val subquery = queryFactory.subquery {
                 val order = entity(Order::class, "o")
 
                 select(count(col(order, Order::id)))
                 from(order)
                 where(col(order, Order::purchaserId).equal(col(Order::purchaserId)))
             }
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(subquery)
                 from(entity(Order::class))
                 orderBy(col(Order::id).asc())
@@ -190,7 +190,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest<S> : CriteriaQueryD
     fun `nestedCol - implicit join and fetch column value`() = runBlocking {
         // when
         val result = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(nestedCol(col(OrderGroup::order), Order::purchaserId))
                 from(entity(OrderGroup::class))
                 join(OrderGroup::address)

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/set/AbstractCriteriaQueryDslUpdateByIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/set/AbstractCriteriaQueryDslUpdateByIntegrationTest.kt
@@ -27,7 +27,7 @@ abstract class AbstractCriteriaQueryDslUpdateByIntegrationTest<S> : CriteriaQuer
     fun update() = runBlocking {
         // when
         val purchaserIds = withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::purchaserId))
                 from(entity(Order::class))
                 groupBy(col(Order::purchaserId))
@@ -45,7 +45,7 @@ abstract class AbstractCriteriaQueryDslUpdateByIntegrationTest<S> : CriteriaQuer
 
         // then
         assertThat(withFactory { queryFactory ->
-            queryFactory.listQuery<Long> {
+            queryFactory.listQuery {
                 select(col(Order::purchaserId))
                 from(entity(Order::class))
                 groupBy(col(Order::purchaserId))
@@ -109,7 +109,7 @@ abstract class AbstractCriteriaQueryDslUpdateByIntegrationTest<S> : CriteriaQuer
 
         // then
         assertThat(withFactory { queryFactory ->
-            queryFactory.listQuery<String> {
+            queryFactory.listQuery {
                 select(col(OrderGroup::orderGroupName))
                 from(entity(OrderGroup::class))
                 join(OrderGroup::order)
@@ -118,7 +118,7 @@ abstract class AbstractCriteriaQueryDslUpdateByIntegrationTest<S> : CriteriaQuer
         }).containsOnly("newGroupName")
 
         assertThat(withFactory { queryFactory ->
-            queryFactory.listQuery<String> {
+            queryFactory.listQuery {
                 select(col(OrderGroup::orderGroupName))
                 from(entity(OrderGroup::class))
                 join(OrderGroup::order)

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
@@ -62,7 +62,7 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest<S> : CriteriaQueryDs
     fun `where using subquery`() = runBlocking {
         // when
         val orderIds = withFactory { queryFactory ->
-            val subquery = queryFactory.subquery<Long> {
+            val subquery = queryFactory.subquery {
                 val order = entity(Order::class, "o")
 
                 select(col(order, Order::id))
@@ -84,7 +84,7 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest<S> : CriteriaQueryDs
     fun `where using subquery with ref key`() = runBlocking {
         // when
         val orderIds = withFactory { queryFactory ->
-            val subQuery = queryFactory.subquery<Long> {
+            val subQuery = queryFactory.subquery {
                 select(nestedCol(col(OrderGroup::order), Order::id))
                 from(entity(OrderGroup::class))
                 join(OrderGroup::address)

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/expression/AbstractCriteriaQueryDslExpressionIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/expression/AbstractCriteriaQueryDslExpressionIntegrationTest.kt
@@ -9,7 +9,6 @@ import com.linecorp.kotlinjdsl.test.entity.test.TestTable
 import com.linecorp.kotlinjdsl.test.integration.AbstractCriteriaQueryDslIntegrationTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
 
 abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCriteriaQueryDslIntegrationTest() {
     private val orderItem1 = orderItem { productName = "test1"; productImage = null; price = 10; claimed = true }
@@ -53,7 +52,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun entityAlias() {
         // when
-        val orders = queryFactory.listQuery<Order> {
+        val orders = queryFactory.listQuery {
             val entity = entity(Order::class, "orderAlias")
             select(entity)
             from(entity)
@@ -66,7 +65,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun literal() {
         // when
-        val literals = queryFactory.listQuery<Int> {
+        val literals = queryFactory.listQuery {
             select(literal(10))
             from(entity(Order::class))
         }
@@ -78,7 +77,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun nullLiteral() {
         // when
-        val literals = queryFactory.listQuery<Int?> {
+        val literals = queryFactory.listQuery {
             select(nullLiteral(Int::class.java))
             from(entity(Order::class))
         }
@@ -90,7 +89,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun column() {
         // when
-        val literals = queryFactory.listQuery<Long> {
+        val literals = queryFactory.listQuery {
             select(column(Order::id))
             from(entity(Order::class))
         }
@@ -102,7 +101,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun max() {
         // when
-        val max = queryFactory.singleQuery<BigDecimal> {
+        val max = queryFactory.singleQuery {
             select(max(OrderItem::price))
             from(entity(OrderItem::class))
         }
@@ -114,7 +113,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun min() {
         // when
-        val min = queryFactory.singleQuery<BigDecimal> {
+        val min = queryFactory.singleQuery {
             select(min(OrderItem::price))
             from(entity(OrderItem::class))
         }
@@ -126,7 +125,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun avg() {
         // when
-        val avg = queryFactory.singleQuery<Double> {
+        val avg = queryFactory.singleQuery {
             select(avg(OrderItem::price))
             from(entity(OrderItem::class))
         }
@@ -138,7 +137,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun sum() {
         // when
-        val sum = queryFactory.singleQuery<BigDecimal> {
+        val sum = queryFactory.singleQuery {
             select(sum(OrderItem::price))
             from(entity(OrderItem::class))
         }
@@ -187,7 +186,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun count() {
         // when
-        val count = queryFactory.singleQuery<Long> {
+        val count = queryFactory.singleQuery {
             select(count(OrderItem::id))
             from(entity(OrderItem::class))
         }
@@ -199,7 +198,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun countExpression() {
         // when
-        val count = queryFactory.singleQuery<Long> {
+        val count = queryFactory.singleQuery {
             select(
                 count(literal(1))
             )
@@ -213,7 +212,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun countDistinct() {
         // when
-        val count = queryFactory.singleQuery<Long> {
+        val count = queryFactory.singleQuery {
             select(countDistinct(OrderItem::productName))
             from(entity(OrderItem::class))
         }
@@ -225,7 +224,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun greatest() {
         // when
-        val greatest = queryFactory.singleQuery<String> {
+        val greatest = queryFactory.singleQuery {
             select(greatest(OrderItem::productName))
             from(entity(OrderItem::class))
         }
@@ -237,7 +236,7 @@ abstract class AbstractCriteriaQueryDslExpressionIntegrationTest : AbstractCrite
     @Test
     fun least() {
         // when
-        val least = queryFactory.singleQuery<String> {
+        val least = queryFactory.singleQuery {
             select(least(OrderItem::productName))
             from(entity(OrderItem::class))
         }

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/from/AbstractCriteriaQueryDslFromIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/from/AbstractCriteriaQueryDslFromIntegrationTest.kt
@@ -38,7 +38,7 @@ abstract class AbstractCriteriaQueryDslFromIntegrationTest : AbstractCriteriaQue
     @Test
     fun join() {
         // when
-        val purchaserIds = queryFactory.listQuery<Long> {
+        val purchaserIds = queryFactory.listQuery {
             selectDistinct(col(Order::id))
             from(entity(Order::class))
             join(Order::groups)
@@ -83,7 +83,7 @@ abstract class AbstractCriteriaQueryDslFromIntegrationTest : AbstractCriteriaQue
         entityManager.flushAndClear()
 
         // when
-        val zipCodes = queryFactory.listQuery<String> {
+        val zipCodes = queryFactory.listQuery {
             selectDistinct(col(Address::zipCode))
             from(entity(Delivery::class))
             join(Order::class, on { col(Delivery::orderId).equal(col(Order::id)) })

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/from/AbstractCriteriaQueryDslFromTreatIntegrationTest.kt
@@ -80,7 +80,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriter
     @Test
     open fun getProjectByFullTimeEmployeesSalarySelectFullTimeEmployee() {
         // when
-        val employees = queryFactory.listQuery<FullTimeEmployee> {
+        val employees = queryFactory.listQuery {
             val project: EntitySpec<Project> = Project::class.alias("project")
             val fullTimeEmployee = FullTimeEmployee::class.alias("fe")
             val employee = Employee::class.alias("e")
@@ -162,7 +162,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriter
 
     private fun getProjectsWithSupervisorSalaryEqualBySubqueryFullTimeEmployeesSalaryAndPartTimeEmployeeWeeklySalary(fetch: Boolean) {
         // when
-        val sub = queryFactory.subquery<Long> {
+        val sub = queryFactory.subquery {
             select(col(Project::id))
             from(entity(Project::class))
 
@@ -175,7 +175,7 @@ abstract class AbstractCriteriaQueryDslFromTreatIntegrationTest : AbstractCriter
                 )
             )
         }
-        val projects = queryFactory.listQuery<Project> {
+        val projects = queryFactory.listQuery {
             val project = Project::class.alias("dedupeProject")
             selectDistinct(project)
             from(project)

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/groupby/AbstractCriteriaQueryDslGroupByIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/groupby/AbstractCriteriaQueryDslGroupByIntegrationTest.kt
@@ -21,7 +21,7 @@ abstract class AbstractCriteriaQueryDslGroupByIntegrationTest : AbstractCriteria
     @Test
     fun groupBy() {
         // when
-        val purchaserIds = queryFactory.listQuery<Long> {
+        val purchaserIds = queryFactory.listQuery {
             select(col(Order::purchaserId))
             from(entity(Order::class))
             groupBy(col(Order::purchaserId))

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/having/AbstractCriteriaQueryDslHavingIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/having/AbstractCriteriaQueryDslHavingIntegrationTest.kt
@@ -22,7 +22,7 @@ abstract class AbstractCriteriaQueryDslHavingIntegrationTest : AbstractCriteriaQ
     @Test
     fun having() {
         // when
-        val purchaserIds = queryFactory.listQuery<Long> {
+        val purchaserIds = queryFactory.listQuery {
             select(col(Order::purchaserId))
             from(entity(Order::class))
             groupBy(col(Order::purchaserId))

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/limit/AbstractCriteriaQueryDslLimitIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/limit/AbstractCriteriaQueryDslLimitIntegrationTest.kt
@@ -21,7 +21,7 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest : AbstractCriteriaQu
     @Test
     fun offset() {
         // when
-        val orderIds = queryFactory.listQuery<Long> {
+        val orderIds = queryFactory.listQuery {
             select(col(Order::id))
             from(entity(Order::class))
             orderBy(col(Order::id).asc())
@@ -35,7 +35,7 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest : AbstractCriteriaQu
     @Test
     fun maxResults() {
         // when
-        val orderIds = queryFactory.listQuery<Long> {
+        val orderIds = queryFactory.listQuery {
             select(col(Order::id))
             from(entity(Order::class))
             orderBy(col(Order::id).asc())
@@ -49,7 +49,7 @@ abstract class AbstractCriteriaQueryDslLimitIntegrationTest : AbstractCriteriaQu
     @Test
     fun limit() {
         // when
-        val orderIds = queryFactory.listQuery<Long> {
+        val orderIds = queryFactory.listQuery {
             select(col(Order::id))
             from(entity(Order::class))
             orderBy(col(Order::id).asc())

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/orderby/AbstractCriteriaQueryDslOrderByIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/orderby/AbstractCriteriaQueryDslOrderByIntegrationTest.kt
@@ -20,7 +20,7 @@ abstract class AbstractCriteriaQueryDslOrderByIntegrationTest : AbstractCriteria
     @Test
     fun asc() {
         // when
-        val orderIds = queryFactory.listQuery<Long> {
+        val orderIds = queryFactory.listQuery {
             select(col(Order::id))
             from(entity(Order::class))
             orderBy(col(Order::id).asc())
@@ -33,7 +33,7 @@ abstract class AbstractCriteriaQueryDslOrderByIntegrationTest : AbstractCriteria
     @Test
     fun desc() {
         // when
-        val orderIds = queryFactory.listQuery<Long> {
+        val orderIds = queryFactory.listQuery {
             select(col(Order::id))
             from(entity(Order::class))
             orderBy(col(Order::id).desc())

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/predicate/AbstractCriteriaQueryDslPredicateIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/predicate/AbstractCriteriaQueryDslPredicateIntegrationTest.kt
@@ -42,7 +42,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun not() {
         // when
-        val orderIds = queryFactory.listQuery<Long> {
+        val orderIds = queryFactory.listQuery {
             select(col(Order::id))
             from(entity(Order::class))
             where(not(col(Order::purchaserId).equal(1000)))
@@ -56,7 +56,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun and() {
         // when
-        val orderItemId = queryFactory.singleQuery<Long> {
+        val orderItemId = queryFactory.singleQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(
@@ -74,7 +74,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun or() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(
@@ -92,7 +92,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun equal() {
         // when
-        val orderItemId = queryFactory.singleQuery<Long> {
+        val orderItemId = queryFactory.singleQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::id).equal(orderItem1.id))
@@ -105,7 +105,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun notEqual() {
         // when
-        val orderItemId = queryFactory.singleQuery<Long> {
+        val orderItemId = queryFactory.singleQuery {
             select(col(Order::id))
             from(entity(Order::class))
             where(col(Order::purchaserId).notEqual(1000))
@@ -118,7 +118,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun `in`() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::id).`in`(orderItem1.id, orderItem2.id))
@@ -131,7 +131,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun lessThanOrEqualTo() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::price).lessThanOrEqualTo(20.toBigDecimal()))
@@ -144,7 +144,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun lessThan() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::price).lessThan(20.toBigDecimal()))
@@ -157,7 +157,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun greaterThanOrEqualTo() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::price).greaterThanOrEqualTo(20.toBigDecimal()))
@@ -170,7 +170,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun greaterThan() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::price).greaterThan(20.toBigDecimal()))
@@ -183,7 +183,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun between() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::price).between(20.toBigDecimal(), 40.toBigDecimal()))
@@ -196,7 +196,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun isTrue() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::claimed).isTrue())
@@ -209,7 +209,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun isFalse() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::claimed).isFalse())
@@ -222,7 +222,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun isNull() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::productImage).isNull())
@@ -235,7 +235,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun isNotNull() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::productImage).isNotNull())
@@ -248,7 +248,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun like() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::productName).like("test%"))
@@ -261,7 +261,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     @Test
     fun notLike() {
         // when
-        val orderItemIds = queryFactory.listQuery<Long> {
+        val orderItemIds = queryFactory.listQuery {
             select(col(OrderItem::id))
             from(entity(OrderItem::class))
             where(col(OrderItem::productName).notLike("test%"))
@@ -272,9 +272,9 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
     }
 
     @Test
-    fun `exists - subquery`() {
-
-        val existFoundOrders = queryFactory.listQuery<Order> {
+    fun exists() {
+        // when
+        val existFoundOrders = queryFactory.listQuery {
             val entity: EntitySpec<Order> = entity(Order::class)
             select(entity)
             from(entity)
@@ -293,13 +293,14 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
             )
         }
 
+        // then
         assertThat(existFoundOrders.map { it.id }).isEqualTo(listOf(order1.id))
     }
 
     @Test
-    fun `notExists - subquery`() {
-
-        val existFoundOrders = queryFactory.listQuery<Order> {
+    fun notExists() {
+        // when
+        val existFoundOrders = queryFactory.listQuery {
             val entity: EntitySpec<Order> = entity(Order::class)
             select(entity)
             from(entity)
@@ -318,6 +319,7 @@ abstract class AbstractCriteriaQueryDslPredicateIntegrationTest : AbstractCriter
             )
         }
 
+        // then
         assertThat(existFoundOrders.map { it.id }).isEqualTo(listOf(order2.id, order3.id))
     }
 }

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/select/AbstractCriteriaQueryDslSelectIntegrationTest.kt
@@ -102,7 +102,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
      */
     @Test
     open fun `listQuery - subquery in select, subquery in from`() {
-        val subquery = queryFactory.subquery<Long> {
+        val subquery = queryFactory.subquery {
             val order = entity(Order::class, "o")
 
             select(count(col(order, Order::id)))
@@ -172,7 +172,7 @@ abstract class AbstractCriteriaQueryDslSelectIntegrationTest : AbstractCriteriaQ
     @Test
     fun `nestedCol - implicit join and fetch column value`() {
         // when
-        val result = queryFactory.listQuery<Long> {
+        val result = queryFactory.listQuery {
             select(nestedCol(col(OrderGroup::order), Order::purchaserId))
             from(entity(OrderGroup::class))
             join(OrderGroup::address)

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/set/AbstractCriteriaQueryDslUpdateByIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/set/AbstractCriteriaQueryDslUpdateByIntegrationTest.kt
@@ -27,7 +27,7 @@ abstract class AbstractCriteriaQueryDslUpdateByIntegrationTest : AbstractCriteri
     @Test
     fun update() {
         // when
-        val purchaserIds = queryFactory.listQuery<Long> {
+        val purchaserIds = queryFactory.listQuery {
             select(col(Order::purchaserId))
             from(entity(Order::class))
             groupBy(col(Order::purchaserId))
@@ -103,14 +103,14 @@ abstract class AbstractCriteriaQueryDslUpdateByIntegrationTest : AbstractCriteri
         }.executeUpdate()
 
         // then
-        assertThat(queryFactory.listQuery<String> {
+        assertThat(queryFactory.listQuery {
             select(col(OrderGroup::orderGroupName))
             from(entity(OrderGroup::class))
             join(OrderGroup::order)
             where(col(Order::id).equal(order1.id))
         }).containsOnly("newGroupName")
 
-        assertThat(queryFactory.listQuery<String> {
+        assertThat(queryFactory.listQuery {
             select(col(OrderGroup::orderGroupName))
             from(entity(OrderGroup::class))
             join(OrderGroup::order)

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/querydsl/where/AbstractCriteriaQueryDslWhereIntegrationTest.kt
@@ -55,7 +55,7 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest : AbstractCriteriaQu
     @Test
     fun `where using subquery`() {
         // when
-        val subquery = queryFactory.subquery<Long> {
+        val subquery = queryFactory.subquery {
             val order = entity(Order::class, "o")
 
             select(col(order, Order::id))
@@ -63,7 +63,7 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest : AbstractCriteriaQu
             where(col(order, Order::purchaserId).lessThan(2000))
         }
 
-        val orderIds = queryFactory.listQuery<Long> {
+        val orderIds = queryFactory.listQuery {
             select(col(Order::id))
             from(entity(Order::class))
             where(col(Order::id).`in`(subquery))
@@ -76,7 +76,7 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest : AbstractCriteriaQu
     @Test
     fun `where using subquery with ref key`() {
         // when
-        val subQuery = queryFactory.subquery<Long> {
+        val subQuery = queryFactory.subquery {
             select(nestedCol(col(OrderGroup::order), Order::id))
             from(entity(OrderGroup::class))
             join(OrderGroup::address)
@@ -84,7 +84,7 @@ abstract class AbstractCriteriaQueryDslWhereIntegrationTest : AbstractCriteriaQu
             where(col(Address::zipCode).equal("zipCode1"))
         }
 
-        val orderIds = queryFactory.listQuery<Long> {
+        val orderIds = queryFactory.listQuery {
             select(col(Order::id))
             from(entity(Order::class))
             where(col(Order::id).`in`(subQuery))


### PR DESCRIPTION
# Motivation:

* There are not stmt for creating exists sql stmt in jdsl project

# Modifications:

* Add ExistsSpec to enable `exists`/`not exist` sql stmt

# Commit Convention Rule

* Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)

| Commit type | Description                                             |
|-------------|---------------------------------------------------------|
| feat        | New Feature                                             |
| fix         | Fix bug                                                 |
| docs        | Documentation only changed                              |
| ci          | Change CI configuration                                 |
| refactor    | Not a bug fix or add feature, just refactoring code     |
| test        | Add Test case or fix wrong test case                    |
| style       | Only change the code style(ex. white-space, formatting) |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

* If you want to add some more `commit type` please describe it on the **Pull Request**


# Result:

* User can use exists query if they want!

# Closes 
* closes #123