### PR TITLE
Add Min, Max jpql serializer

### DIFF
--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMaxSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMaxSerializer.kt
@@ -20,6 +20,7 @@ class JpqlMaxSerializer : JpqlSerializer<JpqlMax<*>> {
 
         if (part.distinct) {
             writer.write("DISTINCT")
+            writer.write(" ")
         }
 
         delegate.serialize(part.expr, writer, context)

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMinSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMinSerializer.kt
@@ -1,0 +1,29 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMin
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+class JpqlMinSerializer : JpqlSerializer<JpqlMin<*>> {
+    override fun handledType(): KClass<JpqlMin<*>> {
+        return JpqlMin::class
+    }
+
+    override fun serialize(part: JpqlMin<*>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        writer.write("MIN")
+        writer.write("(")
+
+        if (part.distinct) {
+            writer.write("DISTINCT")
+        }
+
+        delegate.serialize(part.expr, writer, context)
+
+        writer.write(")")
+    }
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMinSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMinSerializer.kt
@@ -20,6 +20,7 @@ class JpqlMinSerializer : JpqlSerializer<JpqlMin<*>> {
 
         if (part.distinct) {
             writer.write("DISTINCT")
+            writer.write(" ")
         }
 
         delegate.serialize(part.expr, writer, context)

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMaxSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMaxSerializerTest.kt
@@ -80,6 +80,7 @@ class JpqlMaxSerializerTest : WithAssertions {
             writer.write("MAX")
             writer.write("(")
             writer.write("DISTINCT")
+            writer.write(" ")
             serializer.serialize(part.expr, writer, context)
             writer.write(")")
         }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMaxSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMaxSerializerTest.kt
@@ -1,0 +1,96 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMax
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.*
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class JpqlMaxSerializerTest : WithAssertions {
+    private val sut = JpqlMaxSerializer()
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlMax::class)
+    }
+
+    @Test
+    fun `serialize - WHEN distinct is disabled, THEN draw max function only`() {
+        // given
+        val writer = mockkClass(JpqlWriter::class) {
+            every { write(any<String>()) } just runs
+        }
+
+        val serializer = mockkClass(JpqlRenderSerializer::class) {
+            every { key } returns JpqlRenderSerializer
+            every { serialize(any(), any(), any()) } just runs
+        }
+
+        val part = Expressions.max(false, Expressions.stringLiteral("name"))
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlMax<*>, writer, context)
+
+        // then
+        verify(exactly = 1) {
+            writer.write("MAX")
+            writer.write("(")
+            serializer.serialize(part.expr, writer, context)
+            writer.write(")")
+        }
+
+        verify {
+            serializer.key
+        }
+
+        confirmVerified(
+            writer,
+            serializer,
+        )
+    }
+
+    @Test
+    fun `serialize - WHEN distinct is enabled, THEN draw max function with distinct`() {
+        // given
+        val writer = mockkClass(JpqlWriter::class) {
+            every { write(any<String>()) } just runs
+        }
+
+        val serializer = mockkClass(JpqlRenderSerializer::class) {
+            every { key } returns JpqlRenderSerializer
+            every { serialize(any(), any(), any()) } just runs
+        }
+
+        val part = Expressions.max(true, Expressions.stringLiteral("name"))
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlMax<*>, writer, context)
+
+        // then
+        verify(exactly = 1) {
+            writer.write("MAX")
+            writer.write("(")
+            writer.write("DISTINCT")
+            serializer.serialize(part.expr, writer, context)
+            writer.write(")")
+        }
+
+        verify {
+            serializer.key
+        }
+
+        confirmVerified(
+            writer,
+            serializer,
+        )
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMinSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMinSerializerTest.kt
@@ -1,0 +1,97 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMax
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMin
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.*
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class JpqlMinSerializerTest : WithAssertions {
+    private val sut = JpqlMinSerializer()
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlMin::class)
+    }
+
+    @Test
+    fun `serialize - WHEN distinct is disabled, THEN draw min function only`() {
+        // given
+        val writer = mockkClass(JpqlWriter::class) {
+            every { write(any<String>()) } just runs
+        }
+
+        val serializer = mockkClass(JpqlRenderSerializer::class) {
+            every { key } returns JpqlRenderSerializer
+            every { serialize(any(), any(), any()) } just runs
+        }
+
+        val part = Expressions.min(false, Expressions.stringLiteral("name"))
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlMin<*>, writer, context)
+
+        // then
+        verify(exactly = 1) {
+            writer.write("MIN")
+            writer.write("(")
+            serializer.serialize(part.expr, writer, context)
+            writer.write(")")
+        }
+
+        verify {
+            serializer.key
+        }
+
+        confirmVerified(
+            writer,
+            serializer,
+        )
+    }
+
+    @Test
+    fun `serialize - WHEN distinct is enabled, THEN draw min function with distinct`() {
+        // given
+        val writer = mockkClass(JpqlWriter::class) {
+            every { write(any<String>()) } just runs
+        }
+
+        val serializer = mockkClass(JpqlRenderSerializer::class) {
+            every { key } returns JpqlRenderSerializer
+            every { serialize(any(), any(), any()) } just runs
+        }
+
+        val part = Expressions.min(true, Expressions.stringLiteral("name"))
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlMin<*>, writer, context)
+
+        // then
+        verify(exactly = 1) {
+            writer.write("MIN")
+            writer.write("(")
+            writer.write("DISTINCT")
+            serializer.serialize(part.expr, writer, context)
+            writer.write(")")
+        }
+
+        verify {
+            serializer.key
+        }
+
+        confirmVerified(
+            writer,
+            serializer,
+        )
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMinSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlMinSerializerTest.kt
@@ -81,6 +81,7 @@ class JpqlMinSerializerTest : WithAssertions {
             writer.write("MIN")
             writer.write("(")
             writer.write("DISTINCT")
+            writer.write(" ")
             serializer.serialize(part.expr, writer, context)
             writer.write(")")
         }


### PR DESCRIPTION
# Motivation:

# Modifications:

* Add `JpqlMinSerializer`
* Add test for `JpqlMinSerializer`, `JpqlMaxSerializer`

# Commit Convention Rule

* Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)

| Commit type | Description                                             |
|-------------|---------------------------------------------------------|
| feat        | New Feature                                             |
| fix         | Fix bug                                                 |
| docs        | Documentation only changed                              |
| ci          | Change CI configuration                                 |
| refactor    | Not a bug fix or add feature, just refactoring code     |
| test        | Add Test case or fix wrong test case                    |
| style       | Only change the code style(ex. white-space, formatting) |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

* If you want to add some more `commit type` please describe it on the **Pull Request**


# Result:

Closes #342 #343
