### PR TITLE
test: change arg method in MockKAnswerScope

### DIFF
--- a/render/jpql/src/testFixtures/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/JpqlSerializerExtension.kt
+++ b/render/jpql/src/testFixtures/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/JpqlSerializerExtension.kt
@@ -76,13 +76,13 @@ internal class JpqlSerializerExtension : InvocationInterceptor, BeforeEachCallba
             every { any.write(any<String>()) } just runs
             every { any.writeIfAbsent(any<String>()) } just runs
             every { any.writeEach<Any>(any(), any(), any(), any(), any()) } answers {
-                val predicates: Iterable<Any> = arg(0)
-                val write: (Any) -> Unit = arg(4)
+                val predicates = firstArg<Iterable<Any>>()
+                val write = lastArg<(Any) -> Unit>()
 
                 predicates.forEach { predicate -> write(predicate) }
             }
             every { any.writeParentheses(any<() -> Unit>()) } answers {
-                val inner: () -> Unit = arg(0)
+                val inner = firstArg<() -> Unit>()
 
                 inner()
             }


### PR DESCRIPTION
# Motivation

-  Replace the use of the `arg` function with a more intuitive function in the `answer` block of Kotest.

# Modifications

- modify JpqlSerializerExtension.kt

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**
