### PR TITLE
feat: singleOrNullQuery to SpringDataQueryFactoryExtensions.kt

### DIFF
--- a/spring/data-core-jakarta/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensions.kt
+++ b/spring/data-core-jakarta/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensions.kt
@@ -2,12 +2,22 @@ package com.linecorp.kotlinjdsl.spring.data
 
 import com.linecorp.kotlinjdsl.query.clause.select.SingleSelectClause
 import com.linecorp.kotlinjdsl.spring.data.querydsl.*
+import jakarta.persistence.NoResultException
 import org.springframework.data.domain.Pageable
 import java.util.stream.Stream
 
 inline fun <reified T> SpringDataQueryFactory.singleQuery(
     noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit
 ): T = selectQuery(T::class.java, dsl).singleResult
+
+inline fun <reified T> SpringDataQueryFactory.singleOrNullQuery(
+    noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit
+): T? =
+    try {
+        selectQuery(T::class.java, dsl).singleResult
+    } catch (e: NoResultException) {
+        null
+    }
 
 inline fun <reified T> SpringDataQueryFactory.listQuery(
     noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit

--- a/spring/data-core-jakarta/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
+++ b/spring/data-core-jakarta/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
@@ -60,6 +60,31 @@ internal class SpringDataQueryFactoryExtensionsTest : WithKotlinJdslAssertions {
     }
 
     @Test
+    fun singleOrNullQuery() {
+        // given
+        every { queryFactory.selectQuery<Data1>(any(), any()) } returns typedQuery
+        every { typedQuery.singleResult } returns Data1()
+
+        val dsl: SpringDataCriteriaQueryDsl<Data1>.() -> Unit = {
+            select(entity(Data1::class))
+            from(entity(Data1::class))
+        }
+
+        // when
+        val actual: Data1? = queryFactory.singleOrNullQuery(dsl)
+
+        // then
+        assertThat(actual).isEqualTo(Data1())
+
+        verify(exactly = 1) {
+            queryFactory.selectQuery(Data1::class.java, dsl)
+            typedQuery.singleResult
+        }
+
+        confirmVerified(queryFactory, typedQuery)
+    }
+
+    @Test
     fun listQuery() {
         // given
         every { queryFactory.selectQuery<Data1>(any(), any()) } returns typedQuery

--- a/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensions.kt
+++ b/spring/data-core/src/main/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensions.kt
@@ -4,10 +4,20 @@ import com.linecorp.kotlinjdsl.query.clause.select.SingleSelectClause
 import com.linecorp.kotlinjdsl.spring.data.querydsl.*
 import org.springframework.data.domain.Pageable
 import java.util.stream.Stream
+import javax.persistence.NoResultException
 
 inline fun <reified T> SpringDataQueryFactory.singleQuery(
     noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit
 ): T = selectQuery(T::class.java, dsl).singleResult
+
+inline fun <reified T> SpringDataQueryFactory.singleOrNullQuery(
+    noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit
+): T? =
+    try {
+        selectQuery(T::class.java, dsl).singleResult
+    } catch (e: NoResultException) {
+        null
+    }
 
 inline fun <reified T> SpringDataQueryFactory.listQuery(
     noinline dsl: SpringDataCriteriaQueryDsl<T>.() -> Unit

--- a/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
+++ b/spring/data-core/src/test/kotlin/com/linecorp/kotlinjdsl/spring/data/SpringDataQueryFactoryExtensionsTest.kt
@@ -19,7 +19,6 @@ import org.springframework.data.domain.PageRequest
 import java.util.stream.Stream
 import javax.persistence.Query
 import javax.persistence.TypedQuery
-import kotlin.streams.toList
 
 @ExtendWith(MockKExtension::class)
 internal class SpringDataQueryFactoryExtensionsTest : WithKotlinJdslAssertions {
@@ -48,6 +47,31 @@ internal class SpringDataQueryFactoryExtensionsTest : WithKotlinJdslAssertions {
 
         // when
         val actual: Data1 = queryFactory.singleQuery(dsl)
+
+        // then
+        assertThat(actual).isEqualTo(Data1())
+
+        verify(exactly = 1) {
+            queryFactory.selectQuery(Data1::class.java, dsl)
+            typedQuery.singleResult
+        }
+
+        confirmVerified(queryFactory, typedQuery)
+    }
+
+    @Test
+    fun singleOrNullQuery() {
+        // given
+        every { queryFactory.selectQuery<Data1>(any(), any()) } returns typedQuery
+        every { typedQuery.singleResult } returns Data1()
+
+        val dsl: SpringDataCriteriaQueryDsl<Data1>.() -> Unit = {
+            select(entity(Data1::class))
+            from(entity(Data1::class))
+        }
+
+        // when
+        val actual: Data1? = queryFactory.singleOrNullQuery(dsl)
 
         // then
         assertThat(actual).isEqualTo(Data1())


### PR DESCRIPTION
# Motivation:

* In JPA Criteria APIs, `singleResult` throws a `NoResultException` if the value doesn't exist. In this case, the unity of the whole code seems to be broken because the Try - Catch construct has to be used in all contexts. So I submit this pull request.

-- korean
* JPA Criteria API에서 `singleResult`는 값이 존재하지 않는 경우 `NoResultException`을 발생시킵니다. 이 경우 모든 컨텍스트에서 Try - Catch 구문을 사용해야 하기 때문에 전체 코드의 통일성이 깨지는 것 같습니다. 그래서 이 풀 리퀘스트를 제출합니다.


# Modifications:

* Add `SpringDataQueryFactory.singleOrNullQuery` to `spring/data/SpringDataQueryFactoryExtensions.kt`

-- korean 
* `spring/data/SpringDataQueryFactoryExtensions.kt` 에 `SpringDataQueryFactory.singleOrNullQuery` 추가

# Result:
* Can use `singleOrNullQuery` which will not throw `NoResultException`.
-- korean
* `NoResultException`이 발생하지 않는 `singleOrNullQuery`를 사용할 수 있습니다.
