### PR TITLE
feat: Support Hibernate-Reactive javax version

### DIFF
--- a/example/hibernate-reactive-javax/build.gradle.kts
+++ b/example/hibernate-reactive-javax/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    alias(libs.plugins.test.spring.boot2)
+    alias(libs.plugins.kotlin.noarg)
+    alias(libs.plugins.kotlin.allopen)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.kotlin.jpa)
+}
+
+dependencies {
+    @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
+    implementation(libs.test.h2)
+    implementation(libs.hibernate.reactive1)
+    implementation(libs.slf4j)
+    implementation(libs.logback)
+    implementation(libs.vertx.jdbc.client)
+    implementation(libs.agroal.pool)
+    implementation(projects.example)
+    implementation(projects.jpqlDsl)
+    implementation(projects.jpqlRender)
+    implementation(projects.hibernateReactiveJavaxSupport)
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+noArg {
+    annotation("com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.annotation.CompositeId")
+}
+
+allOpen {
+    annotation("com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.annotation.CompositeId")
+    annotation("javax.persistence.Entity")
+    annotation("javax.persistence.Embeddable")
+}
+
+tasks.withType<PublishToMavenRepository>().configureEach { enabled = false }
+tasks.withType<PublishToMavenLocal>().configureEach { enabled = false }

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/annotation/CompositeId.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/annotation/CompositeId.kt
@@ -1,0 +1,3 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.annotation
+
+annotation class CompositeId

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/author/Author.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/author/Author.kt
@@ -1,0 +1,23 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.author
+
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity
+@Table(name = "author")
+class Author(
+    @Id
+    @Column(name = "author_id")
+    val authorId: Long,
+
+    @Column(name = "name")
+    var name: String,
+) {
+    override fun equals(other: Any?): Boolean = Objects.equals(authorId, (other as? Author)?.authorId)
+    override fun hashCode(): Int = Objects.hashCode(authorId)
+
+    override fun toString(): String = "Author(authorId=$authorId)"
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/book/Book.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/book/Book.kt
@@ -1,0 +1,57 @@
+@file:Suppress("LeakingThis")
+
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book
+
+import java.time.OffsetDateTime
+import java.util.*
+import javax.persistence.AttributeOverride
+import javax.persistence.CascadeType
+import javax.persistence.Column
+import javax.persistence.Embedded
+import javax.persistence.EmbeddedId
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.OneToMany
+import javax.persistence.Table
+
+@Entity
+@Table(name = "book")
+class Book(
+    @Id
+    @EmbeddedId
+    @AttributeOverride(name = "value", column = Column(name = "isbn"))
+    val isbn: Isbn,
+
+    @Column(name = "title")
+    var title: String,
+
+    @Column(name = "image_url")
+    var imageUrl: String,
+
+    @Embedded
+    @AttributeOverride(name = "value", column = Column(name = "price"))
+    var price: BookPrice,
+
+    @Embedded
+    @AttributeOverride(name = "value", column = Column(name = "sale_price"))
+    var salePrice: BookPrice,
+
+    @Column(name = "publish_date")
+    var publishDate: OffsetDateTime,
+
+    @OneToMany(mappedBy = "book", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val authors: MutableSet<BookAuthor>,
+
+    @OneToMany(mappedBy = "book", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val publishers: List<BookPublisher>,
+) {
+    init {
+        authors.forEach { it.book = this }
+        publishers.forEach { it.book = this }
+    }
+
+    override fun equals(other: Any?): Boolean = Objects.equals(isbn, (other as? Book)?.isbn)
+    override fun hashCode(): Int = Objects.hashCode(isbn)
+
+    override fun toString(): String = "Book(isbn=$isbn)"
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/book/BookAuthor.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/book/BookAuthor.kt
@@ -1,0 +1,43 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book
+
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.annotation.CompositeId
+import java.io.Serializable
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.IdClass
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "book_author")
+@IdClass(BookAuthor.BookAuthorId::class)
+class BookAuthor(
+    @Id
+    @Column(name = "author_id")
+    val authorId: Long,
+) {
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "isbn")
+    lateinit var book: Book
+
+    private val bookAuthorId get() = BookAuthorId(book.isbn, authorId)
+
+    override fun equals(other: Any?): Boolean =
+        Objects.equals(bookAuthorId, (other as? BookAuthor)?.bookAuthorId)
+
+    override fun hashCode(): Int =
+        Objects.hashCode(bookAuthorId)
+
+    override fun toString(): String =
+        "BookAuthor(bookAuthorId=$bookAuthorId)"
+
+    @CompositeId
+    data class BookAuthorId(
+        val book: Isbn,
+        val authorId: Long,
+    ) : Serializable
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/book/BookPrice.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/book/BookPrice.kt
@@ -1,0 +1,19 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book
+
+import java.math.BigDecimal
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+data class BookPrice(
+    @Column(name = "price", scale = 2)
+    val value: BigDecimal,
+)
+
+fun BookPrice(int: Int): BookPrice {
+    return BookPrice(BigDecimal.valueOf(int.toLong()).setScale(2))
+}
+
+fun BookPrice(double: Double): BookPrice {
+    return BookPrice(BigDecimal.valueOf(double).setScale(2))
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/book/BookPublisher.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/book/BookPublisher.kt
@@ -1,0 +1,43 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book
+
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.annotation.CompositeId
+import java.io.Serializable
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.IdClass
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "book_publisher")
+@IdClass(BookPublisher.BookPublisherId::class)
+class BookPublisher(
+    @Id
+    @Column(name = "publisher_id")
+    val publisherId: Long,
+) {
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "isbn")
+    lateinit var book: Book
+
+    private val bookPublisherId get() = BookPublisherId(book.isbn, publisherId)
+
+    override fun equals(other: Any?): Boolean =
+        Objects.equals(bookPublisherId, (other as? BookPublisher)?.bookPublisherId)
+
+    override fun hashCode(): Int =
+        Objects.hashCode(bookPublisherId)
+
+    override fun toString(): String =
+        "BookPublisher(bookPublisherId=$bookPublisherId)"
+
+    @CompositeId
+    data class BookPublisherId(
+        val book: Isbn,
+        val publisherId: Long,
+    ) : Serializable
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/book/Isbn.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/book/Isbn.kt
@@ -1,0 +1,14 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book
+
+import java.io.Serializable
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+/**
+ * International Standard Book Number
+ */
+@Embeddable
+data class Isbn(
+    @Column(name = "isbn")
+    val value: String,
+) : Serializable

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/department/Department.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/department/Department.kt
@@ -1,0 +1,23 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.department
+
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity
+@Table(name = "department")
+class Department(
+    @Id
+    @Column(name = "department_id")
+    val departmentId: Long,
+
+    @Column(name = "name")
+    val name: String,
+) {
+    override fun equals(other: Any?): Boolean = Objects.equals(departmentId, (other as? Department)?.departmentId)
+    override fun hashCode(): Int = Objects.hashCode(departmentId)
+
+    override fun toString(): String = "Department(departmentId=$departmentId)"
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/Employee.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/Employee.kt
@@ -1,0 +1,48 @@
+@file:Suppress("unused", "LeakingThis", "JpaDataSourceORMInspection")
+
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee
+
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.DiscriminatorColumn
+import javax.persistence.Embedded
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Inheritance
+import javax.persistence.InheritanceType
+import javax.persistence.OneToMany
+import javax.persistence.Table
+
+@Entity
+@Table(name = "employee")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "employee_type")
+class Employee(
+    @Id
+    @Column(name = "employee_id")
+    val employeeId: Long,
+
+    @Column(name = "name")
+    var name: String,
+
+    @Column(name = "nickname")
+    var nickname: String?,
+
+    @Column(name = "phone")
+    var phone: String,
+
+    @Embedded
+    val address: EmployeeAddress,
+
+    @OneToMany(mappedBy = "employee")
+    val departments: MutableSet<EmployeeDepartment>,
+) {
+    init {
+        departments.forEach { it.employee = this }
+    }
+
+    override fun equals(other: Any?): Boolean = Objects.equals(employeeId, (other as? Employee)?.employeeId)
+    override fun hashCode(): Int = Objects.hashCode(employeeId)
+
+    override fun toString(): String = "Employee(employeeId=$employeeId)"
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/EmployeeAddress.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/EmployeeAddress.kt
@@ -1,0 +1,22 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee
+
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+data class EmployeeAddress(
+    @Column(name = "zip_code")
+    val zipCode: String,
+
+    @Column(name = "street_address_1")
+    val streetAddress1: String,
+
+    @Column(name = "street_address_2")
+    val streetAddress2: String?,
+
+    @Column(name = "city")
+    val city: String,
+
+    @Column(name = "province")
+    val province: String,
+)

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/EmployeeDepartment.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/EmployeeDepartment.kt
@@ -1,0 +1,45 @@
+@file:Suppress("JpaDataSourceORMInspection")
+
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee
+
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.annotation.CompositeId
+import java.io.Serializable
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.IdClass
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "employee_department")
+@IdClass(EmployeeDepartment.EmployeeDepartmentId::class)
+class EmployeeDepartment(
+    @Id
+    @Column(name = "department_id")
+    val departmentId: Long,
+) {
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "employee_id")
+    lateinit var employee: Employee
+
+    private val employeeDepartmentId get() = EmployeeDepartmentId(employee.employeeId, departmentId)
+
+    override fun equals(other: Any?): Boolean =
+        Objects.equals(employeeDepartmentId, (other as? EmployeeDepartment)?.employeeDepartmentId)
+
+    override fun hashCode(): Int =
+        Objects.hashCode(employeeDepartmentId)
+
+    override fun toString(): String =
+        "EmployeeDepartment(employeeDepartmentId=$employeeDepartmentId)"
+
+    @CompositeId
+    data class EmployeeDepartmentId(
+        val employee: Long,
+        val departmentId: Long,
+    ) : Serializable
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/EmployeeSalary.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/EmployeeSalary.kt
@@ -1,0 +1,19 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee
+
+import java.math.BigDecimal
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+data class EmployeeSalary(
+    @Column(name = "salary", scale = 2)
+    val value: BigDecimal,
+)
+
+fun EmployeeSalary(int: Int): EmployeeSalary {
+    return EmployeeSalary(BigDecimal.valueOf(int.toLong()).setScale(2))
+}
+
+fun EmployeeSalary(double: Double): EmployeeSalary {
+    return EmployeeSalary(BigDecimal.valueOf(double).setScale(2))
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/FullTimeEmployee.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/FullTimeEmployee.kt
@@ -1,0 +1,36 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee
+
+import javax.persistence.AttributeOverride
+import javax.persistence.Column
+import javax.persistence.DiscriminatorValue
+import javax.persistence.Embedded
+import javax.persistence.Entity
+
+@Entity
+@DiscriminatorValue("FULL_TIME")
+class FullTimeEmployee(
+    employeeId: Long,
+
+    name: String,
+
+    nickname: String?,
+
+    phone: String,
+
+    address: EmployeeAddress,
+
+    departments: MutableSet<EmployeeDepartment>,
+
+    @Embedded
+    @AttributeOverride(name = "value", column = Column(name = "annual_salary"))
+    var annualSalary: EmployeeSalary,
+) : Employee(
+    employeeId = employeeId,
+    name = name,
+    nickname = nickname,
+    phone = phone,
+    address = address,
+    departments = departments,
+) {
+    override fun toString(): String = "FullTimeEmployee(employeeId=$employeeId)"
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/PartTimeEmployee.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/employee/PartTimeEmployee.kt
@@ -1,0 +1,36 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee
+
+import javax.persistence.AttributeOverride
+import javax.persistence.Column
+import javax.persistence.DiscriminatorValue
+import javax.persistence.Embedded
+import javax.persistence.Entity
+
+@Entity
+@DiscriminatorValue("PART_TIME")
+class PartTimeEmployee(
+    employeeId: Long,
+
+    name: String,
+
+    nickname: String?,
+
+    phone: String,
+
+    address: EmployeeAddress,
+
+    departments: MutableSet<EmployeeDepartment>,
+
+    @Embedded
+    @AttributeOverride(name = "value", column = Column(name = "weekly_salary"))
+    val weeklySalary: EmployeeSalary,
+) : Employee(
+    employeeId = employeeId,
+    name = name,
+    nickname = nickname,
+    phone = phone,
+    address = address,
+    departments = departments,
+) {
+    override fun toString(): String = "PartTimeEmployee(weeklySalary=$weeklySalary)"
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/publisher/Publisher.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/entity/publisher/Publisher.kt
@@ -1,0 +1,23 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.publisher
+
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity
+@Table(name = "publisher")
+class Publisher(
+    @Id
+    @Column(name = "publisher_id")
+    val publisherId: Long,
+
+    @Column(name = "name")
+    var name: String,
+) {
+    override fun equals(other: Any?): Boolean = Objects.equals(publisherId, (other as? Publisher)?.publisherId)
+    override fun hashCode(): Int = Objects.hashCode(publisherId)
+
+    override fun toString(): String = "Publisher(publisherId=$publisherId)"
+}

--- a/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/vertx/configuration/VertxH2DBConnectionPoolConfiguration.kt
+++ b/example/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/vertx/configuration/VertxH2DBConnectionPoolConfiguration.kt
@@ -1,0 +1,71 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.vertx.configuration
+
+import io.vertx.core.Vertx
+import io.vertx.jdbcclient.JDBCConnectOptions
+import io.vertx.jdbcclient.JDBCPool
+import io.vertx.sqlclient.Pool
+import io.vertx.sqlclient.PoolOptions
+import io.vertx.sqlclient.SqlConnectOptions
+import java.net.URI
+import org.hibernate.internal.util.config.ConfigurationHelper
+import org.hibernate.reactive.pool.impl.DefaultSqlClientPool
+import org.hibernate.reactive.pool.impl.DefaultSqlClientPoolConfiguration
+import org.hibernate.reactive.provider.Settings
+
+class H2ConnectionPool : DefaultSqlClientPool() {
+    override fun createPool(
+        uri: URI,
+        connectOptions: SqlConnectOptions,
+        poolOptions: PoolOptions,
+        vertx: Vertx,
+    ): Pool {
+        return JDBCPool.pool(
+            vertx,
+            JDBCConnectOptions()
+                .setJdbcUrl(connectOptions.host)
+                .setUser(connectOptions.user)
+                .setPassword(connectOptions.password)
+                .setDatabase(connectOptions.database),
+            poolOptions,
+        )
+    }
+}
+
+class VertxH2DBConnectionPoolConfiguration : DefaultSqlClientPoolConfiguration() {
+    private lateinit var user: String
+    private var pass: String? = null
+    private var cacheMaxSize: Int? = null
+    private var sqlLimit: Int? = null
+    override fun connectOptions(uri: URI): SqlConnectOptions {
+        if (uri.scheme == "h2") {
+            return SqlConnectOptions()
+                .setHost("jdbc:$uri")
+                .setUser(user)
+                .apply {
+                    pass?.let { password = it }
+                    // enable the prepared statement cache by default
+                    cachePreparedStatements = true
+
+                    cacheMaxSize?.run {
+                        if (this <= 0) {
+                            cachePreparedStatements = false
+                        } else {
+                            preparedStatementCacheMaxSize = this
+                        }
+                    }
+
+                    sqlLimit?.run { setPreparedStatementCacheSqlLimit(this) }
+                }
+        }
+
+        return super.connectOptions(uri)
+    }
+
+    override fun configure(configuration: MutableMap<Any?, Any?>) {
+        user = ConfigurationHelper.getString(Settings.USER, configuration)
+        pass = ConfigurationHelper.getString(Settings.PASS, configuration)
+        cacheMaxSize = ConfigurationHelper.getInteger(Settings.PREPARED_STATEMENT_CACHE_MAX_SIZE, configuration)
+        sqlLimit = ConfigurationHelper.getInteger(Settings.PREPARED_STATEMENT_CACHE_SQL_LIMIT, configuration)
+        super.configure(configuration)
+    }
+}

--- a/example/hibernate-reactive-javax/src/main/resources/META-INF/persistence.xml
+++ b/example/hibernate-reactive-javax/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+
+    <persistence-unit name="jdsl">
+        <provider>org.hibernate.reactive.provider.ReactivePersistenceProvider</provider>
+        <class>com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.author.Author</class>
+        <class>com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Book</class>
+        <class>com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.BookAuthor</class>
+        <class>com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.BookPublisher</class>
+        <class>com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.department.Department</class>
+        <class>com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee</class>
+        <class>com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment</class>
+        <class>com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.publisher.Publisher</class>
+
+        <properties>
+            <property name="hibernate.vertx.pool.connect_timeout" value="30000"/>
+            <property name="hibernate.vertx.pool.class" value="com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.vertx.configuration.H2ConnectionPool"/>
+            <property name="hibernate.vertx.pool.configuration_class" value="com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.vertx.configuration.VertxH2DBConnectionPoolConfiguration"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:~/test;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;DATABASE_TO_UPPER=false"/>
+            <property name="javax.persistence.jdbc.user" value="sa"/>
+            <property name="javax.persistence.jdbc.password" value=""/>
+            <property name="javax.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL8Dialect"/>
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.hbm2ddl.auto" value="none"/>
+            <property name="hibernate.use_sql_comments" value="true"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/SessionFactoryCreator.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/SessionFactoryCreator.kt
@@ -1,0 +1,32 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax
+
+import javax.persistence.EntityManagerFactory
+import javax.persistence.Persistence
+import org.hibernate.reactive.mutiny.Mutiny
+import org.hibernate.reactive.stage.Stage
+
+object SessionFactoryCreator {
+    val queries = sequenceOf("drop.sql", "schema.sql", "data.sql").map {
+        Thread.currentThread().contextClassLoader.getResourceAsStream(it)!!.bufferedReader().readText().split(";")
+            .map { it.trim() }
+    }.flatten().toList()
+
+    fun mutinySessionFactory(factory: EntityManagerFactory = entityManagerFactory()): Mutiny.SessionFactory =
+        factory.unwrap(Mutiny.SessionFactory::class.java).apply {
+            queries.forEach { query ->
+                withSession {
+                    it.createNativeQuery<Unit>(query).executeUpdate()
+                }.await().indefinitely()
+            }
+        }
+    fun stageSessionFactory(factory: EntityManagerFactory = entityManagerFactory()): Stage.SessionFactory =
+        factory.unwrap(Stage.SessionFactory::class.java).apply {
+            queries.forEach { query ->
+                withSession {
+                    it.createNativeQuery<Unit>(query).executeUpdate()
+                }.toCompletableFuture().get()
+            }
+        }
+
+    private fun entityManagerFactory(): EntityManagerFactory = Persistence.createEntityManagerFactory("jdsl")
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/delete/DeleteMutinySessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/delete/DeleteMutinySessionExample.kt
@@ -1,0 +1,124 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.delete
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.department.Department
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.time.OffsetDateTime
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.mutiny.Mutiny.SessionFactory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DeleteMutinySessionExample : WithAssertions {
+    private lateinit var sessionFactory: SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.mutinySessionFactory()
+    }
+
+    @Test
+    fun `delete all books published after June 2023`() {
+        val query = jpql {
+            deleteFrom(
+                entity(Book::class),
+            ).where(
+                path(Book::publishDate).ge(OffsetDateTime.parse("2023-06-01T00:00:00+09:00")),
+            )
+        }
+        // when
+
+        sessionFactory.withSession {
+            it.createQuery(query, context).executeUpdate()
+        }.await().indefinitely()
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        entity(Book::class),
+                    ).from(
+                        entity(Book::class),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely().map { it.isbn }
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+            ),
+        )
+    }
+
+    @Test
+    fun `remove the employees from department 03`() {
+        // when
+        val query = jpql {
+            val employeeIds = select<Long>(
+                path(EmployeeDepartment::employee)(Employee::employeeId),
+            ).from(
+                entity(Department::class),
+                join(EmployeeDepartment::class)
+                    .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+            ).where(
+                path(Department::name).like("%03"),
+            ).asSubquery()
+
+            deleteFrom(
+                entity(Employee::class),
+            ).where(
+                path(Employee::employeeId).`in`(employeeIds),
+            )
+        }
+
+        sessionFactory.withSession {
+            it.createQuery(query, context).executeUpdate()
+        }.await().indefinitely()
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        entity(Employee::class),
+                    ).from(
+                        entity(Employee::class),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely().map { it.employeeId }
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                2L,
+                3L,
+                4L,
+                5L,
+                6L,
+                15L,
+                16L,
+                17L,
+                18L,
+                19L,
+                20L,
+                22L,
+            ),
+        )
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/delete/DeleteMutinyStatelessSessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/delete/DeleteMutinyStatelessSessionExample.kt
@@ -1,0 +1,124 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.delete
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.department.Department
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.time.OffsetDateTime
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.mutiny.Mutiny.SessionFactory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DeleteMutinyStatelessSessionExample : WithAssertions {
+    private lateinit var sessionFactory: SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.mutinySessionFactory()
+    }
+
+    @Test
+    fun `delete all books published after June 2023`() {
+        val query = jpql {
+            deleteFrom(
+                entity(Book::class),
+            ).where(
+                path(Book::publishDate).ge(OffsetDateTime.parse("2023-06-01T00:00:00+09:00")),
+            )
+        }
+        // when
+
+        sessionFactory.withStatelessSession {
+            it.createQuery(query, context).executeUpdate()
+        }.await().indefinitely()
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        entity(Book::class),
+                    ).from(
+                        entity(Book::class),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely().map { it.isbn }
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+            ),
+        )
+    }
+
+    @Test
+    fun `remove the employees from department 03`() {
+        // when
+        val query = jpql {
+            val employeeIds = select<Long>(
+                path(EmployeeDepartment::employee)(Employee::employeeId),
+            ).from(
+                entity(Department::class),
+                join(EmployeeDepartment::class)
+                    .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+            ).where(
+                path(Department::name).like("%03"),
+            ).asSubquery()
+
+            deleteFrom(
+                entity(Employee::class),
+            ).where(
+                path(Employee::employeeId).`in`(employeeIds),
+            )
+        }
+
+        sessionFactory.withStatelessSession {
+            it.createQuery(query, context).executeUpdate()
+        }.await().indefinitely()
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        entity(Employee::class),
+                    ).from(
+                        entity(Employee::class),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely().map { it.employeeId }
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                2L,
+                3L,
+                4L,
+                5L,
+                6L,
+                15L,
+                16L,
+                17L,
+                18L,
+                19L,
+                20L,
+                22L,
+            ),
+        )
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/delete/DeleteStageSessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/delete/DeleteStageSessionExample.kt
@@ -1,0 +1,124 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.delete
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.department.Department
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.time.OffsetDateTime
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.stage.Stage.SessionFactory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DeleteStageSessionExample : WithAssertions {
+    private lateinit var sessionFactory: SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.stageSessionFactory()
+    }
+
+    @Test
+    fun `delete all books published after June 2023`() {
+        val query = jpql {
+            deleteFrom(
+                entity(Book::class),
+            ).where(
+                path(Book::publishDate).ge(OffsetDateTime.parse("2023-06-01T00:00:00+09:00")),
+            )
+        }
+        // when
+
+        sessionFactory.withSession {
+            it.createQuery(query, context).executeUpdate()
+        }.toCompletableFuture().get()
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        entity(Book::class),
+                    ).from(
+                        entity(Book::class),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get().map { it.isbn }
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+            ),
+        )
+    }
+
+    @Test
+    fun `remove the employees from department 03`() {
+        // when
+        val query = jpql {
+            val employeeIds = select<Long>(
+                path(EmployeeDepartment::employee)(Employee::employeeId),
+            ).from(
+                entity(Department::class),
+                join(EmployeeDepartment::class)
+                    .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+            ).where(
+                path(Department::name).like("%03"),
+            ).asSubquery()
+
+            deleteFrom(
+                entity(Employee::class),
+            ).where(
+                path(Employee::employeeId).`in`(employeeIds),
+            )
+        }
+
+        sessionFactory.withSession {
+            it.createQuery(query, context).executeUpdate()
+        }.toCompletableFuture().get()
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        entity(Employee::class),
+                    ).from(
+                        entity(Employee::class),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get().map { it.employeeId }
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                2L,
+                3L,
+                4L,
+                5L,
+                6L,
+                15L,
+                16L,
+                17L,
+                18L,
+                19L,
+                20L,
+                22L,
+            ),
+        )
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/delete/DeleteStageStatelessSessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/delete/DeleteStageStatelessSessionExample.kt
@@ -1,0 +1,124 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.delete
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.department.Department
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.time.OffsetDateTime
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.stage.Stage.SessionFactory
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DeleteStageStatelessSessionExample : WithAssertions {
+    private lateinit var sessionFactory: SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.stageSessionFactory()
+    }
+
+    @Test
+    fun `delete all books published after June 2023`() {
+        val query = jpql {
+            deleteFrom(
+                entity(Book::class),
+            ).where(
+                path(Book::publishDate).ge(OffsetDateTime.parse("2023-06-01T00:00:00+09:00")),
+            )
+        }
+        // when
+
+        sessionFactory.withStatelessSession {
+            it.createQuery(query, context).executeUpdate()
+        }.toCompletableFuture().get()
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        entity(Book::class),
+                    ).from(
+                        entity(Book::class),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get().map { it.isbn }
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+            ),
+        )
+    }
+
+    @Test
+    fun `remove the employees from department 03`() {
+        // when
+        val query = jpql {
+            val employeeIds = select<Long>(
+                path(EmployeeDepartment::employee)(Employee::employeeId),
+            ).from(
+                entity(Department::class),
+                join(EmployeeDepartment::class)
+                    .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+            ).where(
+                path(Department::name).like("%03"),
+            ).asSubquery()
+
+            deleteFrom(
+                entity(Employee::class),
+            ).where(
+                path(Employee::employeeId).`in`(employeeIds),
+            )
+        }
+
+        sessionFactory.withStatelessSession {
+            it.createQuery(query, context).executeUpdate()
+        }.toCompletableFuture().get()
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        entity(Employee::class),
+                    ).from(
+                        entity(Employee::class),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get().map { it.employeeId }
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                2L,
+                3L,
+                4L,
+                5L,
+                6L,
+                15L,
+                16L,
+                17L,
+                18L,
+                19L,
+                20L,
+                22L,
+            ),
+        )
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/select/SelectMutinySessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/select/SelectMutinySessionExample.kt
@@ -1,0 +1,321 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.author.Author
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.BookAuthor
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.time.OffsetDateTime
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SelectMutinySessionExample : WithAssertions {
+    private lateinit var sessionFactory: Mutiny.SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.mutinySessionFactory()
+    }
+
+    @Test
+    fun `the most prolific author`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Author::authorId),
+                    ).from(
+                        entity(Author::class),
+                        join(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
+                    ).groupBy(
+                        path(Author::authorId),
+                    ).orderBy(
+                        count(Author::authorId).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(1L)
+    }
+
+    @Test
+    fun `authors who haven't written a book`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Author::authorId),
+                    ).from(
+                        entity(Author::class),
+                        leftJoin(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
+                    ).where(
+                        path(BookAuthor::authorId).isNull(),
+                    ).orderBy(
+                        path(Author::authorId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(listOf(4L))
+    }
+
+    @Test
+    fun `the book with the most authors`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                        join(Book::authors),
+                    ).groupBy(
+                        path(Book::isbn),
+                    ).orderBy(
+                        count(Book::isbn).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("01"))
+    }
+
+    @Test
+    fun `the most expensive book`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::salePrice).desc(),
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("10"))
+    }
+
+    @Test
+    fun `the most recently published book`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::salePrice).desc(),
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("10"))
+    }
+
+    @Test
+    fun `books published between January and June 2023`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).where(
+                        path(Book::publishDate).between(
+                            OffsetDateTime.parse("2023-01-01T00:00:00+09:00"),
+                            OffsetDateTime.parse("2023-06-30T23:59:59+09:00"),
+                        ),
+                    ).orderBy(
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+                Isbn("06"),
+            ),
+        )
+    }
+
+    @Test
+    fun `the book with the biggest discounts`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::price)(BookPrice::value).minus(path(Book::salePrice)(BookPrice::value)).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("12"))
+    }
+
+    @Test
+    fun `employees without a nickname`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                    ).where(
+                        path(Employee::nickname).isNull(),
+                    ).orderBy(
+                        path(Employee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                1L,
+                2L,
+                3L,
+                4L,
+                5L,
+                6L,
+                7L,
+                16L,
+                17L,
+                18L,
+                19L,
+                20L,
+                21L,
+                22L,
+                23L,
+            ),
+        )
+    }
+
+    @Test
+    fun the_number_of_employees_per_department() {
+        // given
+        data class Row(
+            val departmentId: Long,
+            val count: Long,
+        )
+
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(EmployeeDepartment::departmentId),
+                        count(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                        join(Employee::departments),
+                    ).groupBy(
+                        path(EmployeeDepartment::departmentId),
+                    ).orderBy(
+                        path(EmployeeDepartment::departmentId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(1, 6),
+                Row(2, 15),
+                Row(3, 18),
+            ),
+        )
+    }
+
+    @Test
+    fun `the number of employees who belong to more than one department`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    val subquery = select(
+                        path(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                        join(Employee::departments),
+                    ).groupBy(
+                        path(Employee::employeeId),
+                    ).having(
+                        count(Employee::employeeId).greaterThan(1L),
+                    ).asSubquery()
+
+                    select(
+                        count(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                    ).where(
+                        path(Employee::employeeId).`in`(subquery),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(listOf(7L))
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/select/SelectMutinyStatelessSessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/select/SelectMutinyStatelessSessionExample.kt
@@ -1,0 +1,321 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.author.Author
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.BookAuthor
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.time.OffsetDateTime
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SelectMutinyStatelessSessionExample : WithAssertions {
+    private lateinit var sessionFactory: Mutiny.SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.mutinySessionFactory()
+    }
+
+    @Test
+    fun `the most prolific author`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Author::authorId),
+                    ).from(
+                        entity(Author::class),
+                        join(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
+                    ).groupBy(
+                        path(Author::authorId),
+                    ).orderBy(
+                        count(Author::authorId).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(1L)
+    }
+
+    @Test
+    fun `authors who haven't written a book`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Author::authorId),
+                    ).from(
+                        entity(Author::class),
+                        leftJoin(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
+                    ).where(
+                        path(BookAuthor::authorId).isNull(),
+                    ).orderBy(
+                        path(Author::authorId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(listOf(4L))
+    }
+
+    @Test
+    fun `the book with the most authors`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                        join(Book::authors),
+                    ).groupBy(
+                        path(Book::isbn),
+                    ).orderBy(
+                        count(Book::isbn).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("01"))
+    }
+
+    @Test
+    fun `the most expensive book`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::salePrice).desc(),
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("10"))
+    }
+
+    @Test
+    fun `the most recently published book`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::salePrice).desc(),
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("10"))
+    }
+
+    @Test
+    fun `books published between January and June 2023`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).where(
+                        path(Book::publishDate).between(
+                            OffsetDateTime.parse("2023-01-01T00:00:00+09:00"),
+                            OffsetDateTime.parse("2023-06-30T23:59:59+09:00"),
+                        ),
+                    ).orderBy(
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+                Isbn("06"),
+            ),
+        )
+    }
+
+    @Test
+    fun `the book with the biggest discounts`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::price)(BookPrice::value).minus(path(Book::salePrice)(BookPrice::value)).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("12"))
+    }
+
+    @Test
+    fun `employees without a nickname`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                    ).where(
+                        path(Employee::nickname).isNull(),
+                    ).orderBy(
+                        path(Employee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                1L,
+                2L,
+                3L,
+                4L,
+                5L,
+                6L,
+                7L,
+                16L,
+                17L,
+                18L,
+                19L,
+                20L,
+                21L,
+                22L,
+                23L,
+            ),
+        )
+    }
+
+    @Test
+    fun the_number_of_employees_per_department() {
+        // given
+        data class Row(
+            val departmentId: Long,
+            val count: Long,
+        )
+
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(EmployeeDepartment::departmentId),
+                        count(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                        join(Employee::departments),
+                    ).groupBy(
+                        path(EmployeeDepartment::departmentId),
+                    ).orderBy(
+                        path(EmployeeDepartment::departmentId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(1, 6),
+                Row(2, 15),
+                Row(3, 18),
+            ),
+        )
+    }
+
+    @Test
+    fun `the number of employees who belong to more than one department`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    val subquery = select(
+                        path(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                        join(Employee::departments),
+                    ).groupBy(
+                        path(Employee::employeeId),
+                    ).having(
+                        count(Employee::employeeId).greaterThan(1L),
+                    ).asSubquery()
+
+                    select(
+                        count(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                    ).where(
+                        path(Employee::employeeId).`in`(subquery),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(listOf(7L))
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/select/SelectStageSessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/select/SelectStageSessionExample.kt
@@ -1,0 +1,321 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.author.Author
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.BookAuthor
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.time.OffsetDateTime
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.stage.Stage
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SelectStageSessionExample : WithAssertions {
+    private lateinit var sessionFactory: Stage.SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.stageSessionFactory()
+    }
+
+    @Test
+    fun `the most prolific author`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Author::authorId),
+                    ).from(
+                        entity(Author::class),
+                        join(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
+                    ).groupBy(
+                        path(Author::authorId),
+                    ).orderBy(
+                        count(Author::authorId).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(1L)
+    }
+
+    @Test
+    fun `authors who haven't written a book`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Author::authorId),
+                    ).from(
+                        entity(Author::class),
+                        leftJoin(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
+                    ).where(
+                        path(BookAuthor::authorId).isNull(),
+                    ).orderBy(
+                        path(Author::authorId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(listOf(4L))
+    }
+
+    @Test
+    fun `the book with the most authors`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                        join(Book::authors),
+                    ).groupBy(
+                        path(Book::isbn),
+                    ).orderBy(
+                        count(Book::isbn).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("01"))
+    }
+
+    @Test
+    fun `the most expensive book`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::salePrice).desc(),
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("10"))
+    }
+
+    @Test
+    fun `the most recently published book`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::salePrice).desc(),
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("10"))
+    }
+
+    @Test
+    fun `books published between January and June 2023`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).where(
+                        path(Book::publishDate).between(
+                            OffsetDateTime.parse("2023-01-01T00:00:00+09:00"),
+                            OffsetDateTime.parse("2023-06-30T23:59:59+09:00"),
+                        ),
+                    ).orderBy(
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+                Isbn("06"),
+            ),
+        )
+    }
+
+    @Test
+    fun `the book with the biggest discounts`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::price)(BookPrice::value).minus(path(Book::salePrice)(BookPrice::value)).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("12"))
+    }
+
+    @Test
+    fun `employees without a nickname`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                    ).where(
+                        path(Employee::nickname).isNull(),
+                    ).orderBy(
+                        path(Employee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                1L,
+                2L,
+                3L,
+                4L,
+                5L,
+                6L,
+                7L,
+                16L,
+                17L,
+                18L,
+                19L,
+                20L,
+                21L,
+                22L,
+                23L,
+            ),
+        )
+    }
+
+    @Test
+    fun the_number_of_employees_per_department() {
+        // given
+        data class Row(
+            val departmentId: Long,
+            val count: Long,
+        )
+
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(EmployeeDepartment::departmentId),
+                        count(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                        join(Employee::departments),
+                    ).groupBy(
+                        path(EmployeeDepartment::departmentId),
+                    ).orderBy(
+                        path(EmployeeDepartment::departmentId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(1, 6),
+                Row(2, 15),
+                Row(3, 18),
+            ),
+        )
+    }
+
+    @Test
+    fun `the number of employees who belong to more than one department`() {
+        // when
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    val subquery = select(
+                        path(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                        join(Employee::departments),
+                    ).groupBy(
+                        path(Employee::employeeId),
+                    ).having(
+                        count(Employee::employeeId).greaterThan(1L),
+                    ).asSubquery()
+
+                    select(
+                        count(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                    ).where(
+                        path(Employee::employeeId).`in`(subquery),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(listOf(7L))
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/select/SelectStageStatelessSessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/select/SelectStageStatelessSessionExample.kt
@@ -1,0 +1,321 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.author.Author
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.BookAuthor
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.time.OffsetDateTime
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.stage.Stage
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SelectStageStatelessSessionExample : WithAssertions {
+    private lateinit var sessionFactory: Stage.SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.stageSessionFactory()
+    }
+
+    @Test
+    fun `the most prolific author`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Author::authorId),
+                    ).from(
+                        entity(Author::class),
+                        join(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
+                    ).groupBy(
+                        path(Author::authorId),
+                    ).orderBy(
+                        count(Author::authorId).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(1L)
+    }
+
+    @Test
+    fun `authors who haven't written a book`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Author::authorId),
+                    ).from(
+                        entity(Author::class),
+                        leftJoin(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
+                    ).where(
+                        path(BookAuthor::authorId).isNull(),
+                    ).orderBy(
+                        path(Author::authorId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(listOf(4L))
+    }
+
+    @Test
+    fun `the book with the most authors`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                        join(Book::authors),
+                    ).groupBy(
+                        path(Book::isbn),
+                    ).orderBy(
+                        count(Book::isbn).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("01"))
+    }
+
+    @Test
+    fun `the most expensive book`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::salePrice).desc(),
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("10"))
+    }
+
+    @Test
+    fun `the most recently published book`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::salePrice).desc(),
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("10"))
+    }
+
+    @Test
+    fun `books published between January and June 2023`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).where(
+                        path(Book::publishDate).between(
+                            OffsetDateTime.parse("2023-01-01T00:00:00+09:00"),
+                            OffsetDateTime.parse("2023-06-30T23:59:59+09:00"),
+                        ),
+                    ).orderBy(
+                        path(Book::isbn).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+                Isbn("06"),
+            ),
+        )
+    }
+
+    @Test
+    fun `the book with the biggest discounts`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Book::isbn),
+                    ).from(
+                        entity(Book::class),
+                    ).orderBy(
+                        path(Book::price)(BookPrice::value).minus(path(Book::salePrice)(BookPrice::value)).desc(),
+                    )
+                },
+                context,
+            ).setMaxResults(1).singleResult
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(Isbn("12"))
+    }
+
+    @Test
+    fun `employees without a nickname`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    select(
+                        path(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                    ).where(
+                        path(Employee::nickname).isNull(),
+                    ).orderBy(
+                        path(Employee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                1L,
+                2L,
+                3L,
+                4L,
+                5L,
+                6L,
+                7L,
+                16L,
+                17L,
+                18L,
+                19L,
+                20L,
+                21L,
+                22L,
+                23L,
+            ),
+        )
+    }
+
+    @Test
+    fun the_number_of_employees_per_department() {
+        // given
+        data class Row(
+            val departmentId: Long,
+            val count: Long,
+        )
+
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(EmployeeDepartment::departmentId),
+                        count(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                        join(Employee::departments),
+                    ).groupBy(
+                        path(EmployeeDepartment::departmentId),
+                    ).orderBy(
+                        path(EmployeeDepartment::departmentId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(1, 6),
+                Row(2, 15),
+                Row(3, 18),
+            ),
+        )
+    }
+
+    @Test
+    fun `the number of employees who belong to more than one department`() {
+        // when
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    val subquery = select(
+                        path(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                        join(Employee::departments),
+                    ).groupBy(
+                        path(Employee::employeeId),
+                    ).having(
+                        count(Employee::employeeId).greaterThan(1L),
+                    ).asSubquery()
+
+                    select(
+                        count(Employee::employeeId),
+                    ).from(
+                        entity(Employee::class),
+                    ).where(
+                        path(Employee::employeeId).`in`(subquery),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(listOf(7L))
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/update/UpdateMutinySessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/update/UpdateMutinySessionExample.kt
@@ -1,0 +1,189 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.update
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.department.Department
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeSalary
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.FullTimeEmployee
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.math.BigDecimal
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UpdateMutinySessionExample : WithAssertions {
+    private lateinit var sessionFactory: Mutiny.SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.mutinySessionFactory()
+    }
+
+    @Test
+    fun increase_the_annual_salaries_of_employees_in_department_03_by_10_percent() {
+        // given
+        data class Row(
+            val employeeId: Long,
+            val annualSalary: EmployeeSalary,
+        )
+
+        // when
+        sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    val employeeIds = select<Long>(
+                        path(EmployeeDepartment::employee)(Employee::employeeId),
+                    ).from(
+                        entity(Department::class),
+                        join(EmployeeDepartment::class)
+                            .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+                    ).where(
+                        path(Department::name).like("%03"),
+                    ).asSubquery()
+
+                    update(
+                        entity(FullTimeEmployee::class),
+                    ).set(
+                        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value),
+                        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value).times(BigDecimal.valueOf(1.1)),
+                    ).where(
+                        path(FullTimeEmployee::employeeId).`in`(employeeIds),
+                    )
+                },
+                context,
+            ).executeUpdate()
+        }.await().indefinitely()
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(FullTimeEmployee::employeeId),
+                        path(FullTimeEmployee::annualSalary),
+                    ).from(
+                        entity(FullTimeEmployee::class),
+                    ).orderBy(
+                        path(FullTimeEmployee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(16, EmployeeSalary(1600)),
+                Row(17, EmployeeSalary(1700)),
+                Row(18, EmployeeSalary(1800)),
+                Row(19, EmployeeSalary(1900)),
+                Row(20, EmployeeSalary(2000)),
+                Row(21, EmployeeSalary(2310)),
+                Row(22, EmployeeSalary(2200)),
+                Row(23, EmployeeSalary(2530)),
+                Row(24, EmployeeSalary(2640)),
+                Row(25, EmployeeSalary(2750)),
+                Row(26, EmployeeSalary(2860)),
+                Row(27, EmployeeSalary(2970)),
+                Row(28, EmployeeSalary(3080)),
+                Row(29, EmployeeSalary(3190)),
+                Row(30, EmployeeSalary(3300)),
+            ),
+        )
+    }
+
+    @Test
+    fun set_the_nickname_to_the_name_for_employees_in_department_03_who_do_not_have_nicknames() {
+        // given
+        data class Row(
+            val employeeId: Long,
+            val nickname: String?,
+        )
+
+        // when
+        sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    val employeeIds = select<Long>(
+                        path(EmployeeDepartment::employee)(Employee::employeeId),
+                    ).from(
+                        entity(Department::class),
+                        join(EmployeeDepartment::class)
+                            .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+                    ).where(
+                        path(Department::name).like("%03"),
+                    ).asSubquery()
+
+                    update(
+                        entity(Employee::class),
+                    ).set(
+                        path(Employee::nickname),
+                        path(Employee::name),
+                    ).whereAnd(
+                        path(Employee::nickname).isNull(),
+                        path(Employee::employeeId).`in`(employeeIds),
+                    )
+                },
+                context,
+            ).executeUpdate()
+        }.await().indefinitely()
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(Employee::employeeId),
+                        path(Employee::nickname),
+                    ).from(
+                        entity(Employee::class),
+                    ).orderBy(
+                        path(Employee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(1, "Employee01"),
+                Row(2, null),
+                Row(3, null),
+                Row(4, null),
+                Row(5, null),
+                Row(6, null),
+                Row(7, "Employee07"),
+                Row(8, "Nickname08"),
+                Row(9, "Nickname09"),
+                Row(10, "Nickname10"),
+                Row(11, "Nickname11"),
+                Row(12, "Nickname12"),
+                Row(13, "Nickname13"),
+                Row(14, "Nickname14"),
+                Row(15, "Nickname15"),
+                Row(16, null),
+                Row(17, null),
+                Row(18, null),
+                Row(19, null),
+                Row(20, null),
+                Row(21, "Employee21"),
+                Row(22, null),
+                Row(23, "Employee23"),
+                Row(24, "Nickname24"),
+                Row(25, "Nickname25"),
+                Row(26, "Nickname26"),
+                Row(27, "Nickname27"),
+                Row(28, "Nickname28"),
+                Row(29, "Nickname29"),
+                Row(30, "Nickname30"),
+            ),
+        )
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/update/UpdateMutinyStatelessSessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/update/UpdateMutinyStatelessSessionExample.kt
@@ -1,0 +1,189 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.update
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.department.Department
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeSalary
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.FullTimeEmployee
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.math.BigDecimal
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UpdateMutinyStatelessSessionExample : WithAssertions {
+    private lateinit var sessionFactory: Mutiny.SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.mutinySessionFactory()
+    }
+
+    @Test
+    fun increase_the_annual_salaries_of_employees_in_department_03_by_10_percent() {
+        // given
+        data class Row(
+            val employeeId: Long,
+            val annualSalary: EmployeeSalary,
+        )
+
+        // when
+        sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    val employeeIds = select<Long>(
+                        path(EmployeeDepartment::employee)(Employee::employeeId),
+                    ).from(
+                        entity(Department::class),
+                        join(EmployeeDepartment::class)
+                            .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+                    ).where(
+                        path(Department::name).like("%03"),
+                    ).asSubquery()
+
+                    update(
+                        entity(FullTimeEmployee::class),
+                    ).set(
+                        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value),
+                        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value).times(BigDecimal.valueOf(1.1)),
+                    ).where(
+                        path(FullTimeEmployee::employeeId).`in`(employeeIds),
+                    )
+                },
+                context,
+            ).executeUpdate()
+        }.await().indefinitely()
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(FullTimeEmployee::employeeId),
+                        path(FullTimeEmployee::annualSalary),
+                    ).from(
+                        entity(FullTimeEmployee::class),
+                    ).orderBy(
+                        path(FullTimeEmployee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(16, EmployeeSalary(1600)),
+                Row(17, EmployeeSalary(1700)),
+                Row(18, EmployeeSalary(1800)),
+                Row(19, EmployeeSalary(1900)),
+                Row(20, EmployeeSalary(2000)),
+                Row(21, EmployeeSalary(2310)),
+                Row(22, EmployeeSalary(2200)),
+                Row(23, EmployeeSalary(2530)),
+                Row(24, EmployeeSalary(2640)),
+                Row(25, EmployeeSalary(2750)),
+                Row(26, EmployeeSalary(2860)),
+                Row(27, EmployeeSalary(2970)),
+                Row(28, EmployeeSalary(3080)),
+                Row(29, EmployeeSalary(3190)),
+                Row(30, EmployeeSalary(3300)),
+            ),
+        )
+    }
+
+    @Test
+    fun set_the_nickname_to_the_name_for_employees_in_department_03_who_do_not_have_nicknames() {
+        // given
+        data class Row(
+            val employeeId: Long,
+            val nickname: String?,
+        )
+
+        // when
+        sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    val employeeIds = select<Long>(
+                        path(EmployeeDepartment::employee)(Employee::employeeId),
+                    ).from(
+                        entity(Department::class),
+                        join(EmployeeDepartment::class)
+                            .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+                    ).where(
+                        path(Department::name).like("%03"),
+                    ).asSubquery()
+
+                    update(
+                        entity(Employee::class),
+                    ).set(
+                        path(Employee::nickname),
+                        path(Employee::name),
+                    ).whereAnd(
+                        path(Employee::nickname).isNull(),
+                        path(Employee::employeeId).`in`(employeeIds),
+                    )
+                },
+                context,
+            ).executeUpdate()
+        }.await().indefinitely()
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(Employee::employeeId),
+                        path(Employee::nickname),
+                    ).from(
+                        entity(Employee::class),
+                    ).orderBy(
+                        path(Employee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(1, "Employee01"),
+                Row(2, null),
+                Row(3, null),
+                Row(4, null),
+                Row(5, null),
+                Row(6, null),
+                Row(7, "Employee07"),
+                Row(8, "Nickname08"),
+                Row(9, "Nickname09"),
+                Row(10, "Nickname10"),
+                Row(11, "Nickname11"),
+                Row(12, "Nickname12"),
+                Row(13, "Nickname13"),
+                Row(14, "Nickname14"),
+                Row(15, "Nickname15"),
+                Row(16, null),
+                Row(17, null),
+                Row(18, null),
+                Row(19, null),
+                Row(20, null),
+                Row(21, "Employee21"),
+                Row(22, null),
+                Row(23, "Employee23"),
+                Row(24, "Nickname24"),
+                Row(25, "Nickname25"),
+                Row(26, "Nickname26"),
+                Row(27, "Nickname27"),
+                Row(28, "Nickname28"),
+                Row(29, "Nickname29"),
+                Row(30, "Nickname30"),
+            ),
+        )
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/update/UpdateStageSessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/update/UpdateStageSessionExample.kt
@@ -1,0 +1,189 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.update
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.department.Department
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeSalary
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.FullTimeEmployee
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.math.BigDecimal
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.stage.Stage
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UpdateStageSessionExample : WithAssertions {
+    private lateinit var sessionFactory: Stage.SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.stageSessionFactory()
+    }
+
+    @Test
+    fun increase_the_annual_salaries_of_employees_in_department_03_by_10_percent() {
+        // given
+        data class Row(
+            val employeeId: Long,
+            val annualSalary: EmployeeSalary,
+        )
+
+        // when
+        sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    val employeeIds = select<Long>(
+                        path(EmployeeDepartment::employee)(Employee::employeeId),
+                    ).from(
+                        entity(Department::class),
+                        join(EmployeeDepartment::class)
+                            .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+                    ).where(
+                        path(Department::name).like("%03"),
+                    ).asSubquery()
+
+                    update(
+                        entity(FullTimeEmployee::class),
+                    ).set(
+                        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value),
+                        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value).times(BigDecimal.valueOf(1.1)),
+                    ).where(
+                        path(FullTimeEmployee::employeeId).`in`(employeeIds),
+                    )
+                },
+                context,
+            ).executeUpdate()
+        }.toCompletableFuture().get()
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(FullTimeEmployee::employeeId),
+                        path(FullTimeEmployee::annualSalary),
+                    ).from(
+                        entity(FullTimeEmployee::class),
+                    ).orderBy(
+                        path(FullTimeEmployee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(16, EmployeeSalary(1600)),
+                Row(17, EmployeeSalary(1700)),
+                Row(18, EmployeeSalary(1800)),
+                Row(19, EmployeeSalary(1900)),
+                Row(20, EmployeeSalary(2000)),
+                Row(21, EmployeeSalary(2310)),
+                Row(22, EmployeeSalary(2200)),
+                Row(23, EmployeeSalary(2530)),
+                Row(24, EmployeeSalary(2640)),
+                Row(25, EmployeeSalary(2750)),
+                Row(26, EmployeeSalary(2860)),
+                Row(27, EmployeeSalary(2970)),
+                Row(28, EmployeeSalary(3080)),
+                Row(29, EmployeeSalary(3190)),
+                Row(30, EmployeeSalary(3300)),
+            ),
+        )
+    }
+
+    @Test
+    fun set_the_nickname_to_the_name_for_employees_in_department_03_who_do_not_have_nicknames() {
+        // given
+        data class Row(
+            val employeeId: Long,
+            val nickname: String?,
+        )
+
+        // when
+        sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    val employeeIds = select<Long>(
+                        path(EmployeeDepartment::employee)(Employee::employeeId),
+                    ).from(
+                        entity(Department::class),
+                        join(EmployeeDepartment::class)
+                            .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+                    ).where(
+                        path(Department::name).like("%03"),
+                    ).asSubquery()
+
+                    update(
+                        entity(Employee::class),
+                    ).set(
+                        path(Employee::nickname),
+                        path(Employee::name),
+                    ).whereAnd(
+                        path(Employee::nickname).isNull(),
+                        path(Employee::employeeId).`in`(employeeIds),
+                    )
+                },
+                context,
+            ).executeUpdate()
+        }.toCompletableFuture().get()
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(Employee::employeeId),
+                        path(Employee::nickname),
+                    ).from(
+                        entity(Employee::class),
+                    ).orderBy(
+                        path(Employee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(1, "Employee01"),
+                Row(2, null),
+                Row(3, null),
+                Row(4, null),
+                Row(5, null),
+                Row(6, null),
+                Row(7, "Employee07"),
+                Row(8, "Nickname08"),
+                Row(9, "Nickname09"),
+                Row(10, "Nickname10"),
+                Row(11, "Nickname11"),
+                Row(12, "Nickname12"),
+                Row(13, "Nickname13"),
+                Row(14, "Nickname14"),
+                Row(15, "Nickname15"),
+                Row(16, null),
+                Row(17, null),
+                Row(18, null),
+                Row(19, null),
+                Row(20, null),
+                Row(21, "Employee21"),
+                Row(22, null),
+                Row(23, "Employee23"),
+                Row(24, "Nickname24"),
+                Row(25, "Nickname25"),
+                Row(26, "Nickname26"),
+                Row(27, "Nickname27"),
+                Row(28, "Nickname28"),
+                Row(29, "Nickname29"),
+                Row(30, "Nickname30"),
+            ),
+        )
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/update/UpdateStageStatelessSessionExample.kt
+++ b/example/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/reactive/javax/update/UpdateStageStatelessSessionExample.kt
@@ -1,0 +1,189 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.update
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.SessionFactoryCreator
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.department.Department
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.Employee
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeDepartment
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.EmployeeSalary
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.reactive.javax.entity.employee.FullTimeEmployee
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import java.math.BigDecimal
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.stage.Stage
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class UpdateStageStatelessSessionExample : WithAssertions {
+    private lateinit var sessionFactory: Stage.SessionFactory
+
+    private val context = JpqlRenderContext()
+
+    @BeforeEach
+    fun before() {
+        sessionFactory = SessionFactoryCreator.stageSessionFactory()
+    }
+
+    @Test
+    fun increase_the_annual_salaries_of_employees_in_department_03_by_10_percent() {
+        // given
+        data class Row(
+            val employeeId: Long,
+            val annualSalary: EmployeeSalary,
+        )
+
+        // when
+        sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    val employeeIds = select<Long>(
+                        path(EmployeeDepartment::employee)(Employee::employeeId),
+                    ).from(
+                        entity(Department::class),
+                        join(EmployeeDepartment::class)
+                            .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+                    ).where(
+                        path(Department::name).like("%03"),
+                    ).asSubquery()
+
+                    update(
+                        entity(FullTimeEmployee::class),
+                    ).set(
+                        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value),
+                        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value).times(BigDecimal.valueOf(1.1)),
+                    ).where(
+                        path(FullTimeEmployee::employeeId).`in`(employeeIds),
+                    )
+                },
+                context,
+            ).executeUpdate()
+        }.toCompletableFuture().get()
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(FullTimeEmployee::employeeId),
+                        path(FullTimeEmployee::annualSalary),
+                    ).from(
+                        entity(FullTimeEmployee::class),
+                    ).orderBy(
+                        path(FullTimeEmployee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(16, EmployeeSalary(1600)),
+                Row(17, EmployeeSalary(1700)),
+                Row(18, EmployeeSalary(1800)),
+                Row(19, EmployeeSalary(1900)),
+                Row(20, EmployeeSalary(2000)),
+                Row(21, EmployeeSalary(2310)),
+                Row(22, EmployeeSalary(2200)),
+                Row(23, EmployeeSalary(2530)),
+                Row(24, EmployeeSalary(2640)),
+                Row(25, EmployeeSalary(2750)),
+                Row(26, EmployeeSalary(2860)),
+                Row(27, EmployeeSalary(2970)),
+                Row(28, EmployeeSalary(3080)),
+                Row(29, EmployeeSalary(3190)),
+                Row(30, EmployeeSalary(3300)),
+            ),
+        )
+    }
+
+    @Test
+    fun set_the_nickname_to_the_name_for_employees_in_department_03_who_do_not_have_nicknames() {
+        // given
+        data class Row(
+            val employeeId: Long,
+            val nickname: String?,
+        )
+
+        // when
+        sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    val employeeIds = select<Long>(
+                        path(EmployeeDepartment::employee)(Employee::employeeId),
+                    ).from(
+                        entity(Department::class),
+                        join(EmployeeDepartment::class)
+                            .on(path(Department::departmentId).equal(path(EmployeeDepartment::departmentId))),
+                    ).where(
+                        path(Department::name).like("%03"),
+                    ).asSubquery()
+
+                    update(
+                        entity(Employee::class),
+                    ).set(
+                        path(Employee::nickname),
+                        path(Employee::name),
+                    ).whereAnd(
+                        path(Employee::nickname).isNull(),
+                        path(Employee::employeeId).`in`(employeeIds),
+                    )
+                },
+                context,
+            ).executeUpdate()
+        }.toCompletableFuture().get()
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(
+                jpql {
+                    selectNew<Row>(
+                        path(Employee::employeeId),
+                        path(Employee::nickname),
+                    ).from(
+                        entity(Employee::class),
+                    ).orderBy(
+                        path(Employee::employeeId).asc(),
+                    )
+                },
+                context,
+            ).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Row(1, "Employee01"),
+                Row(2, null),
+                Row(3, null),
+                Row(4, null),
+                Row(5, null),
+                Row(6, null),
+                Row(7, "Employee07"),
+                Row(8, "Nickname08"),
+                Row(9, "Nickname09"),
+                Row(10, "Nickname10"),
+                Row(11, "Nickname11"),
+                Row(12, "Nickname12"),
+                Row(13, "Nickname13"),
+                Row(14, "Nickname14"),
+                Row(15, "Nickname15"),
+                Row(16, null),
+                Row(17, null),
+                Row(18, null),
+                Row(19, null),
+                Row(20, null),
+                Row(21, "Employee21"),
+                Row(22, null),
+                Row(23, "Employee23"),
+                Row(24, "Nickname24"),
+                Row(25, "Nickname25"),
+                Row(26, "Nickname26"),
+                Row(27, "Nickname27"),
+                Row(28, "Nickname28"),
+                Row(29, "Nickname29"),
+                Row(30, "Nickname30"),
+            ),
+        )
+    }
+}

--- a/example/hibernate-reactive-javax/src/test/resources/drop.sql
+++ b/example/hibernate-reactive-javax/src/test/resources/drop.sql
@@ -1,0 +1,8 @@
+drop table if exists author;
+drop table if exists publisher;
+drop table if exists book;
+drop table if exists book_author;
+drop table if exists book_publisher;
+drop table if exists department;
+drop table if exists employee;
+drop table if exists employee_department;

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -4,8 +4,10 @@ kotlin = "1.9.0"
 spring6 = "6.0.11"
 spring5 = "5.3.29"
 
-test-spring-boot3 = "3.1.2"
+test-spring-boot3 = "3.1.3"
 test-spring-boot2 = "2.7.15"
+
+mutiny = "2.4.0"
 
 [libraries]
 # kotlin
@@ -22,6 +24,21 @@ logback = { module = "ch.qos.logback:logback-classic", version = "1.2.11" }
 # SpringBoot
 spring-boot3-starter = { module = "org.springframework.boot:spring-boot-starter", version = "3.0.3" }
 spring-boot2-starter = { module = "org.springframework.boot:spring-boot-starter", version = "2.7.10" }
+
+# hibernate-reactive
+hibernate-reactive1 = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "1.1.9.Final" }
+hibernate-reactive2 = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "2.0.4" }
+
+# vertx-jdbc-client
+vertx-jdbc-client = { module = "io.vertx:vertx-jdbc-client", version = "4.4.5" }
+agroal-pool = { module = "io.agroal:agroal-pool", version = "2.2" }
+
+# coroutines
+coroutine-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version = "1.7.3" }
+
+# mutiny
+mutiny-core = { module = "io.smallrye.reactive:mutiny", version.ref = "mutiny" }
+mutiny-kotlin = { module = "io.smallrye.reactive:mutiny-kotlin", version.ref = "mutiny" }
 
 # Spring
 spring-jdbc = { module = "org.springframework:spring-jdbc", version = "6.0.11" }
@@ -48,11 +65,14 @@ test-spring-boot2-test = { module = "org.springframework.boot:spring-boot-starte
 test-spring-batch5-test = { module = "org.springframework.batch:spring-batch-test", version = "5.0.3" }
 test-spring-batch4-test = { module = "org.springframework.batch:spring-batch-test", version = "4.3.9" }
 
-test-junit = { module = "org.junit.jupiter:junit-jupiter", version = "5.9.2" }
+test-junit = { module = "org.junit.jupiter:junit-jupiter", version = "5.10.0" }
 test-assertJ = { module = "org.assertj:assertj-core", version = "3.24.2" }
-test-mockk = { module = "io.mockk:mockk", version = "1.13.4" }
+test-mockk = { module = "io.mockk:mockk", version = "1.13.7" }
 
-test-h2 = { module = "com.h2database:h2", version = "2.2.220" }
+test-h2 = { module = "com.h2database:h2", version = "2.2.222" }
+
+[bundles]
+mutiny = ["mutiny-core", "mutiny-kotlin"]
 
 [plugins]
 test-spring-boot3 = { id = "org.springframework.boot", version.ref = "test-spring-boot3" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,11 +25,13 @@ module(name = ":support", path = "support")
 module(name = ":spring-batch-support", path = "support/spring-batch")
 module(name = ":spring-data-jpa-support", path = "support/spring-data-jpa")
 module(name = ":spring-data-jpa-javax-support", path = "support/spring-data-jpa-javax")
+module(name = ":hibernate-reactive-javax-support", path = "support/hibernate-reactive-javax")
 
 module(name = ":example", path = "example")
 module(name = ":spring-batch-example", path = "example/spring-batch")
 module(name = ":spring-data-jpa-example", path = "example/spring-data-jpa")
 module(name = ":spring-data-jpa-javax-example", path = "example/spring-data-jpa-javax")
+module(name = ":hibernate-reactive-javax-example", path = "example/hibernate-reactive-javax")
 
 module(name = ":benchmark", path = "benchmark")
 

--- a/support/hibernate-reactive-javax/build.gradle.kts
+++ b/support/hibernate-reactive-javax/build.gradle.kts
@@ -1,0 +1,23 @@
+@file:Suppress("VulnerableLibrariesLocal")
+
+dependencies {
+    compileOnly(libs.hibernate.reactive1)
+    compileOnly(libs.javax.persistence.api)
+    compileOnly(projects.jpqlDsl)
+    compileOnly(projects.jpqlQueryModel)
+    compileOnly(projects.jpqlRender)
+    compileOnly(libs.bundles.mutiny)
+
+    testImplementation(libs.test.assertJ)
+    testImplementation(libs.test.mockk)
+    testImplementation(libs.hibernate.reactive1)
+    testImplementation(libs.javax.persistence.api)
+    testImplementation(libs.bundles.mutiny)
+    testImplementation(projects.jpqlDsl)
+    testImplementation(projects.jpqlQueryModel)
+    testImplementation(projects.jpqlRender)
+}
+
+kotlin {
+    jvmToolchain(17)
+}

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinySessionUtils.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinySessionUtils.kt
@@ -1,0 +1,100 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
+import kotlin.reflect.KClass
+import org.hibernate.reactive.mutiny.Mutiny
+
+internal object JpqlMutinySessionUtils {
+    fun <T : Any> createQuery(
+        session: Mutiny.Session,
+        query: SelectQuery<T>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered, query.returnType)
+    }
+
+    fun <T : Any> createQuery(
+        session: Mutiny.Session,
+        query: SelectQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered, query.returnType)
+    }
+
+    fun <T : Any> createQuery(
+        session: Mutiny.Session,
+        query: UpdateQuery<T>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Mutiny.Session,
+        query: UpdateQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Mutiny.Session,
+        query: DeleteQuery<T>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Mutiny.Session,
+        query: DeleteQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered)
+    }
+
+    private fun <T : Any> createQuery(
+        session: Mutiny.Session,
+        rendered: JpqlRendered,
+        resultClass: KClass<T>,
+    ): Mutiny.Query<T> {
+        return session.createQuery(rendered.query, resultClass.java).apply {
+            setParams(this, rendered.params)
+        }
+    }
+
+    private fun <T> createQuery(
+        session: Mutiny.Session,
+        rendered: JpqlRendered,
+    ): Mutiny.Query<T> {
+        return session.createQuery<T>(rendered.query).apply {
+            setParams(this, rendered.params)
+        }
+    }
+
+    private fun <T> setParams(query: Mutiny.Query<T>, params: JpqlRenderedParams) {
+        params.forEach { (name, value) ->
+            query.setParameter(name, value)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinyStatelessSessionUtils.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinyStatelessSessionUtils.kt
@@ -1,0 +1,100 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
+import kotlin.reflect.KClass
+import org.hibernate.reactive.mutiny.Mutiny
+
+internal object JpqlMutinyStatelessSessionUtils {
+    fun <T : Any> createQuery(
+        session: Mutiny.StatelessSession,
+        query: SelectQuery<T>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered, query.returnType)
+    }
+
+    fun <T : Any> createQuery(
+        session: Mutiny.StatelessSession,
+        query: SelectQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered, query.returnType)
+    }
+
+    fun <T : Any> createQuery(
+        session: Mutiny.StatelessSession,
+        query: UpdateQuery<T>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Mutiny.StatelessSession,
+        query: UpdateQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Mutiny.StatelessSession,
+        query: DeleteQuery<T>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Mutiny.StatelessSession,
+        query: DeleteQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Mutiny.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered)
+    }
+
+    private fun <T : Any> createQuery(
+        session: Mutiny.StatelessSession,
+        rendered: JpqlRendered,
+        resultClass: KClass<T>,
+    ): Mutiny.Query<T> {
+        return session.createQuery(rendered.query, resultClass.java).apply {
+            setParams(this, rendered.params)
+        }
+    }
+
+    private fun <T> createQuery(
+        session: Mutiny.StatelessSession,
+        rendered: JpqlRendered,
+    ): Mutiny.Query<T> {
+        return session.createQuery<T>(rendered.query).apply {
+            setParams(this, rendered.params)
+        }
+    }
+
+    private fun <T> setParams(query: Mutiny.Query<T>, params: JpqlRenderedParams) {
+        params.forEach { (name, value) ->
+            query.setParameter(name, value)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlRendererHolder.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlRendererHolder.kt
@@ -1,0 +1,15 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive
+
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+
+internal object JpqlRendererHolder {
+    private var renderer = JpqlRenderer()
+
+    fun get(): JpqlRenderer {
+        return renderer
+    }
+
+    fun set(renderer: JpqlRenderer) {
+        JpqlRendererHolder.renderer = renderer
+    }
+}

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageSessionUtils.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageSessionUtils.kt
@@ -1,0 +1,100 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
+import kotlin.reflect.KClass
+import org.hibernate.reactive.stage.Stage
+
+internal object JpqlStageSessionUtils {
+    fun <T : Any> createQuery(
+        session: Stage.Session,
+        query: SelectQuery<T>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered, query.returnType)
+    }
+
+    fun <T : Any> createQuery(
+        session: Stage.Session,
+        query: SelectQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered, query.returnType)
+    }
+
+    fun <T : Any> createQuery(
+        session: Stage.Session,
+        query: UpdateQuery<T>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Stage.Session,
+        query: UpdateQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Stage.Session,
+        query: DeleteQuery<T>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Stage.Session,
+        query: DeleteQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered)
+    }
+
+    private fun <T : Any> createQuery(
+        session: Stage.Session,
+        rendered: JpqlRendered,
+        resultClass: KClass<T>,
+    ): Stage.Query<T> {
+        return session.createQuery(rendered.query, resultClass.java).apply {
+            setParams(this, rendered.params)
+        }
+    }
+
+    private fun <T> createQuery(
+        session: Stage.Session,
+        rendered: JpqlRendered,
+    ): Stage.Query<T> {
+        return session.createQuery<T>(rendered.query).apply {
+            setParams(this, rendered.params)
+        }
+    }
+
+    private fun <T> setParams(query: Stage.Query<T>, params: JpqlRenderedParams) {
+        params.forEach { (name, value) ->
+            query.setParameter(name, value)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageStatelessSessionUtils.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageStatelessSessionUtils.kt
@@ -1,0 +1,100 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
+import kotlin.reflect.KClass
+import org.hibernate.reactive.stage.Stage
+
+internal object JpqlStageStatelessSessionUtils {
+    fun <T : Any> createQuery(
+        session: Stage.StatelessSession,
+        query: SelectQuery<T>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered, query.returnType)
+    }
+
+    fun <T : Any> createQuery(
+        session: Stage.StatelessSession,
+        query: SelectQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered, query.returnType)
+    }
+
+    fun <T : Any> createQuery(
+        session: Stage.StatelessSession,
+        query: UpdateQuery<T>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Stage.StatelessSession,
+        query: UpdateQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Stage.StatelessSession,
+        query: DeleteQuery<T>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(session, rendered)
+    }
+
+    fun <T : Any> createQuery(
+        session: Stage.StatelessSession,
+        query: DeleteQuery<T>,
+        queryParams: Map<String, Any?>,
+        context: RenderContext,
+    ): Stage.Query<T> {
+        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
+
+        return createQuery(session, rendered)
+    }
+
+    private fun <T : Any> createQuery(
+        session: Stage.StatelessSession,
+        rendered: JpqlRendered,
+        resultClass: KClass<T>,
+    ): Stage.Query<T> {
+        return session.createQuery(rendered.query, resultClass.java).apply {
+            setParams(this, rendered.params)
+        }
+    }
+
+    private fun <T> createQuery(
+        session: Stage.StatelessSession,
+        rendered: JpqlRendered,
+    ): Stage.Query<T> {
+        return session.createQuery<T>(rendered.query).apply {
+            setParams(this, rendered.params)
+        }
+    }
+
+    private fun <T> setParams(query: Stage.Query<T>, params: JpqlRenderedParams) {
+        params.forEach { (name, value) ->
+            query.setParameter(name, value)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/MutinySessionExtensions.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/MutinySessionExtensions.kt
@@ -1,0 +1,48 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive.extension
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.JpqlMutinySessionUtils
+import org.hibernate.reactive.mutiny.Mutiny
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.Session.createQuery(
+    query: SelectQuery<T>,
+    context: RenderContext,
+) = JpqlMutinySessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.Session.createQuery(
+    query: SelectQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlMutinySessionUtils.createQuery(this, query, queryParams, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.Session.createQuery(
+    query: UpdateQuery<T>,
+    context: RenderContext,
+) = JpqlMutinySessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.Session.createQuery(
+    query: UpdateQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlMutinySessionUtils.createQuery(this, query, queryParams, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.Session.createQuery(
+    query: DeleteQuery<T>,
+    context: RenderContext,
+) = JpqlMutinySessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.Session.createQuery(
+    query: DeleteQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlMutinySessionUtils.createQuery(this, query, queryParams, context)

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/MutinyStatelessSessionExtensions.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/MutinyStatelessSessionExtensions.kt
@@ -1,0 +1,48 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive.extension
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.JpqlMutinyStatelessSessionUtils
+import org.hibernate.reactive.mutiny.Mutiny
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.StatelessSession.createQuery(
+    query: SelectQuery<T>,
+    context: RenderContext,
+) = JpqlMutinyStatelessSessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.StatelessSession.createQuery(
+    query: SelectQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlMutinyStatelessSessionUtils.createQuery(this, query, queryParams, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.StatelessSession.createQuery(
+    query: UpdateQuery<T>,
+    context: RenderContext,
+) = JpqlMutinyStatelessSessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.StatelessSession.createQuery(
+    query: UpdateQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlMutinyStatelessSessionUtils.createQuery(this, query, queryParams, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.StatelessSession.createQuery(
+    query: DeleteQuery<T>,
+    context: RenderContext,
+) = JpqlMutinyStatelessSessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Mutiny.StatelessSession.createQuery(
+    query: DeleteQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlMutinyStatelessSessionUtils.createQuery(this, query, queryParams, context)

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/StageSessionExtensions.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/StageSessionExtensions.kt
@@ -1,0 +1,48 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive.extension
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.JpqlStageSessionUtils
+import org.hibernate.reactive.stage.Stage
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.Session.createQuery(
+    query: SelectQuery<T>,
+    context: RenderContext,
+) = JpqlStageSessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.Session.createQuery(
+    query: SelectQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlStageSessionUtils.createQuery(this, query, queryParams, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.Session.createQuery(
+    query: UpdateQuery<T>,
+    context: RenderContext,
+) = JpqlStageSessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.Session.createQuery(
+    query: UpdateQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlStageSessionUtils.createQuery(this, query, queryParams, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.Session.createQuery(
+    query: DeleteQuery<T>,
+    context: RenderContext,
+) = JpqlStageSessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.Session.createQuery(
+    query: DeleteQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlStageSessionUtils.createQuery(this, query, queryParams, context)

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/StageStatelessSessionExtensions.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/StageStatelessSessionExtensions.kt
@@ -1,0 +1,48 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive.extension
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.JpqlStageStatelessSessionUtils
+import org.hibernate.reactive.stage.Stage
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.StatelessSession.createQuery(
+    query: SelectQuery<T>,
+    context: RenderContext,
+) = JpqlStageStatelessSessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.StatelessSession.createQuery(
+    query: SelectQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlStageStatelessSessionUtils.createQuery(this, query, queryParams, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.StatelessSession.createQuery(
+    query: UpdateQuery<T>,
+    context: RenderContext,
+) = JpqlStageStatelessSessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.StatelessSession.createQuery(
+    query: UpdateQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlStageStatelessSessionUtils.createQuery(this, query, queryParams, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.StatelessSession.createQuery(
+    query: DeleteQuery<T>,
+    context: RenderContext,
+) = JpqlStageStatelessSessionUtils.createQuery(this, query, context)
+
+@SinceJdsl("3.0.0")
+fun <T : Any> Stage.StatelessSession.createQuery(
+    query: DeleteQuery<T>,
+    queryParams: Map<String, Any?>,
+    context: RenderContext,
+) = JpqlStageStatelessSessionUtils.createQuery(this, query, queryParams, context)

--- a/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinySessionUtilsTest.kt
+++ b/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinySessionUtilsTest.kt
@@ -1,0 +1,207 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import io.mockk.every
+import io.mockk.excludeRecords
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockkObject
+import io.mockk.verifySequence
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class JpqlMutinySessionUtilsTest : WithAssertions {
+    @MockK
+    private lateinit var session: Mutiny.Session
+
+    @MockK
+    private lateinit var selectQuery: SelectQuery<String>
+
+    @MockK
+    private lateinit var updateQuery: UpdateQuery<String>
+
+    @MockK
+    private lateinit var deleteQuery: DeleteQuery<String>
+
+    @MockK
+    private lateinit var query: Mutiny.Query<String>
+
+    @MockK
+    private lateinit var renderer: JpqlRenderer
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    private val renderedQuery1 = "query"
+    private val renderedParam1 = "queryParam1" to "queryParamValue1"
+    private val renderedParam2 = "queryParam2" to "queryParamValue2"
+
+    private val queryParam1 = "queryParam1" to "queryParamValue1"
+    private val queryParam2 = "queryParam2" to "queryParamValue2"
+
+    @BeforeEach
+    @Suppress("UnusedEquals")
+    fun setUp() {
+        mockkObject(JpqlRendererHolder)
+
+        every { JpqlRendererHolder.get() } returns renderer
+
+        excludeRecords { JpqlRendererHolder.get() }
+        excludeRecords { query.equals(any()) }
+    }
+
+    @Test
+    fun `createQuery - select query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { selectQuery.returnType } returns String::class
+        every { session.createQuery(any<String>(), any<Class<String>>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinySessionUtils.createQuery(session, selectQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(selectQuery, context)
+            selectQuery.returnType
+            session.createQuery(rendered1.query, String::class.java)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - select query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { selectQuery.returnType } returns String::class
+        every { session.createQuery(any<String>(), any<Class<String>>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinySessionUtils
+            .createQuery(session, selectQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(selectQuery, mapOf(queryParam1, queryParam2), context)
+            selectQuery.returnType
+            session.createQuery(rendered1.query, String::class.java)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinySessionUtils.createQuery(session, updateQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(updateQuery, context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinySessionUtils
+            .createQuery(session, updateQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(updateQuery, mapOf(queryParam1, queryParam2), context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinySessionUtils.createQuery(session, deleteQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(deleteQuery, context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinySessionUtils
+            .createQuery(session, deleteQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(deleteQuery, mapOf(queryParam1, queryParam2), context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinyStatelessSessionUtilsTest.kt
+++ b/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinyStatelessSessionUtilsTest.kt
@@ -1,0 +1,207 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import io.mockk.every
+import io.mockk.excludeRecords
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockkObject
+import io.mockk.verifySequence
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class JpqlMutinyStatelessSessionUtilsTest : WithAssertions {
+    @MockK
+    private lateinit var session: Mutiny.StatelessSession
+
+    @MockK
+    private lateinit var selectQuery: SelectQuery<String>
+
+    @MockK
+    private lateinit var updateQuery: UpdateQuery<String>
+
+    @MockK
+    private lateinit var deleteQuery: DeleteQuery<String>
+
+    @MockK
+    private lateinit var query: Mutiny.Query<String>
+
+    @MockK
+    private lateinit var renderer: JpqlRenderer
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    private val renderedQuery1 = "query"
+    private val renderedParam1 = "queryParam1" to "queryParamValue1"
+    private val renderedParam2 = "queryParam2" to "queryParamValue2"
+
+    private val queryParam1 = "queryParam1" to "queryParamValue1"
+    private val queryParam2 = "queryParam2" to "queryParamValue2"
+
+    @BeforeEach
+    @Suppress("UnusedEquals")
+    fun setUp() {
+        mockkObject(JpqlRendererHolder)
+
+        every { JpqlRendererHolder.get() } returns renderer
+
+        excludeRecords { JpqlRendererHolder.get() }
+        excludeRecords { query.equals(any()) }
+    }
+
+    @Test
+    fun `createQuery - select query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { selectQuery.returnType } returns String::class
+        every { session.createQuery(any<String>(), any<Class<String>>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinyStatelessSessionUtils.createQuery(session, selectQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(selectQuery, context)
+            selectQuery.returnType
+            session.createQuery(rendered1.query, String::class.java)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - select query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { selectQuery.returnType } returns String::class
+        every { session.createQuery(any<String>(), any<Class<String>>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinyStatelessSessionUtils
+            .createQuery(session, selectQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(selectQuery, mapOf(queryParam1, queryParam2), context)
+            selectQuery.returnType
+            session.createQuery(rendered1.query, String::class.java)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinyStatelessSessionUtils.createQuery(session, updateQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(updateQuery, context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinyStatelessSessionUtils
+            .createQuery(session, updateQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(updateQuery, mapOf(queryParam1, queryParam2), context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinyStatelessSessionUtils.createQuery(session, deleteQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(deleteQuery, context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlMutinyStatelessSessionUtils
+            .createQuery(session, deleteQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(deleteQuery, mapOf(queryParam1, queryParam2), context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageSessionUtilsTest.kt
+++ b/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageSessionUtilsTest.kt
@@ -1,0 +1,207 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import io.mockk.every
+import io.mockk.excludeRecords
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockkObject
+import io.mockk.verifySequence
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.stage.Stage
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class JpqlStageSessionUtilsTest : WithAssertions {
+    @MockK
+    private lateinit var session: Stage.Session
+
+    @MockK
+    private lateinit var selectQuery: SelectQuery<String>
+
+    @MockK
+    private lateinit var updateQuery: UpdateQuery<String>
+
+    @MockK
+    private lateinit var deleteQuery: DeleteQuery<String>
+
+    @MockK
+    private lateinit var query: Stage.Query<String>
+
+    @MockK
+    private lateinit var renderer: JpqlRenderer
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    private val renderedQuery1 = "query"
+    private val renderedParam1 = "queryParam1" to "queryParamValue1"
+    private val renderedParam2 = "queryParam2" to "queryParamValue2"
+
+    private val queryParam1 = "queryParam1" to "queryParamValue1"
+    private val queryParam2 = "queryParam2" to "queryParamValue2"
+
+    @BeforeEach
+    @Suppress("UnusedEquals")
+    fun setUp() {
+        mockkObject(JpqlRendererHolder)
+
+        every { JpqlRendererHolder.get() } returns renderer
+
+        excludeRecords { JpqlRendererHolder.get() }
+        excludeRecords { query.equals(any()) }
+    }
+
+    @Test
+    fun `createQuery - select query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { selectQuery.returnType } returns String::class
+        every { session.createQuery(any<String>(), any<Class<String>>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageSessionUtils.createQuery(session, selectQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(selectQuery, context)
+            selectQuery.returnType
+            session.createQuery(rendered1.query, String::class.java)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - select query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { selectQuery.returnType } returns String::class
+        every { session.createQuery(any<String>(), any<Class<String>>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageSessionUtils
+            .createQuery(session, selectQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(selectQuery, mapOf(queryParam1, queryParam2), context)
+            selectQuery.returnType
+            session.createQuery(rendered1.query, String::class.java)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageSessionUtils.createQuery(session, updateQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(updateQuery, context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageSessionUtils
+            .createQuery(session, updateQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(updateQuery, mapOf(queryParam1, queryParam2), context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageSessionUtils.createQuery(session, deleteQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(deleteQuery, context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageSessionUtils
+            .createQuery(session, deleteQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(deleteQuery, mapOf(queryParam1, queryParam2), context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageStatelessSessionUtilsTest.kt
+++ b/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageStatelessSessionUtilsTest.kt
@@ -1,0 +1,207 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
+import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderer
+import io.mockk.every
+import io.mockk.excludeRecords
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockkObject
+import io.mockk.verifySequence
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.stage.Stage
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class JpqlStageStatelessSessionUtilsTest : WithAssertions {
+    @MockK
+    private lateinit var session: Stage.StatelessSession
+
+    @MockK
+    private lateinit var selectQuery: SelectQuery<String>
+
+    @MockK
+    private lateinit var updateQuery: UpdateQuery<String>
+
+    @MockK
+    private lateinit var deleteQuery: DeleteQuery<String>
+
+    @MockK
+    private lateinit var query: Stage.Query<String>
+
+    @MockK
+    private lateinit var renderer: JpqlRenderer
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    private val renderedQuery1 = "query"
+    private val renderedParam1 = "queryParam1" to "queryParamValue1"
+    private val renderedParam2 = "queryParam2" to "queryParamValue2"
+
+    private val queryParam1 = "queryParam1" to "queryParamValue1"
+    private val queryParam2 = "queryParam2" to "queryParamValue2"
+
+    @BeforeEach
+    @Suppress("UnusedEquals")
+    fun setUp() {
+        mockkObject(JpqlRendererHolder)
+
+        every { JpqlRendererHolder.get() } returns renderer
+
+        excludeRecords { JpqlRendererHolder.get() }
+        excludeRecords { query.equals(any()) }
+    }
+
+    @Test
+    fun `createQuery - select query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { selectQuery.returnType } returns String::class
+        every { session.createQuery(any<String>(), any<Class<String>>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageStatelessSessionUtils.createQuery(session, selectQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(selectQuery, context)
+            selectQuery.returnType
+            session.createQuery(rendered1.query, String::class.java)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - select query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { selectQuery.returnType } returns String::class
+        every { session.createQuery(any<String>(), any<Class<String>>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageStatelessSessionUtils
+            .createQuery(session, selectQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(selectQuery, mapOf(queryParam1, queryParam2), context)
+            selectQuery.returnType
+            session.createQuery(rendered1.query, String::class.java)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageStatelessSessionUtils.createQuery(session, updateQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(updateQuery, context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageStatelessSessionUtils
+            .createQuery(session, updateQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(updateQuery, mapOf(queryParam1, queryParam2), context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageStatelessSessionUtils.createQuery(session, deleteQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(deleteQuery, context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query with query params`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any(), any(), any()) } returns rendered1
+        every { session.createQuery<String>(any<String>()) } returns query
+        every { query.setParameter(any<String>(), any()) } returns query
+
+        // when
+        val actual = JpqlStageStatelessSessionUtils
+            .createQuery(session, deleteQuery, mapOf(queryParam1, queryParam2), context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            renderer.render(deleteQuery, mapOf(queryParam1, queryParam2), context)
+            session.createQuery<String>(rendered1.query)
+            query.setParameter(renderedParam1.first, renderedParam1.second)
+            query.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/MutinySessionExtensionsKtTest.kt
+++ b/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/MutinySessionExtensionsKtTest.kt
@@ -1,0 +1,152 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive.extension
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.JpqlMutinySessionUtils
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verifySequence
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class MutinySessionExtensionsKtTest : WithAssertions {
+    @MockK
+    private lateinit var session: Mutiny.Session
+
+    @MockK
+    private lateinit var selectQuery: SelectQuery<String>
+
+    @MockK
+    private lateinit var updateQuery: UpdateQuery<String>
+
+    @MockK
+    private lateinit var deleteQuery: DeleteQuery<String>
+
+    @MockK
+    private lateinit var queryParams: Map<String, Any?>
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(JpqlMutinySessionUtils)
+    }
+
+    @Test
+    fun `createQuery - select query`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinySessionUtils.createQuery(session, selectQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(selectQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinySessionUtils.createQuery(session, selectQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - select query with query params`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinySessionUtils.createQuery(session, selectQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(selectQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinySessionUtils.createQuery(session, selectQuery, queryParams, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinySessionUtils.createQuery(session, updateQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(updateQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinySessionUtils.createQuery(session, updateQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query with query params`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinySessionUtils.createQuery(session, updateQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(updateQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinySessionUtils.createQuery(session, updateQuery, queryParams, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinySessionUtils.createQuery(session, deleteQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(deleteQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinySessionUtils.createQuery(session, deleteQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query with query params`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinySessionUtils.createQuery(session, deleteQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(deleteQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinySessionUtils.createQuery(session, deleteQuery, queryParams, context)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/MutinyStatelessSessionExtensionsKtTest.kt
+++ b/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/MutinyStatelessSessionExtensionsKtTest.kt
@@ -1,0 +1,152 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive.extension
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.JpqlMutinyStatelessSessionUtils
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verifySequence
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class MutinyStatelessSessionExtensionsKtTest : WithAssertions {
+    @MockK
+    private lateinit var session: Mutiny.StatelessSession
+
+    @MockK
+    private lateinit var selectQuery: SelectQuery<String>
+
+    @MockK
+    private lateinit var updateQuery: UpdateQuery<String>
+
+    @MockK
+    private lateinit var deleteQuery: DeleteQuery<String>
+
+    @MockK
+    private lateinit var queryParams: Map<String, Any?>
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(JpqlMutinyStatelessSessionUtils)
+    }
+
+    @Test
+    fun `createQuery - select query`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinyStatelessSessionUtils.createQuery(session, selectQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(selectQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinyStatelessSessionUtils.createQuery(session, selectQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - select query with query params`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinyStatelessSessionUtils.createQuery(session, selectQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(selectQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinyStatelessSessionUtils.createQuery(session, selectQuery, queryParams, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinyStatelessSessionUtils.createQuery(session, updateQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(updateQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinyStatelessSessionUtils.createQuery(session, updateQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query with query params`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinyStatelessSessionUtils.createQuery(session, updateQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(updateQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinyStatelessSessionUtils.createQuery(session, updateQuery, queryParams, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinyStatelessSessionUtils.createQuery(session, deleteQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(deleteQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinyStatelessSessionUtils.createQuery(session, deleteQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query with query params`() {
+        val query = mockk<Mutiny.Query<String>>()
+
+        // given
+        every { JpqlMutinyStatelessSessionUtils.createQuery(session, deleteQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(deleteQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlMutinyStatelessSessionUtils.createQuery(session, deleteQuery, queryParams, context)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/StageSessionExtensionsKtTest.kt
+++ b/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/StageSessionExtensionsKtTest.kt
@@ -1,0 +1,152 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive.extension
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.JpqlStageSessionUtils
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verifySequence
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.stage.Stage
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class StageSessionExtensionsKtTest : WithAssertions {
+    @MockK
+    private lateinit var session: Stage.Session
+
+    @MockK
+    private lateinit var selectQuery: SelectQuery<String>
+
+    @MockK
+    private lateinit var updateQuery: UpdateQuery<String>
+
+    @MockK
+    private lateinit var deleteQuery: DeleteQuery<String>
+
+    @MockK
+    private lateinit var queryParams: Map<String, Any?>
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(JpqlStageSessionUtils)
+    }
+
+    @Test
+    fun `createQuery - select query`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageSessionUtils.createQuery(session, selectQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(selectQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageSessionUtils.createQuery(session, selectQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - select query with query params`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageSessionUtils.createQuery(session, selectQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(selectQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageSessionUtils.createQuery(session, selectQuery, queryParams, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageSessionUtils.createQuery(session, updateQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(updateQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageSessionUtils.createQuery(session, updateQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query with query params`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageSessionUtils.createQuery(session, updateQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(updateQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageSessionUtils.createQuery(session, updateQuery, queryParams, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageSessionUtils.createQuery(session, deleteQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(deleteQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageSessionUtils.createQuery(session, deleteQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query with query params`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageSessionUtils.createQuery(session, deleteQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(deleteQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageSessionUtils.createQuery(session, deleteQuery, queryParams, context)
+        }
+    }
+}

--- a/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/StageStatelessSessionExtensionsKtTest.kt
+++ b/support/hibernate-reactive-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/extension/StageStatelessSessionExtensionsKtTest.kt
@@ -1,0 +1,152 @@
+package com.linecorp.kotlinjdsl.support.hibernate.reactive.extension
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.JpqlStageStatelessSessionUtils
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verifySequence
+import org.assertj.core.api.WithAssertions
+import org.hibernate.reactive.stage.Stage
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class StageStatelessSessionExtensionsKtTest : WithAssertions {
+    @MockK
+    private lateinit var session: Stage.StatelessSession
+
+    @MockK
+    private lateinit var selectQuery: SelectQuery<String>
+
+    @MockK
+    private lateinit var updateQuery: UpdateQuery<String>
+
+    @MockK
+    private lateinit var deleteQuery: DeleteQuery<String>
+
+    @MockK
+    private lateinit var queryParams: Map<String, Any?>
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(JpqlStageStatelessSessionUtils)
+    }
+
+    @Test
+    fun `createQuery - select query`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageStatelessSessionUtils.createQuery(session, selectQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(selectQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageStatelessSessionUtils.createQuery(session, selectQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - select query with query params`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageStatelessSessionUtils.createQuery(session, selectQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(selectQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageStatelessSessionUtils.createQuery(session, selectQuery, queryParams, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageStatelessSessionUtils.createQuery(session, updateQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(updateQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageStatelessSessionUtils.createQuery(session, updateQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - update query with query params`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageStatelessSessionUtils.createQuery(session, updateQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(updateQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageStatelessSessionUtils.createQuery(session, updateQuery, queryParams, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageStatelessSessionUtils.createQuery(session, deleteQuery, context) } returns query
+
+        // when
+        val actual = session.createQuery(deleteQuery, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageStatelessSessionUtils.createQuery(session, deleteQuery, context)
+        }
+    }
+
+    @Test
+    fun `createQuery - delete query with query params`() {
+        val query = mockk<Stage.Query<String>>()
+
+        // given
+        every { JpqlStageStatelessSessionUtils.createQuery(session, deleteQuery, queryParams, context) } returns query
+
+        // when
+        val actual = session.createQuery(deleteQuery, queryParams, context)
+
+        // then
+        assertThat(actual).isEqualTo(query)
+
+        verifySequence {
+            JpqlStageStatelessSessionUtils.createQuery(session, deleteQuery, queryParams, context)
+        }
+    }
+}


### PR DESCRIPTION
#Motivation:

#441 kotlin-jdsl 3.0.0 should support hibernate-reactive.

#Modifications:

* Implement hibernate-reactive-javax-support and example modules.

#Result:
Users can create and execute queries through Mutiny or Stage SessionFactory as shown below.

```kotlin
// when
val actual = sessionFactory.withSession {
     it.createQuery(
         jpql {
             select(
                 path(Author::authorId);
             ).from(
                 entity(Author::class);
                 join(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId)));
             ).groupBy(
                 path(Author::authorId);
             ).orderBy(
                 count(Author::authorId).desc();
             )
         },
         JpqlRenderContext()
     ).setMaxResults(1).singleResult
}
```

# Closes #. (If this resolves the issue.)
* #441 will be closed after working on the jakarta module.