### PR TITLE
Add Avg, Sum jpql serializers

### DIFF
--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlAvgSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlAvgSerializer.kt
@@ -1,0 +1,30 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlAvg
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+class JpqlAvgSerializer : JpqlSerializer<JpqlAvg<*>> {
+    override fun handledType(): KClass<JpqlAvg<*>> {
+        return JpqlAvg::class
+    }
+
+    override fun serialize(part: JpqlAvg<*>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        writer.write("AVG")
+        writer.write("(")
+
+        if (part.distinct) {
+            writer.write("DISTINCT")
+            writer.write(" ")
+        }
+
+        delegate.serialize(part.expr, writer, context)
+
+        writer.write(")")
+    }
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlCountSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlCountSerializer.kt
@@ -20,6 +20,7 @@ class JpqlCountSerializer : JpqlSerializer<JpqlCount> {
 
         if (part.distinct) {
             writer.write("DISTINCT")
+            writer.write(" ")
         }
 
         delegate.serialize(part.expr, writer, context)

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSumSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSumSerializer.kt
@@ -1,0 +1,30 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlSum
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+class JpqlSumSerializer : JpqlSerializer<JpqlSum<*, *>> {
+    override fun handledType(): KClass<JpqlSum<*, *>> {
+        return JpqlSum::class
+    }
+
+    override fun serialize(part: JpqlSum<*, *>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        writer.write("SUM")
+        writer.write("(")
+
+        if (part.distinct) {
+            writer.write("DISTINCT")
+            writer.write(" ")
+        }
+
+        delegate.serialize(part.expr, writer, context)
+
+        writer.write(")")
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlAvgSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlAvgSerializerTest.kt
@@ -1,0 +1,97 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlAvg
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.*
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class JpqlAvgSerializerTest : WithAssertions {
+    private val sut = JpqlAvgSerializer()
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlAvg::class)
+    }
+
+    @Test
+    fun `serialize - WHEN distinct is disabled, THEN draw avg function only`() {
+        // given
+        val writer = mockkClass(JpqlWriter::class) {
+            every { write(any<String>()) } just runs
+        }
+
+        val serializer = mockkClass(JpqlRenderSerializer::class) {
+            every { key } returns JpqlRenderSerializer
+            every { serialize(any(), any(), any()) } just runs
+        }
+
+        val part = Expressions.avg(false, Expressions.doubleLiteral(3.0))
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlAvg<*>, writer, context)
+
+        // then
+        verify(exactly = 1) {
+            writer.write("AVG")
+            writer.write("(")
+            serializer.serialize(part.expr, writer, context)
+            writer.write(")")
+        }
+
+        verify {
+            serializer.key
+        }
+
+        confirmVerified(
+            writer,
+            serializer,
+        )
+    }
+
+    @Test
+    fun `serialize - WHEN distinct is enabled, THEN draw avg function with distinct`() {
+        // given
+        val writer = mockkClass(JpqlWriter::class) {
+            every { write(any<String>()) } just runs
+        }
+
+        val serializer = mockkClass(JpqlRenderSerializer::class) {
+            every { key } returns JpqlRenderSerializer
+            every { serialize(any(), any(), any()) } just runs
+        }
+
+        val part = Expressions.avg(true, Expressions.doubleLiteral(3.0))
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlAvg<*>, writer, context)
+
+        // then
+        verify(exactly = 1) {
+            writer.write("AVG")
+            writer.write("(")
+            writer.write("DISTINCT")
+            writer.write(" ")
+            serializer.serialize(part.expr, writer, context)
+            writer.write(")")
+        }
+
+        verify {
+            serializer.key
+        }
+
+        confirmVerified(
+            writer,
+            serializer,
+        )
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSumSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSumSerializerTest.kt
@@ -1,0 +1,97 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlSum
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.*
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class JpqlSumSerializerTest : WithAssertions {
+    private val sut = JpqlSumSerializer()
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlSum::class)
+    }
+
+    @Test
+    fun `serialize - WHEN distinct is disabled, THEN draw sum function only`() {
+        // given
+        val writer = mockkClass(JpqlWriter::class) {
+            every { write(any<String>()) } just runs
+        }
+
+        val serializer = mockkClass(JpqlRenderSerializer::class) {
+            every { key } returns JpqlRenderSerializer
+            every { serialize(any(), any(), any()) } just runs
+        }
+
+        val part = Expressions.sum(false, Expressions.intLiteral(10))
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlSum<*, *>, writer, context)
+
+        // then
+        verify(exactly = 1) {
+            writer.write("SUM")
+            writer.write("(")
+            serializer.serialize(part.expr, writer, context)
+            writer.write(")")
+        }
+
+        verify {
+            serializer.key
+        }
+
+        confirmVerified(
+            writer,
+            serializer,
+        )
+    }
+
+    @Test
+    fun `serialize - WHEN distinct is enabled, THEN draw sum function with distinct`() {
+        // given
+        val writer = mockkClass(JpqlWriter::class) {
+            every { write(any<String>()) } just runs
+        }
+
+        val serializer = mockkClass(JpqlRenderSerializer::class) {
+            every { key } returns JpqlRenderSerializer
+            every { serialize(any(), any(), any()) } just runs
+        }
+
+        val part = Expressions.sum(true, Expressions.intLiteral(10))
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlSum<*, *>, writer, context)
+
+        // then
+        verify(exactly = 1) {
+            writer.write("SUM")
+            writer.write("(")
+            writer.write("DISTINCT")
+            writer.write(" ")
+            serializer.serialize(part.expr, writer, context)
+            writer.write(")")
+        }
+
+        verify {
+            serializer.key
+        }
+
+        confirmVerified(
+            writer,
+            serializer,
+        )
+    }
+}


### PR DESCRIPTION
# Motivation:

# Modifications:

- Implement `JpqlSumSerializer`, `JpqlAvgSerializer`

# Commit Convention Rule

* Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)

| Commit type | Description                                             |
|-------------|---------------------------------------------------------|
| feat        | New Feature                                             |
| fix         | Fix bug                                                 |
| docs        | Documentation only changed                              |
| ci          | Change CI configuration                                 |
| refactor    | Not a bug fix or add feature, just refactoring code     |
| test        | Add Test case or fix wrong test case                    |
| style       | Only change the code style(ex. white-space, formatting) |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

* If you want to add some more `commit type` please describe it on the **Pull Request**


# Result:

Closes #352  #328
