### PR TITLE
chore: apply renovate only under example project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -116,3 +116,7 @@ ij_yaml_spaces_within_brackets = true
 
 [*.md]
 max_line_length = 300
+
+[*.json]
+tab_width = 2
+indent_size = 2

--- a/example/eclipselink-javax/build.gradle.kts
+++ b/example/eclipselink-javax/build.gradle.kts
@@ -1,20 +1,20 @@
 plugins {
-    alias(libs.plugins.kotlin.noarg)
-    alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.kotlin.jpa)
+    alias(exampleLibs.plugins.kotlin.noarg)
+    alias(exampleLibs.plugins.kotlin.allopen)
+    alias(exampleLibs.plugins.kotlin.jpa)
 }
 
 dependencies {
-    implementation(libs.test.eclipselink2)
-    implementation(libs.logback)
+    implementation(exampleLibs.test.eclipselink2)
+    implementation(exampleLibs.logback)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
     implementation(projects.eclipselinkJavaxSupport)
 
-    runtimeOnly(libs.test.h2)
+    runtimeOnly(exampleLibs.test.h2)
 
-    testFixturesImplementation(libs.test.eclipselink2)
+    testFixturesImplementation(exampleLibs.test.eclipselink2)
     testFixturesImplementation(projects.jpqlRender)
 }
 

--- a/example/eclipselink/build.gradle.kts
+++ b/example/eclipselink/build.gradle.kts
@@ -1,20 +1,20 @@
 plugins {
-    alias(libs.plugins.kotlin.noarg)
-    alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.kotlin.jpa)
+    alias(exampleLibs.plugins.kotlin.noarg)
+    alias(exampleLibs.plugins.kotlin.allopen)
+    alias(exampleLibs.plugins.kotlin.jpa)
 }
 
 dependencies {
-    implementation(libs.test.eclipselink4)
-    implementation(libs.logback)
+    implementation(exampleLibs.test.eclipselink4)
+    implementation(exampleLibs.logback)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
     implementation(projects.eclipselinkSupport)
 
-    runtimeOnly(libs.test.h2)
+    runtimeOnly(exampleLibs.test.h2)
 
-    testFixturesImplementation(libs.test.eclipselink4)
+    testFixturesImplementation(exampleLibs.test.eclipselink4)
     testFixturesImplementation(projects.jpqlRender)
 }
 

--- a/example/hibernate-javax/build.gradle.kts
+++ b/example/hibernate-javax/build.gradle.kts
@@ -1,20 +1,20 @@
 plugins {
-    alias(libs.plugins.kotlin.noarg)
-    alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.kotlin.jpa)
+    alias(exampleLibs.plugins.kotlin.noarg)
+    alias(exampleLibs.plugins.kotlin.allopen)
+    alias(exampleLibs.plugins.kotlin.jpa)
 }
 
 dependencies {
-    implementation(libs.test.hibernate5.core)
-    implementation(libs.logback)
+    implementation(exampleLibs.test.hibernate5.core)
+    implementation(exampleLibs.logback)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
     implementation(projects.hibernateJavaxSupport)
 
-    runtimeOnly(libs.test.h2)
+    runtimeOnly(exampleLibs.test.h2)
 
-    testFixturesImplementation(libs.test.hibernate5.core)
+    testFixturesImplementation(exampleLibs.test.hibernate5.core)
     testFixturesImplementation(projects.jpqlRender)
 }
 

--- a/example/hibernate-reactive-javax/build.gradle.kts
+++ b/example/hibernate-reactive-javax/build.gradle.kts
@@ -1,22 +1,22 @@
 plugins {
-    alias(libs.plugins.kotlin.noarg)
-    alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.kotlin.jpa)
+    alias(exampleLibs.plugins.kotlin.noarg)
+    alias(exampleLibs.plugins.kotlin.allopen)
+    alias(exampleLibs.plugins.kotlin.jpa)
 }
 
 dependencies {
-    implementation(libs.test.hibernate.reactive1.core)
-    implementation(libs.test.vertx.jdbc.client)
-    implementation(libs.test.agroal.pool)
-    implementation(libs.logback)
+    implementation(exampleLibs.test.hibernate.reactive1.core)
+    implementation(exampleLibs.test.vertx.jdbc.client)
+    implementation(exampleLibs.test.agroal.pool)
+    implementation(exampleLibs.logback)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
     implementation(projects.hibernateReactiveJavaxSupport)
 
-    runtimeOnly(libs.test.h2)
+    runtimeOnly(exampleLibs.test.h2)
 
-    testFixturesImplementation(libs.test.hibernate.reactive1.core)
+    testFixturesImplementation(exampleLibs.test.hibernate.reactive1.core)
     testFixturesImplementation(projects.jpqlRender)
 }
 

--- a/example/hibernate-reactive/build.gradle.kts
+++ b/example/hibernate-reactive/build.gradle.kts
@@ -1,22 +1,22 @@
 plugins {
-    alias(libs.plugins.kotlin.noarg)
-    alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.kotlin.jpa)
+    alias(exampleLibs.plugins.kotlin.noarg)
+    alias(exampleLibs.plugins.kotlin.allopen)
+    alias(exampleLibs.plugins.kotlin.jpa)
 }
 
 dependencies {
-    implementation(libs.test.hibernate.reactive2.core)
-    implementation(libs.test.vertx.jdbc.client)
-    implementation(libs.test.agroal.pool)
-    implementation(libs.logback)
+    implementation(exampleLibs.test.hibernate.reactive2.core)
+    implementation(exampleLibs.test.vertx.jdbc.client)
+    implementation(exampleLibs.test.agroal.pool)
+    implementation(exampleLibs.logback)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
     implementation(projects.hibernateReactiveSupport)
 
-    runtimeOnly(libs.test.h2)
+    runtimeOnly(exampleLibs.test.h2)
 
-    testFixturesImplementation(libs.test.hibernate.reactive2.core)
+    testFixturesImplementation(exampleLibs.test.hibernate.reactive2.core)
     testFixturesImplementation(projects.jpqlRender)
 }
 

--- a/example/hibernate/build.gradle.kts
+++ b/example/hibernate/build.gradle.kts
@@ -1,20 +1,20 @@
 plugins {
-    alias(libs.plugins.kotlin.noarg)
-    alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.kotlin.jpa)
+    alias(exampleLibs.plugins.kotlin.noarg)
+    alias(exampleLibs.plugins.kotlin.allopen)
+    alias(exampleLibs.plugins.kotlin.jpa)
 }
 
 dependencies {
-    implementation(libs.test.hibernate6.core)
-    implementation(libs.logback)
+    implementation(exampleLibs.test.hibernate6.core)
+    implementation(exampleLibs.logback)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
     implementation(projects.hibernateSupport)
 
-    runtimeOnly(libs.test.h2)
+    runtimeOnly(exampleLibs.test.h2)
 
-    testFixturesImplementation(libs.test.hibernate6.core)
+    testFixturesImplementation(exampleLibs.test.hibernate6.core)
     testFixturesImplementation(projects.jpqlRender)
 }
 

--- a/example/spring-batch-javax/build.gradle.kts
+++ b/example/spring-batch-javax/build.gradle.kts
@@ -1,25 +1,25 @@
 plugins {
-    alias(libs.plugins.test.spring.boot2)
-    alias(libs.plugins.kotlin.noarg)
-    alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.kotlin.spring)
-    alias(libs.plugins.kotlin.jpa)
+    alias(exampleLibs.plugins.test.spring.boot2)
+    alias(exampleLibs.plugins.kotlin.noarg)
+    alias(exampleLibs.plugins.kotlin.allopen)
+    alias(exampleLibs.plugins.kotlin.spring)
+    alias(exampleLibs.plugins.kotlin.jpa)
 }
 
 dependencies {
     @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
-    implementation(libs.test.spring.boot2.batch)
-    implementation(libs.test.spring.boot2.jpa)
-    implementation(libs.test.spring.boot2.p6spy)
+    implementation(exampleLibs.test.spring.boot2.batch)
+    implementation(exampleLibs.test.spring.boot2.jpa)
+    implementation(exampleLibs.test.spring.boot2.p6spy)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
     implementation(projects.springBatchJavaxSupport)
 
-    runtimeOnly(libs.test.h2)
+    runtimeOnly(exampleLibs.test.h2)
 
-    testImplementation(libs.test.spring.boot2.test)
-    testImplementation(libs.test.spring.batch4.test)
+    testImplementation(exampleLibs.test.spring.boot2.test)
+    testImplementation(exampleLibs.test.spring.batch4.test)
 }
 
 kotlin {

--- a/example/spring-batch/build.gradle.kts
+++ b/example/spring-batch/build.gradle.kts
@@ -1,25 +1,25 @@
 plugins {
-    alias(libs.plugins.test.spring.boot3)
-    alias(libs.plugins.kotlin.noarg)
-    alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.kotlin.spring)
-    alias(libs.plugins.kotlin.jpa)
+    alias(exampleLibs.plugins.test.spring.boot3)
+    alias(exampleLibs.plugins.kotlin.noarg)
+    alias(exampleLibs.plugins.kotlin.allopen)
+    alias(exampleLibs.plugins.kotlin.spring)
+    alias(exampleLibs.plugins.kotlin.jpa)
 }
 
 dependencies {
     @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
-    implementation(libs.test.spring.boot3.batch)
-    implementation(libs.test.spring.boot3.jpa)
-    implementation(libs.test.spring.boot3.p6spy)
+    implementation(exampleLibs.test.spring.boot3.batch)
+    implementation(exampleLibs.test.spring.boot3.jpa)
+    implementation(exampleLibs.test.spring.boot3.p6spy)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
     implementation(projects.springBatchSupport)
 
-    runtimeOnly(libs.test.h2)
+    runtimeOnly(exampleLibs.test.h2)
 
-    testImplementation(libs.test.spring.boot3.test)
-    testImplementation(libs.test.spring.batch5.test)
+    testImplementation(exampleLibs.test.spring.boot3.test)
+    testImplementation(exampleLibs.test.spring.batch5.test)
 }
 
 kotlin {

--- a/example/spring-data-jpa-javax/build.gradle.kts
+++ b/example/spring-data-jpa-javax/build.gradle.kts
@@ -1,23 +1,23 @@
 plugins {
-    alias(libs.plugins.test.spring.boot2)
-    alias(libs.plugins.kotlin.noarg)
-    alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.kotlin.spring)
-    alias(libs.plugins.kotlin.jpa)
+    alias(exampleLibs.plugins.test.spring.boot2)
+    alias(exampleLibs.plugins.kotlin.noarg)
+    alias(exampleLibs.plugins.kotlin.allopen)
+    alias(exampleLibs.plugins.kotlin.spring)
+    alias(exampleLibs.plugins.kotlin.jpa)
 }
 
 dependencies {
     @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
-    implementation(libs.test.spring.boot2.jpa)
-    implementation(libs.test.spring.boot2.p6spy)
+    implementation(exampleLibs.test.spring.boot2.jpa)
+    implementation(exampleLibs.test.spring.boot2.p6spy)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
     implementation(projects.springDataJpaJavaxSupport)
 
-    runtimeOnly(libs.test.h2)
+    runtimeOnly(exampleLibs.test.h2)
 
-    testImplementation(libs.test.spring.boot2.test)
+    testImplementation(exampleLibs.test.spring.boot2.test)
 }
 
 kotlin {

--- a/example/spring-data-jpa/build.gradle.kts
+++ b/example/spring-data-jpa/build.gradle.kts
@@ -1,23 +1,23 @@
 plugins {
-    alias(libs.plugins.test.spring.boot3)
-    alias(libs.plugins.kotlin.noarg)
-    alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.kotlin.spring)
-    alias(libs.plugins.kotlin.jpa)
+    alias(exampleLibs.plugins.test.spring.boot3)
+    alias(exampleLibs.plugins.kotlin.noarg)
+    alias(exampleLibs.plugins.kotlin.allopen)
+    alias(exampleLibs.plugins.kotlin.spring)
+    alias(exampleLibs.plugins.kotlin.jpa)
 }
 
 dependencies {
     @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
-    implementation(libs.test.spring.boot3.jpa)
-    implementation(libs.test.spring.boot3.p6spy)
+    implementation(exampleLibs.test.spring.boot3.jpa)
+    implementation(exampleLibs.test.spring.boot3.p6spy)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
     implementation(projects.springDataJpaSupport)
 
-    runtimeOnly(libs.test.h2)
+    runtimeOnly(exampleLibs.test.h2)
 
-    testImplementation(libs.test.spring.boot3.test)
+    testImplementation(exampleLibs.test.spring.boot3.test)
 }
 
 kotlin {

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -1,0 +1,98 @@
+[versions]
+kotlin = "1.9.0"
+
+spring6 = "6.0.11"
+spring5 = "5.3.29"
+
+test-spring-boot3 = "3.1.3"
+test-spring-boot2 = "2.7.15"
+
+test-mutiny = "2.4.0"
+
+[libraries]
+# kotlin
+kotlin = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
+kotlin-benchmark = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version = "0.4.9" }
+
+# coroutines
+coroutine-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version = "1.7.3" }
+
+# jpa
+javax-persistence-api = { module = "javax.persistence:javax.persistence-api", version = "2.2" }
+jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api", version = "3.0.0" }
+
+# log
+slf4j = { module = "org.slf4j:slf4j-api", version = "2.0.7" }
+logback = { module = "ch.qos.logback:logback-classic", version = "1.2.11" }
+
+# hibernate
+hibernate5-core = { module = "org.hibernate:hibernate-core", version = "5.0.0.Final" }
+hibernate6-core = { module = "org.hibernate:hibernate-core", version = "6.0.0.Final" }
+
+# hibernate-reactive
+hibernate-reactive1-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "1.0.0.Final" }
+hibernate-reactive2-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "2.0.0.Final" }
+
+# eclipse-link
+eclipselink2 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "2.7.0" }
+eclipselink3 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "3.0.0" }
+
+# spring-boot
+spring-boot3-starter = { module = "org.springframework.boot:spring-boot-starter", version = "3.0.3" }
+spring-boot2-starter = { module = "org.springframework.boot:spring-boot-starter", version = "2.7.10" }
+
+# spring
+spring-jdbc = { module = "org.springframework:spring-jdbc", version = "6.0.11" }
+
+spring-batch5-infrastructure = { module = "org.springframework.batch:spring-batch-infrastructure", version = "5.0.0" }
+spring-batch4-infrastructure = { module = "org.springframework.batch:spring-batch-infrastructure", version = "4.0.0.RELEASE" }
+
+# https://github.com/spring-projects/spring-data-jpa/issues/2812
+spring-data-jpa3 = { module = "org.springframework.data:spring-data-jpa", version = "3.0.3" }
+spring-data-jpa2 = { module = "org.springframework.data:spring-data-jpa", version = "2.7.9" }
+
+# test
+test-spring-boot3-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "test-spring-boot3" }
+test-spring-boot3-batch = { module = "org.springframework.boot:spring-boot-starter-batch", version.ref = "test-spring-boot3" }
+test-spring-boot3-p6spy = { module = "com.github.gavlyukovskiy:p6spy-spring-boot-starter", version = "1.9.0" }
+test-spring-boot3-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "test-spring-boot3" }
+
+test-spring-boot2-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "test-spring-boot2" }
+test-spring-boot2-batch = { module = "org.springframework.boot:spring-boot-starter-batch", version.ref = "test-spring-boot2" }
+test-spring-boot2-p6spy = { module = "com.github.gavlyukovskiy:p6spy-spring-boot-starter", version = "1.8.1" }
+test-spring-boot2-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "test-spring-boot2" }
+
+test-spring-batch5-test = { module = "org.springframework.batch:spring-batch-test", version = "5.0.3" }
+test-spring-batch4-test = { module = "org.springframework.batch:spring-batch-test", version = "4.3.9" }
+
+test-hibernate5-core = { module = "org.hibernate:hibernate-core", version = "5.6.15.Final" }
+test-hibernate6-core = { module = "org.hibernate:hibernate-core", version = "6.3.0.Final" }
+
+test-hibernate-reactive1-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "1.1.9.Final" }
+test-hibernate-reactive2-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "2.0.5.Final" }
+
+test-eclipselink2 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "2.7.13" }
+test-eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "4.0.2" }
+
+test-vertx-jdbc-client = { module = "io.vertx:vertx-jdbc-client", version = "4.4.5" }
+test-agroal-pool = { module = "io.agroal:agroal-pool", version = "2.2" }
+
+test-junit = { module = "org.junit.jupiter:junit-jupiter", version = "5.10.0" }
+test-assertJ = { module = "org.assertj:assertj-core", version = "3.24.2" }
+test-mockk = { module = "io.mockk:mockk", version = "1.13.7" }
+
+test-h2 = { module = "com.h2database:h2", version = "2.2.222" }
+
+[plugins]
+kotlin-benchmark = { id = "org.jetbrains.kotlinx.benchmark", version = "0.4.9" }
+kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
+kotlin-noarg = { id = "org.jetbrains.kotlin.plugin.noarg", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version = "0.7.1" }
+ktlint = { id = "org.jmailen.kotlinter", version = "3.16.0" }
+
+test-spring-boot3 = { id = "org.springframework.boot", version.ref = "test-spring-boot3" }
+test-spring-boot2 = { id = "org.springframework.boot", version.ref = "test-spring-boot2" }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "baseBranches": [
+    "develop"
+  ],
+  "gradle": {
+    "includePaths": [
+      "libs.example.versions.toml"
+    ]
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,9 @@ dependencyResolutionManagement {
         create("libs") {
             from(files("libs.versions.toml"))
         }
+        create("exampleLibs") {
+            from(files("libs.example.versions.toml"))
+        }
     }
 }
 


### PR DESCRIPTION
# Motivation

-  `renovate` should be applied only on the develop branch and example projects.

# Modifications

- move original `libs.versions.toml` to `gradle/libs.version.toml` (default version catalog path)
- copy `libs.versions.toml` to `example.libs.versions.toml`
- update `.editorconfig` to change indent size of json file.

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- target branch of renovate will be `develop`
- renovate manages only `example.libs.versions.toml`

# Closes

- resolves #458 
