### PR TITLE
remove unnecessarily @Suppress("DSL_SCOPE_VIOLATION") annotation in build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     jacoco
 

--- a/examples/spring-boot-2.7/build.gradle.kts
+++ b/examples/spring-boot-2.7/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.spring.boot)
     kotlin("plugin.spring")

--- a/examples/spring-boot-3/build.gradle.kts
+++ b/examples/spring-boot-3/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.spring.boot3)
     kotlin("plugin.spring")

--- a/examples/spring-boot-hibernate-reactive-2.7/build.gradle.kts
+++ b/examples/spring-boot-hibernate-reactive-2.7/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.spring.boot)
     kotlin("plugin.spring")

--- a/examples/spring-boot-hibernate-reactive-3/build.gradle.kts
+++ b/examples/spring-boot-hibernate-reactive-3/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.spring.boot3)
     kotlin("plugin.spring")


### PR DESCRIPTION
# Motivation:

* With gradle upgrade to 8.1, you no longer need to declare `@Suppress("DSL_SCOPE_VIOLATION")` above plugins in build.gradle.kts.

-- korean
* gradle이 8.1로 업그레이드 되면서 더이상 `@Suppress("DSL_SCOPE_VIOLATION")` 을 build.gradle.kts 의 plugins 위에 선언할 필요가 없어졌습니다.

# Modifications:

* Removed annotation from all build.gradle.kts files where `@Suppress("DSL_SCOPE_VIOLATION")` exists.

-- korean
* `@Suppress("DSL_SCOPE_VIOLATION")`가 존재하는 모든 build.gradle.kts 파일안에서 annotation 을 제거했습니다.

#Result:
There is no separate change felt by the user.

-- korean
유저가 느끼는 별도의 변화는 없습니다.
