### PR TITLE
Add escape property for (NOT) LIKE  + add JpqlNotLikeSerializer

### DIFF
--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -94,6 +94,11 @@ open class Jpql : JpqlDsl {
     }
 
     @SinceJdsl("3.0.0")
+    fun charLiteral(char: Char): Expression<Char> {
+        return Expressions.charLiteral(char)
+    }
+
+    @SinceJdsl("3.0.0")
     fun stringLiteral(string: String): Expression<String> {
         return Expressions.stringLiteral(string)
     }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/LiteralDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/LiteralDslTest.kt
@@ -11,6 +11,7 @@ class LiteralDslTest : AbstractJpqlDslTest() {
     private val float1: Float = 1f
     private val double1: Double = 1.0
     private val boolean1: Boolean = true
+    private val char1: Char = 'a'
     private val string1: String = "string1 "
 
     @Test
@@ -84,6 +85,21 @@ class LiteralDslTest : AbstractJpqlDslTest() {
 
         // then
         val expected = Expressions.booleanLiteral(boolean1)
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun charLiteral() {
+        // when
+        val expression = testJpql {
+            charLiteral(char1)
+        }.toExpression()
+
+        val actual: Expression<Char> = expression // for type check
+
+        // then
+        val expected = Expressions.charLiteral(char1)
 
         assertThat(actual).isEqualTo(expected)
     }

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
@@ -53,6 +53,11 @@ object Expressions {
     }
 
     @SinceJdsl("3.0.0")
+    fun charLiteral(char: Char): Expression<Char> {
+        return JpqlLiteral.CharLiteral(char)
+    }
+
+    @SinceJdsl("3.0.0")
     fun stringLiteral(string: String): Expression<String> {
         return JpqlLiteral.StringLiteral(string)
     }

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlLiteral.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlLiteral.kt
@@ -44,6 +44,10 @@ sealed interface JpqlLiteral<T : Any> : Expression<T> {
         val boolean: Boolean
     ) : JpqlLiteral<Boolean>
 
+    data class CharLiteral internal constructor(
+        val char: Char
+    ) : JpqlLiteral<Char>
+
     data class StringLiteral internal constructor(
         val string: String
     ) : JpqlLiteral<String>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/predicate/Predicates.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/predicate/Predicates.kt
@@ -176,8 +176,8 @@ object Predicates {
     }
 
     @SinceJdsl("3.0.0")
-    fun like(value: Expression<String>, pattern: Expression<String>): Predicate {
-        return JpqlLike(value, pattern)
+    fun like(value: Expression<String>, pattern: Expression<String>, escape: Expression<Char>? = null): Predicate {
+        return JpqlLike(value, pattern, escape)
     }
 
     @SinceJdsl("3.0.0")

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/predicate/Predicates.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/predicate/Predicates.kt
@@ -181,8 +181,8 @@ object Predicates {
     }
 
     @SinceJdsl("3.0.0")
-    fun notLike(value: Expression<String>, pattern: Expression<String>): Predicate {
-        return JpqlNotLike(value, pattern)
+    fun notLike(value: Expression<String>, pattern: Expression<String>, escape: Expression<Char>? = null): Predicate {
+        return JpqlNotLike(value, pattern, escape)
     }
 
     @SinceJdsl("3.0.0")

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/predicate/impl/JpqlLike.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/predicate/impl/JpqlLike.kt
@@ -8,4 +8,5 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 data class JpqlLike internal constructor(
     val value: Expression<String>,
     val pattern: Expression<String>,
+    val escape: Expression<Char>?,
 ) : Predicate

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/predicate/impl/JpqlNotLike.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/predicate/impl/JpqlNotLike.kt
@@ -8,4 +8,5 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 data class JpqlNotLike internal constructor(
     val value: Expression<String>,
     val pattern: Expression<String>,
+    val escape: Expression<Char>?,
 ) : Predicate

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLikeSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLikeSerializer.kt
@@ -22,5 +22,13 @@ class JpqlLikeSerializer : JpqlSerializer<JpqlLike> {
         writer.write(" ")
 
         delegate.serialize(part.pattern, writer, context)
+
+        part.escape?.let {
+            writer.write(" ")
+            writer.write("ESCAPE")
+            writer.write(" ")
+
+            delegate.serialize(it, writer, context)
+        }
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLiteralSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLiteralSerializer.kt
@@ -47,7 +47,10 @@ class JpqlLiteralSerializer : JpqlSerializer<JpqlLiteral<*>> {
 
     private fun serialize(part: JpqlLiteral.CharLiteral, writer: JpqlWriter) {
         writer.write("'")
-        writer.write("${part.char}")
+        when (part.char) {
+            '\'' -> writer.write("''")
+            else -> writer.write("${part.char}")
+        }
         writer.write("'")
     }
 

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLiteralSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLiteralSerializer.kt
@@ -18,6 +18,7 @@ class JpqlLiteralSerializer : JpqlSerializer<JpqlLiteral<*>> {
             is JpqlLiteral.FloatLiteral -> serialize(part, writer)
             is JpqlLiteral.DoubleLiteral -> serialize(part, writer)
             is JpqlLiteral.BooleanLiteral -> serialize(part, writer)
+            is JpqlLiteral.CharLiteral -> serialize(part, writer)
             is JpqlLiteral.StringLiteral -> serialize(part, writer)
             is JpqlLiteral.EnumLiteral -> serialize(part, writer)
             is JpqlLiteral.NullLiteral -> serializeNull(writer)
@@ -42,6 +43,12 @@ class JpqlLiteralSerializer : JpqlSerializer<JpqlLiteral<*>> {
 
     private fun serialize(part: JpqlLiteral.BooleanLiteral, writer: JpqlWriter) {
         writer.write(part.boolean)
+    }
+
+    private fun serialize(part: JpqlLiteral.CharLiteral, writer: JpqlWriter) {
+        writer.write("'")
+        writer.write("${part.char}")
+        writer.write("'")
     }
 
     private fun serialize(part: JpqlLiteral.StringLiteral, writer: JpqlWriter) {

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlNotLikeSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlNotLikeSerializer.kt
@@ -1,0 +1,32 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.impl.JpqlNotLike
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+class JpqlNotLikeSerializer : JpqlSerializer<JpqlNotLike> {
+    override fun handledType(): KClass<JpqlNotLike> {
+        return JpqlNotLike::class
+    }
+
+    override fun serialize(part: JpqlNotLike, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        delegate.serialize(part.value, writer, context)
+
+        writer.write(" ")
+        writer.write("NOT LIKE")
+        writer.write(" ")
+
+        delegate.serialize(part.pattern, writer, context)
+
+        part.escape?.let {
+            writer.write(" ")
+            writer.write("ESCAPE")
+            writer.write(" ")
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLikeSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLikeSerializerTest.kt
@@ -1,0 +1,94 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.impl.JpqlLike
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+@JpqlSerializerTest
+class JpqlLikeSerializerTest : WithAssertions {
+    private val sut = JpqlLikeSerializer()
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlLike::class)
+    }
+
+    @Test
+    fun `serialize - WHEN escape is not given, THEN draw only LIKE`() {
+        // given
+        every { writer.write(any<String>()) } just runs
+        every { serializer.serialize(any(), any(), any()) } just runs
+
+        val part = Predicates.like(
+            Expressions.stringLiteral("value"),
+            Expressions.stringLiteral("pattern"),
+        )
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlLike, writer, context)
+
+        // then
+        verifySequence {
+            serializer.serialize(part.value, writer, context)
+
+            writer.write(" ")
+            writer.write("LIKE")
+            writer.write(" ")
+
+            serializer.serialize(part.pattern, writer, context)
+        }
+    }
+
+    @Test
+    fun `serialize - WHEN escape is given, THEN draw LIKE with escape`() {
+        // given
+        every { writer.write(any<String>()) } just runs
+        every { serializer.serialize(any(), any(), any()) } just runs
+
+        val part = Predicates.like(
+            Expressions.stringLiteral("value"),
+            Expressions.stringLiteral("pattern"),
+            Expressions.charLiteral('/'),
+        )
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlLike, writer, context)
+
+        // then
+        verifySequence {
+            serializer.serialize(part.value, writer, context)
+
+            writer.write(" ")
+            writer.write("LIKE")
+            writer.write(" ")
+
+            serializer.serialize(part.pattern, writer, context)
+
+            writer.write(" ")
+            writer.write("ESCAPE")
+            writer.write(" ")
+
+            serializer.serialize(part.escape!!, writer, context)
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLiteralSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLiteralSerializerTest.kt
@@ -29,6 +29,7 @@ class JpqlLiteralSerializerTest : WithAssertions {
     private val float1: Float = 1f
     private val double1: Double = 1.0
     private val boolean1: Boolean = true
+    private val char1: Char = 'a'
     private val string1: String = "string1"
     private val string2: String = "string2"
     private val singleQuote: String = "'"
@@ -124,6 +125,25 @@ class JpqlLiteralSerializerTest : WithAssertions {
         // then
         verifySequence {
             writer.write(boolean1)
+        }
+    }
+
+    @Test
+    fun `serialize - char`() {
+        // given
+        every { writer.write(any<String>()) } just runs
+
+        val part = Expressions.charLiteral(char1)
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlLiteral.CharLiteral, writer, context)
+
+        // then
+        verifySequence {
+            writer.write(singleQuote)
+            writer.write("$char1")
+            writer.write(singleQuote)
         }
     }
 

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLiteralSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLiteralSerializerTest.kt
@@ -148,6 +148,25 @@ class JpqlLiteralSerializerTest : WithAssertions {
     }
 
     @Test
+    fun `serialize - single quote char`() {
+        // given
+        every { writer.write(any<String>()) } just runs
+
+        val part = Expressions.charLiteral(singleQuote[0])
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlLiteral.CharLiteral, writer, context)
+
+        // then
+        verifySequence {
+            writer.write(singleQuote)
+            writer.write("$singleQuote$singleQuote")
+            writer.write(singleQuote)
+        }
+    }
+
+    @Test
     fun `serialize - string`() {
         // given
         every { writer.write(any<String>()) } just runs

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlNotLikeSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlNotLikeSerializerTest.kt
@@ -1,0 +1,94 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
+import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.impl.JpqlNotLike
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+@JpqlSerializerTest
+class JpqlNotLikeSerializerTest : WithAssertions {
+    private val sut = JpqlNotLikeSerializer()
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlNotLike::class)
+    }
+
+    @Test
+    fun `serialize - WHEN escape is not given, THEN draw only NOT LIKE`() {
+        // given
+        every { writer.write(any<String>()) } just runs
+        every { serializer.serialize(any(), any(), any()) } just runs
+
+        val part = Predicates.notLike(
+            Expressions.stringLiteral("value"),
+            Expressions.stringLiteral("pattern"),
+        )
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlNotLike, writer, context)
+
+        // then
+        verifySequence {
+            serializer.serialize(part.value, writer, context)
+
+            writer.write(" ")
+            writer.write("NOT LIKE")
+            writer.write(" ")
+
+            serializer.serialize(part.pattern, writer, context)
+        }
+    }
+
+    @Test
+    fun `serialize - WHEN escape is given, THEN draw NOT LIKE with escape`() {
+        // given
+        every { writer.write(any<String>()) } just runs
+        every { serializer.serialize(any(), any(), any()) } just runs
+
+        val part = Predicates.notLike(
+            Expressions.stringLiteral("value"),
+            Expressions.stringLiteral("pattern"),
+            Expressions.charLiteral('/'),
+        )
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlNotLike, writer, context)
+
+        // then
+        verifySequence {
+            serializer.serialize(part.value, writer, context)
+
+            writer.write(" ")
+            writer.write("NOT LIKE")
+            writer.write(" ")
+
+            serializer.serialize(part.pattern, writer, context)
+
+            writer.write(" ")
+            writer.write("ESCAPE")
+            writer.write(" ")
+
+            serializer.serialize(part.escape!!, writer, context)
+        }
+    }
+}


### PR DESCRIPTION
# Motivation:

# Modifications:

- add `escape` property to `JpqlLike` and `JpqlNotLike`
- Implement `JpqlNotLikeSerializer` and test

# Commit Convention Rule

* Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
* This commit convention is referred from [angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)

| Commit type | Description                                             |
|-------------|---------------------------------------------------------|
| feat        | New Feature                                             |
| fix         | Fix bug                                                 |
| docs        | Documentation only changed                              |
| ci          | Change CI configuration                                 |
| refactor    | Not a bug fix or add feature, just refactoring code     |
| test        | Add Test case or fix wrong test case                    |
| style       | Only change the code style(ex. white-space, formatting) |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

* If you want to add some more `commit type` please describe it on the **Pull Request**


# Result:

Closes #375 #382 
