### PR TITLE
Fixing in treating empty lists as a conjunction.

### DIFF
--- a/query-jakarta/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InValueSpec.kt
+++ b/query-jakarta/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InValueSpec.kt
@@ -13,7 +13,7 @@ data class InValueSpec<T>(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        if (rights.isEmpty()) return criteriaBuilder.conjunction()
+        if (rights.isEmpty()) return criteriaBuilder.disjunction()
 
         return criteriaBuilder.`in`(left.toCriteriaExpression(froms, query, criteriaBuilder)).apply {
             rights.forEach { value(it) }
@@ -25,7 +25,7 @@ data class InValueSpec<T>(
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        if (rights.isEmpty()) return criteriaBuilder.conjunction()
+        if (rights.isEmpty()) return criteriaBuilder.disjunction()
 
         return criteriaBuilder.`in`(left.toCriteriaExpression(froms, query, criteriaBuilder)).apply {
             rights.forEach { value(it) }
@@ -37,7 +37,7 @@ data class InValueSpec<T>(
         query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        if (rights.isEmpty()) return criteriaBuilder.conjunction()
+        if (rights.isEmpty()) return criteriaBuilder.disjunction()
 
         return criteriaBuilder.`in`(left.toCriteriaExpression(froms, query, criteriaBuilder)).apply {
             rights.forEach { value(it) }

--- a/query-jakarta/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InValueSpecTest.kt
+++ b/query-jakarta/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InValueSpecTest.kt
@@ -69,19 +69,19 @@ internal class InValueSpecTest : WithKotlinJdslAssertions {
         // given
         val leftExpressionSpec: ExpressionSpec<Int> = mockk()
 
-        val emptyPredicate: Predicate = mockk()
+        val falsePredicate: Predicate = mockk()
 
-        every { criteriaBuilder.conjunction() } returns emptyPredicate
+        every { criteriaBuilder.disjunction() } returns falsePredicate
 
         // when
         val actual = InValueSpec(leftExpressionSpec, emptyList())
             .toCriteriaPredicate(froms, query, criteriaBuilder)
 
         // then
-        assertThat(actual).isEqualTo(emptyPredicate)
+        assertThat(actual).isEqualTo(falsePredicate)
 
         verify(exactly = 1) {
-            criteriaBuilder.conjunction()
+            criteriaBuilder.disjunction()
         }
 
         confirmVerified(froms, query, criteriaBuilder)
@@ -126,19 +126,19 @@ internal class InValueSpecTest : WithKotlinJdslAssertions {
         // given
         val leftExpressionSpec: ExpressionSpec<Int> = mockk()
 
-        val emptyPredicate: Predicate = mockk()
+        val falsePredicate: Predicate = mockk()
 
-        every { criteriaBuilder.conjunction() } returns emptyPredicate
+        every { criteriaBuilder.disjunction() } returns falsePredicate
 
         // when
         val actual = InValueSpec(leftExpressionSpec, emptyList())
             .toCriteriaPredicate(froms, updateQuery, criteriaBuilder)
 
         // then
-        assertThat(actual).isEqualTo(emptyPredicate)
+        assertThat(actual).isEqualTo(falsePredicate)
 
         verify(exactly = 1) {
-            criteriaBuilder.conjunction()
+            criteriaBuilder.disjunction()
         }
 
         confirmVerified(froms, updateQuery, criteriaBuilder)
@@ -183,19 +183,19 @@ internal class InValueSpecTest : WithKotlinJdslAssertions {
         // given
         val leftExpressionSpec: ExpressionSpec<Int> = mockk()
 
-        val emptyPredicate: Predicate = mockk()
+        val falsePredicate: Predicate = mockk()
 
-        every { criteriaBuilder.conjunction() } returns emptyPredicate
+        every { criteriaBuilder.disjunction() } returns falsePredicate
 
         // when
         val actual = InValueSpec(leftExpressionSpec, emptyList())
             .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
 
         // then
-        assertThat(actual).isEqualTo(emptyPredicate)
+        assertThat(actual).isEqualTo(falsePredicate)
 
         verify(exactly = 1) {
-            criteriaBuilder.conjunction()
+            criteriaBuilder.disjunction()
         }
 
         confirmVerified(froms, deleteQuery, criteriaBuilder)

--- a/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InValueSpec.kt
+++ b/query/src/main/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InValueSpec.kt
@@ -13,7 +13,7 @@ data class InValueSpec<T>(
         query: AbstractQuery<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        if (rights.isEmpty()) return criteriaBuilder.conjunction()
+        if (rights.isEmpty()) return criteriaBuilder.disjunction()
 
         return criteriaBuilder.`in`(left.toCriteriaExpression(froms, query, criteriaBuilder)).apply {
             rights.forEach { value(it) }
@@ -25,7 +25,7 @@ data class InValueSpec<T>(
         query: CriteriaUpdate<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        if (rights.isEmpty()) return criteriaBuilder.conjunction()
+        if (rights.isEmpty()) return criteriaBuilder.disjunction()
 
         return criteriaBuilder.`in`(left.toCriteriaExpression(froms, query, criteriaBuilder)).apply {
             rights.forEach { value(it) }
@@ -37,7 +37,7 @@ data class InValueSpec<T>(
         query: CriteriaDelete<*>,
         criteriaBuilder: CriteriaBuilder
     ): Predicate {
-        if (rights.isEmpty()) return criteriaBuilder.conjunction()
+        if (rights.isEmpty()) return criteriaBuilder.disjunction()
 
         return criteriaBuilder.`in`(left.toCriteriaExpression(froms, query, criteriaBuilder)).apply {
             rights.forEach { value(it) }

--- a/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InValueSpecTest.kt
+++ b/query/src/test/kotlin/com/linecorp/kotlinjdsl/query/spec/predicate/InValueSpecTest.kt
@@ -69,19 +69,19 @@ internal class InValueSpecTest : WithKotlinJdslAssertions {
         // given
         val leftExpressionSpec: ExpressionSpec<Int> = mockk()
 
-        val emptyPredicate: Predicate = mockk()
+        val falsePredicate: Predicate = mockk()
 
-        every { criteriaBuilder.conjunction() } returns emptyPredicate
+        every { criteriaBuilder.disjunction() } returns falsePredicate
 
         // when
         val actual = InValueSpec(leftExpressionSpec, emptyList())
             .toCriteriaPredicate(froms, query, criteriaBuilder)
 
         // then
-        assertThat(actual).isEqualTo(emptyPredicate)
+        assertThat(actual).isEqualTo(falsePredicate)
 
         verify(exactly = 1) {
-            criteriaBuilder.conjunction()
+            criteriaBuilder.disjunction()
         }
 
         confirmVerified(froms, query, criteriaBuilder)
@@ -126,19 +126,19 @@ internal class InValueSpecTest : WithKotlinJdslAssertions {
         // given
         val leftExpressionSpec: ExpressionSpec<Int> = mockk()
 
-        val emptyPredicate: Predicate = mockk()
+        val falsePredicate: Predicate = mockk()
 
-        every { criteriaBuilder.conjunction() } returns emptyPredicate
+        every { criteriaBuilder.disjunction() } returns falsePredicate
 
         // when
         val actual = InValueSpec(leftExpressionSpec, emptyList())
             .toCriteriaPredicate(froms, updateQuery, criteriaBuilder)
 
         // then
-        assertThat(actual).isEqualTo(emptyPredicate)
+        assertThat(actual).isEqualTo(falsePredicate)
 
         verify(exactly = 1) {
-            criteriaBuilder.conjunction()
+            criteriaBuilder.disjunction()
         }
 
         confirmVerified(froms, updateQuery, criteriaBuilder)
@@ -183,19 +183,19 @@ internal class InValueSpecTest : WithKotlinJdslAssertions {
         // given
         val leftExpressionSpec: ExpressionSpec<Int> = mockk()
 
-        val emptyPredicate: Predicate = mockk()
+        val falsePredicate: Predicate = mockk()
 
-        every { criteriaBuilder.conjunction() } returns emptyPredicate
+        every { criteriaBuilder.disjunction() } returns falsePredicate
 
         // when
         val actual = InValueSpec(leftExpressionSpec, emptyList())
             .toCriteriaPredicate(froms, deleteQuery, criteriaBuilder)
 
         // then
-        assertThat(actual).isEqualTo(emptyPredicate)
+        assertThat(actual).isEqualTo(falsePredicate)
 
         verify(exactly = 1) {
-            criteriaBuilder.conjunction()
+            criteriaBuilder.disjunction()
         }
 
         confirmVerified(froms, deleteQuery, criteriaBuilder)

--- a/test-fixture/integration-jakarta/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
+++ b/test-fixture/integration-jakarta/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
@@ -40,6 +40,32 @@ abstract class AbstractCriteriaDeleteIntegrationTest : AbstractCriteriaQueryDslI
     }
 
     @Test
+    fun deleteEmptyList() {
+        // when
+        val address1 = orderAddress { }
+
+        entityManager.run {
+            persistAll(address1)
+            flushAndClear()
+        }
+
+        queryFactory.deleteQuery<OrderAddress> {
+            where(col(OrderAddress::id).`in`(emptyList<Long>()))
+        }.executeUpdate()
+
+        // when
+        val query = queryFactory.selectQuery<OrderAddress> {
+            select(entity(OrderAddress::class))
+            from(entity(OrderAddress::class))
+            where(col(OrderAddress::id).equal(address1.id))
+            associate(OrderAddress::class, Address::class, on(OrderAddress::address))
+        }
+
+        // then
+        assertThat(query.resultList).singleElement()
+    }
+
+    @Test
     fun deleteEmbedded() {
         // given
         val address1 = orderAddress { }

--- a/test-fixture/integration-reactive-jakarta/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
+++ b/test-fixture/integration-reactive-jakarta/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
@@ -40,6 +40,33 @@ abstract class AbstractCriteriaDeleteIntegrationTest<S> : CriteriaQueryDslIntegr
     }
 
     @Test
+    fun deleteInEmptyList() = runBlocking {
+        // when
+        val address1 = orderAddress { }
+
+        persistAll(address1)
+
+        withFactory { queryFactory ->
+            queryFactory.deleteQuery<OrderAddress> {
+                where(col(OrderAddress::id).`in`(emptyList<Long>()))
+            }.executeUpdate()
+        }
+
+        // when
+        val query = withFactory { queryFactory ->
+            queryFactory.listQuery<OrderAddress> {
+                select(entity(OrderAddress::class))
+                from(entity(OrderAddress::class))
+                where(col(OrderAddress::id).equal(address1.id))
+                associate(OrderAddress::class, Address::class, on(OrderAddress::address))
+            }
+        }
+
+        // then
+        assertThat(query).singleElement()
+    }
+
+    @Test
     fun deleteEmbedded() = runBlocking {
         // given
         val address1 = orderAddress { }

--- a/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
+++ b/test-fixture/integration-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/test/reactive/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
@@ -40,6 +40,33 @@ abstract class AbstractCriteriaDeleteIntegrationTest<S> : CriteriaQueryDslIntegr
     }
 
     @Test
+    fun deleteInEmptyList() = runBlocking {
+        // when
+        val address1 = orderAddress { }
+
+        persistAll(address1)
+
+        withFactory { queryFactory ->
+            queryFactory.deleteQuery<OrderAddress> {
+                where(col(OrderAddress::id).`in`(emptyList<Long>()))
+            }.executeUpdate()
+        }
+
+        // when
+        val query = withFactory { queryFactory ->
+            queryFactory.listQuery<OrderAddress> {
+                select(entity(OrderAddress::class))
+                from(entity(OrderAddress::class))
+                where(col(OrderAddress::id).equal(address1.id))
+                associate(OrderAddress::class, Address::class, on(OrderAddress::address))
+            }
+        }
+
+        // then
+        assertThat(query).singleElement()
+    }
+
+    @Test
     fun deleteEmbedded() = runBlocking {
         // given
         val address1 = orderAddress { }

--- a/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
+++ b/test-fixture/integration/src/main/kotlin/com/linecorp/kotlinjdsl/test/integration/criteriaquery/AbstractCriteriaDeleteIntegrationTest.kt
@@ -40,6 +40,32 @@ abstract class AbstractCriteriaDeleteIntegrationTest : AbstractCriteriaQueryDslI
     }
 
     @Test
+    fun deleteEmptyList() {
+        // when
+        val address1 = orderAddress { }
+
+        entityManager.run {
+            persistAll(address1)
+            flushAndClear()
+        }
+
+        queryFactory.deleteQuery<OrderAddress> {
+            where(col(OrderAddress::id).`in`(emptyList<Long>()))
+        }.executeUpdate()
+
+        // when
+        val query = queryFactory.selectQuery<OrderAddress> {
+            select(entity(OrderAddress::class))
+            from(entity(OrderAddress::class))
+            where(col(OrderAddress::id).equal(address1.id))
+            associate(OrderAddress::class, Address::class, on(OrderAddress::address))
+        }
+
+        // then
+        assertThat(query.resultList).singleElement()
+    }
+
+    @Test
     fun deleteEmbedded() {
         // given
         val address1 = orderAddress { }


### PR DESCRIPTION
# Motivation:

This should prevent the unexpected behavior when providing empty lists to the in predicate function. Currently doing something like 
```kotlin
selectAll()
from<Contract>()
whereAnd(column(Contract::userId).`in`(emptyList()))
```
returns every record on the table. This has the potential to cause data leaks (and would currently cause this exact leak in our code if we had pushed it to production).

# Modifications:

Changed InValueSpec to treat empty lists as a disjunction instead of a conjunction.


# Result:

Closes issue #191 

Queries will no longer ignore predicates containing empty lists, treating them as always false. I did not see any mention of its current behavior in the documentation, so I expect this change will likely result in expected behavior for most users as the current behavior is fairly surprising.


The current behavior has the potential for catastrophic data breaches and loss of data. I believe that the appropriate response here would be to report a critical vulnerability with a CVE organization (such as Snyk) regardless of whether this PR is merged in. I don't expect most users of this library are aware of this behavior, and had I not found it myself I would have greatly appreciated an alert from our dependency security scans.