### PR TITLE
Fix SpringDataQueryFactory.singleQuery

### DIFF
--- a/spring/data-core-jakarta/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensions.kt
+++ b/spring/data-core-jakarta/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensions.kt
@@ -7,7 +7,7 @@ import java.util.stream.Stream
 
 inline fun <reified T> SpringDataQueryFactory.singleQuery(
     noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit
-): T = selectQuery(T::class.java, dsl).singleResult
+): T? = selectQuery(T::class.java, dsl).resultList.firstOrNull()
 
 inline fun <reified T> SpringDataQueryFactory.listQuery(
     noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit


### PR DESCRIPTION
# Motivation:
* In JPA Criteria APIs, SingleResult throws a `NoResultException` if the value doesn't exist. In this case, the unity of the whole code seems to be broken because the Try - Catch construct has to be used in all contexts. So I submit this pull request.

-- korean
* JPA Criteria API에서 SingleResult는 값이 존재하지 않는 경우 `NoResultException`을 발생시킵니다. 이 경우 모든 컨텍스트에서 Try - Catch 구문을 사용해야 하기 때문에 전체 코드의 통일성이 깨지는 것 같습니다. 그래서 이 풀 리퀘스트를 제출합니다.

# Modifications:

* Change `SpringDataQueryFactory.singleQuery` in `spring/data/SpringDataQueryFactoryExtensions.kt` to Nullable
-- korean
* `spring/data/SpringDataQueryFactoryExtensions.kt` 의 `SpringDataQueryFactory.singleQuery` 를 `Nullable`하게 변경

# Result:
* `NoResultException` no longer occurs when using `SpringDataQueryFactory.singleQuery`.

-- korean
* `SpringDataQueryFactory.singleQuery`를 사용할 때 더 이상 `NoResultException`이 발생하지 않습니다.
