### PR TITLE
Add support for java getter

### DIFF
--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/path/impl/JpqlEntityProperty.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/path/impl/JpqlEntityProperty.kt
@@ -3,10 +3,10 @@ package com.linecorp.kotlinjdsl.querymodel.jpql.path.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.entity.Entity
 import com.linecorp.kotlinjdsl.querymodel.jpql.path.Path
-import kotlin.reflect.KProperty1
+import kotlin.reflect.KCallable
 
 @Internal
 data class JpqlEntityProperty<T : Any, V> internal constructor(
-    val entity: Entity<*>,
-    val property: KProperty1<in T, V>,
+    val entity: Entity<T>,
+    val property: KCallable<V>,
 ) : Path<V & Any>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/path/impl/JpqlPathProperty.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/path/impl/JpqlPathProperty.kt
@@ -2,10 +2,10 @@ package com.linecorp.kotlinjdsl.querymodel.jpql.path.impl
 
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.path.Path
-import kotlin.reflect.KProperty1
+import kotlin.reflect.KCallable
 
 @Internal
 data class JpqlPathProperty<T : Any, V> internal constructor(
     val path: Path<T>,
-    val property: KProperty1<in T, V>,
+    val property: KCallable<V>,
 ) : Path<V & Any>

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
@@ -9,6 +9,7 @@ import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlIntrospectorModifier
 import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlRenderIntrospector
 import com.linecorp.kotlinjdsl.render.jpql.introspector.impl.JakartaJpqlIntrospector
 import com.linecorp.kotlinjdsl.render.jpql.introspector.impl.JavaxJpqlIntrospector
+import com.linecorp.kotlinjdsl.render.jpql.introspector.impl.KotlinStyleJpqlPropertyIntrospector
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerModifier
@@ -245,6 +246,8 @@ private class DefaultModule : JpqlRenderModule {
         if (isJakartaPresent) {
             context.appendIntrospector(JakartaJpqlIntrospector())
         }
+
+        context.appendIntrospector(KotlinStyleJpqlPropertyIntrospector())
 
         context.addAllSerializer(
             JpqlAliasedExpressionSerializer(),

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/CombinedJpqlIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/CombinedJpqlIntrospector.kt
@@ -1,6 +1,7 @@
 package com.linecorp.kotlinjdsl.render.jpql.introspector
 
 import com.linecorp.kotlinjdsl.SinceJdsl
+import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 
 /**
@@ -19,5 +20,15 @@ class CombinedJpqlIntrospector(
      */
     override fun introspect(type: KClass<*>): JpqlEntityDescription? {
         return primary.introspect(type) ?: secondary.introspect(type)
+    }
+
+    /**
+     * Get the entity information by introspecting KCallable.
+     *
+     * If the primary introspector introspects this KCallable, it returns the result of the primary introspector.
+     * Otherwise, it returns the result of the secondary introspector.
+     */
+    override fun introspect(property: KCallable<*>): JpqlPropertyDescription? {
+        return primary.introspect(property) ?: secondary.introspect(property)
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/JpqlEntityIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/JpqlEntityIntrospector.kt
@@ -1,0 +1,12 @@
+package com.linecorp.kotlinjdsl.render.jpql.introspector
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import kotlin.reflect.KCallable
+
+/**
+ * Abstract class to get the entity information by introspecting KClass.
+ */
+@SinceJdsl("3.1.0")
+abstract class JpqlEntityIntrospector : JpqlIntrospector {
+    override fun introspect(property: KCallable<*>): JpqlPropertyDescription? = null
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/JpqlIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/JpqlIntrospector.kt
@@ -1,6 +1,7 @@
 package com.linecorp.kotlinjdsl.render.jpql.introspector
 
 import com.linecorp.kotlinjdsl.SinceJdsl
+import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 
 /**
@@ -14,4 +15,11 @@ interface JpqlIntrospector {
      */
     @SinceJdsl("3.0.0")
     fun introspect(type: KClass<*>): JpqlEntityDescription?
+
+    /**
+     * Introspects the KCallable to get the entity information.
+     * If it cannot introspect this KCallable, it returns null.
+     */
+    @SinceJdsl("3.1.0")
+    fun introspect(property: KCallable<*>): JpqlPropertyDescription?
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/JpqlPropertyDescription.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/JpqlPropertyDescription.kt
@@ -1,0 +1,12 @@
+package com.linecorp.kotlinjdsl.render.jpql.introspector
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+
+/**
+ * Interface to represent the property information.
+ */
+@SinceJdsl("3.1.0")
+interface JpqlPropertyDescription {
+    @SinceJdsl("3.1.0")
+    val name: String
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/JpqlPropertyIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/JpqlPropertyIntrospector.kt
@@ -1,0 +1,12 @@
+package com.linecorp.kotlinjdsl.render.jpql.introspector
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import kotlin.reflect.KClass
+
+/**
+ * Abstract class to get the entity information by introspecting KCallable.
+ */
+@SinceJdsl("3.1.0")
+abstract class JpqlPropertyIntrospector : JpqlIntrospector {
+    override fun introspect(type: KClass<*>): JpqlEntityDescription? = null
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/JpqlRenderIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/JpqlRenderIntrospector.kt
@@ -16,8 +16,8 @@ class JpqlRenderIntrospector(
 ) : AbstractRenderContextElement(Key) {
     companion object Key : RenderContext.Key<JpqlRenderIntrospector>
 
-    private val classTableLookupCache: MutableMap<KClass<*>, JpqlEntityDescription> = ConcurrentHashMap()
-    private val propertyTableLookupCache: MutableMap<KCallable<*>, JpqlPropertyDescription> = ConcurrentHashMap()
+    private val entityLookupCache: MutableMap<KClass<*>, JpqlEntityDescription> = ConcurrentHashMap()
+    private val propertyLookupCache: MutableMap<KCallable<*>, JpqlPropertyDescription> = ConcurrentHashMap()
 
     /**
      * Creates a new introspector by combining this introspector and the introspector.
@@ -49,13 +49,13 @@ class JpqlRenderIntrospector(
     }
 
     private fun getCachedDescription(clazz: KClass<*>): JpqlEntityDescription {
-        return classTableLookupCache.computeIfAbsent(clazz) {
+        return entityLookupCache.computeIfAbsent(clazz) {
             getDescription(it)
         }
     }
 
     private fun getCachedDescription(property: KCallable<*>): JpqlPropertyDescription {
-        return propertyTableLookupCache.computeIfAbsent(property) {
+        return propertyLookupCache.computeIfAbsent(property) {
             getDescription(it)
         }
     }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JakartaJpqlIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JakartaJpqlIntrospector.kt
@@ -6,6 +6,8 @@ import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlIntrospector
 import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyDescription
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
+import kotlin.reflect.KFunction1
+import kotlin.reflect.KProperty1
 import kotlin.reflect.full.findAnnotations
 
 /**
@@ -24,8 +26,19 @@ class JakartaJpqlIntrospector : JpqlIntrospector {
     }
 
     override fun introspect(property: KCallable<*>): JpqlPropertyDescription? {
-        TODO("Not yet implemented")
+        return when (property) {
+            is KProperty1<*, *> -> JpqlProperty(property.name)
+            is KFunction1<*, *> -> JpqlProperty(resolvePropertyName(property))
+            else -> null
+        }
     }
+
+    private fun resolvePropertyName(getter: KFunction1<*, *>): String =
+        if (getter.name.startsWith("is")) {
+            getter.name
+        } else {
+            getter.name.removePrefix("get").replaceFirstChar { it.lowercase() }
+        }
 }
 
 private data class JakartaEntity(

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JakartaJpqlIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JakartaJpqlIntrospector.kt
@@ -3,11 +3,13 @@ package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlEntityDescription
 import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlIntrospector
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyDescription
+import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotations
 
 /**
- * Introspector that introspects KClass using [jakarta.persistence.Entity].
+ * Introspector that introspects KClass and KCallable using [jakarta.persistence.Entity].
  */
 @Internal
 class JakartaJpqlIntrospector : JpqlIntrospector {
@@ -19,6 +21,10 @@ class JakartaJpqlIntrospector : JpqlIntrospector {
         } else {
             null
         }
+    }
+
+    override fun introspect(property: KCallable<*>): JpqlPropertyDescription? {
+        TODO("Not yet implemented")
     }
 }
 

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JakartaJpqlIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JakartaJpqlIntrospector.kt
@@ -2,19 +2,15 @@ package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
 
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlEntityDescription
-import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlIntrospector
-import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyDescription
-import kotlin.reflect.KCallable
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlEntityIntrospector
 import kotlin.reflect.KClass
-import kotlin.reflect.KFunction1
-import kotlin.reflect.KProperty1
 import kotlin.reflect.full.findAnnotations
 
 /**
- * Introspector that introspects KClass and KCallable using [jakarta.persistence.Entity].
+ * Introspector that introspects KClass using [jakarta.persistence.Entity].
  */
 @Internal
-class JakartaJpqlIntrospector : JpqlIntrospector {
+class JakartaJpqlIntrospector : JpqlEntityIntrospector() {
     override fun introspect(type: KClass<*>): JpqlEntityDescription? {
         val entity = type.findAnnotations(jakarta.persistence.Entity::class).firstOrNull()
 
@@ -24,21 +20,6 @@ class JakartaJpqlIntrospector : JpqlIntrospector {
             null
         }
     }
-
-    override fun introspect(property: KCallable<*>): JpqlPropertyDescription? {
-        return when (property) {
-            is KProperty1<*, *> -> JpqlProperty(property.name)
-            is KFunction1<*, *> -> JpqlProperty(resolvePropertyName(property))
-            else -> null
-        }
-    }
-
-    private fun resolvePropertyName(getter: KFunction1<*, *>): String =
-        if (getter.name.startsWith("is")) {
-            getter.name
-        } else {
-            getter.name.removePrefix("get").replaceFirstChar { it.lowercase() }
-        }
 }
 
 private data class JakartaEntity(

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JavaxJpqlIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JavaxJpqlIntrospector.kt
@@ -6,6 +6,8 @@ import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlIntrospector
 import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyDescription
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
+import kotlin.reflect.KFunction1
+import kotlin.reflect.KProperty1
 import kotlin.reflect.full.findAnnotations
 
 /**
@@ -24,8 +26,19 @@ class JavaxJpqlIntrospector : JpqlIntrospector {
     }
 
     override fun introspect(property: KCallable<*>): JpqlPropertyDescription? {
-        TODO("Not yet implemented")
+        return when (property) {
+            is KProperty1<*, *> -> JpqlProperty(property.name)
+            is KFunction1<*, *> -> JpqlProperty(resolvePropertyName(property))
+            else -> null
+        }
     }
+
+    private fun resolvePropertyName(getter: KFunction1<*, *>): String =
+        if (getter.name.startsWith("is")) {
+            getter.name
+        } else {
+            getter.name.removePrefix("get").replaceFirstChar { it.lowercase() }
+        }
 }
 
 private data class JavaxEntity(

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JavaxJpqlIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JavaxJpqlIntrospector.kt
@@ -3,11 +3,13 @@ package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlEntityDescription
 import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlIntrospector
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyDescription
+import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotations
 
 /**
- * Introspector that introspects KClass using [javax.persistence.Entity].
+ * Introspector that introspects KClass and KCallable using [javax.persistence.Entity].
  */
 @Internal
 class JavaxJpqlIntrospector : JpqlIntrospector {
@@ -19,6 +21,10 @@ class JavaxJpqlIntrospector : JpqlIntrospector {
         } else {
             null
         }
+    }
+
+    override fun introspect(property: KCallable<*>): JpqlPropertyDescription? {
+        TODO("Not yet implemented")
     }
 }
 

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JavaxJpqlIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JavaxJpqlIntrospector.kt
@@ -2,19 +2,15 @@ package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
 
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlEntityDescription
-import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlIntrospector
-import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyDescription
-import kotlin.reflect.KCallable
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlEntityIntrospector
 import kotlin.reflect.KClass
-import kotlin.reflect.KFunction1
-import kotlin.reflect.KProperty1
 import kotlin.reflect.full.findAnnotations
 
 /**
- * Introspector that introspects KClass and KCallable using [javax.persistence.Entity].
+ * Introspector that introspects KClass using [javax.persistence.Entity].
  */
 @Internal
-class JavaxJpqlIntrospector : JpqlIntrospector {
+class JavaxJpqlIntrospector : JpqlEntityIntrospector() {
     override fun introspect(type: KClass<*>): JpqlEntityDescription? {
         val entity = type.findAnnotations(javax.persistence.Entity::class).firstOrNull()
 
@@ -24,21 +20,6 @@ class JavaxJpqlIntrospector : JpqlIntrospector {
             null
         }
     }
-
-    override fun introspect(property: KCallable<*>): JpqlPropertyDescription? {
-        return when (property) {
-            is KProperty1<*, *> -> JpqlProperty(property.name)
-            is KFunction1<*, *> -> JpqlProperty(resolvePropertyName(property))
-            else -> null
-        }
-    }
-
-    private fun resolvePropertyName(getter: KFunction1<*, *>): String =
-        if (getter.name.startsWith("is")) {
-            getter.name
-        } else {
-            getter.name.removePrefix("get").replaceFirstChar { it.lowercase() }
-        }
 }
 
 private data class JavaxEntity(

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JpqlProperty.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JpqlProperty.kt
@@ -1,0 +1,7 @@
+package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
+
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyDescription
+
+internal data class JpqlProperty(
+    override val name: String,
+) : JpqlPropertyDescription

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JpqlProperty.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JpqlProperty.kt
@@ -1,7 +1,0 @@
-package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
-
-import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyDescription
-
-internal data class JpqlProperty(
-    override val name: String,
-) : JpqlPropertyDescription

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/KotlinStyleJpqlPropertyIntrospector.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/KotlinStyleJpqlPropertyIntrospector.kt
@@ -1,0 +1,33 @@
+package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyDescription
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyIntrospector
+import kotlin.reflect.KCallable
+import kotlin.reflect.KFunction1
+import kotlin.reflect.KProperty1
+
+/**
+ * Introspector that introspects a property name in KCallable using Kotlin style.
+ */
+@Internal
+class KotlinStyleJpqlPropertyIntrospector : JpqlPropertyIntrospector() {
+    override fun introspect(property: KCallable<*>): JpqlPropertyDescription? {
+        return when (property) {
+            is KProperty1<*, *> -> KotlinStyleProperty(property.name)
+            is KFunction1<*, *> -> KotlinStyleProperty(resolvePropertyName(property))
+            else -> null
+        }
+    }
+
+    private fun resolvePropertyName(getter: KFunction1<*, *>): String =
+        if (getter.name.startsWith("is")) {
+            getter.name
+        } else {
+            getter.name.removePrefix("get").replaceFirstChar { it.lowercase() }
+        }
+}
+
+private data class KotlinStyleProperty(
+    override val name: String,
+) : JpqlPropertyDescription

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlEntityPropertySerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlEntityPropertySerializer.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.path.impl.JpqlEntityProperty
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlRenderIntrospector
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
 import kotlin.reflect.KClass
@@ -14,8 +15,11 @@ class JpqlEntityPropertySerializer : JpqlSerializer<JpqlEntityProperty<*, *>> {
     }
 
     override fun serialize(part: JpqlEntityProperty<*, *>, writer: JpqlWriter, context: RenderContext) {
+        val introspector = context.getValue(JpqlRenderIntrospector)
+        val property = introspector.introspect(part.property)
+
         writer.write(part.entity.alias)
         writer.write(".")
-        writer.write(part.property.name)
+        writer.write(property.name)
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlPathPropertySerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlPathPropertySerializer.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.path.impl.JpqlPathProperty
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlRenderIntrospector
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -16,9 +17,11 @@ class JpqlPathPropertySerializer : JpqlSerializer<JpqlPathProperty<*, *>> {
 
     override fun serialize(part: JpqlPathProperty<*, *>, writer: JpqlWriter, context: RenderContext) {
         val delegate = context.getValue(JpqlRenderSerializer)
+        val introspector = context.getValue(JpqlRenderIntrospector)
+        val property = introspector.introspect(part.property)
 
         delegate.serialize(part.path, writer, context)
         writer.write(".")
-        writer.write(part.property.name)
+        writer.write(property.name)
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JakartaJpqlIntrospectorTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JakartaJpqlIntrospectorTest.kt
@@ -1,7 +1,9 @@
 package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
 
+import io.mockk.mockkClass
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KProperty0
 
 class JakartaJpqlIntrospectorTest : WithAssertions {
     private val sut = JakartaJpqlIntrospector()
@@ -11,7 +13,7 @@ class JakartaJpqlIntrospectorTest : WithAssertions {
     }
 
     @Test
-    fun introspect() {
+    fun `introspect(type) returns name of entity annotation, when entity annotation has name`() {
         // given
         val type = EntityClass1::class
 
@@ -23,7 +25,7 @@ class JakartaJpqlIntrospectorTest : WithAssertions {
     }
 
     @Test
-    fun `introspect() returns name of class, when entity annotation does not have name`() {
+    fun `introspect(type) returns name of class, when entity annotation does not have name`() {
         // given
         val type = EntityClass2::class
 
@@ -35,7 +37,7 @@ class JakartaJpqlIntrospectorTest : WithAssertions {
     }
 
     @Test
-    fun `introspect() returns null, when there is no entity annotation`() {
+    fun `introspect(type) returns null, when there is no entity annotation`() {
         // given
         val type = NonEntityCLass1::class
 
@@ -46,8 +48,76 @@ class JakartaJpqlIntrospectorTest : WithAssertions {
         assertThat(actual?.name).isNull()
     }
 
+    @Test
+    fun `introspect(property) returns property name, when property is KProperty1`() {
+        // given
+        val property = EntityClass1::property1
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("property1")
+    }
+
+    @Test
+    fun `introspect(property) returns property name with prefix removed, when getter name starts with get`() {
+        // given
+        val property = EntityClass1::getProperty2
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("property2")
+    }
+
+    @Test
+    fun `introspect(property) returns property name as is, when getter name starts with is`() {
+        // given
+        val property = EntityClass1::isProperty3
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("isProperty3")
+    }
+
+    @Test
+    fun `introspect(property) returns property name as is, when getter name does not start with get or is`() {
+        // given
+        val property = EntityClass1::someProperty
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("someProperty")
+    }
+
+    @Test
+    fun `introspect(property) returns null, when property is not KProperty1 or KFunction1`() {
+        // given
+        val property = mockkClass(KProperty0::class)
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isNull()
+    }
+
     @jakarta.persistence.Entity(name = ENTITY_NAME_1)
-    private open class EntityClass1
+    private open class EntityClass1 {
+        val property1: Long = 0
+
+        fun getProperty2(): Long = 100
+
+        fun isProperty3(): Boolean = true
+
+        fun someProperty(): String = "someProperty"
+    }
 
     @jakarta.persistence.Entity
     private open class EntityClass2

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JakartaJpqlIntrospectorTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JakartaJpqlIntrospectorTest.kt
@@ -1,9 +1,7 @@
 package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
 
-import io.mockk.mockkClass
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
-import kotlin.reflect.KProperty0
 
 class JakartaJpqlIntrospectorTest : WithAssertions {
     private val sut = JakartaJpqlIntrospector()
@@ -13,7 +11,7 @@ class JakartaJpqlIntrospectorTest : WithAssertions {
     }
 
     @Test
-    fun `introspect(type) returns name of entity annotation, when entity annotation has name`() {
+    fun `introspect() returns name of entity annotation, when entity annotation has name`() {
         // given
         val type = EntityClass1::class
 
@@ -25,7 +23,7 @@ class JakartaJpqlIntrospectorTest : WithAssertions {
     }
 
     @Test
-    fun `introspect(type) returns name of class, when entity annotation does not have name`() {
+    fun `introspect() returns name of class, when entity annotation does not have name`() {
         // given
         val type = EntityClass2::class
 
@@ -37,7 +35,7 @@ class JakartaJpqlIntrospectorTest : WithAssertions {
     }
 
     @Test
-    fun `introspect(type) returns null, when there is no entity annotation`() {
+    fun `introspect() returns null, when there is no entity annotation`() {
         // given
         val type = NonEntityCLass1::class
 
@@ -48,76 +46,8 @@ class JakartaJpqlIntrospectorTest : WithAssertions {
         assertThat(actual?.name).isNull()
     }
 
-    @Test
-    fun `introspect(property) returns property name, when property is KProperty1`() {
-        // given
-        val property = EntityClass1::property1
-
-        // when
-        val actual = sut.introspect(property)
-
-        // then
-        assertThat(actual?.name).isEqualTo("property1")
-    }
-
-    @Test
-    fun `introspect(property) returns property name with prefix removed, when getter name starts with get`() {
-        // given
-        val property = EntityClass1::getProperty2
-
-        // when
-        val actual = sut.introspect(property)
-
-        // then
-        assertThat(actual?.name).isEqualTo("property2")
-    }
-
-    @Test
-    fun `introspect(property) returns property name as is, when getter name starts with is`() {
-        // given
-        val property = EntityClass1::isProperty3
-
-        // when
-        val actual = sut.introspect(property)
-
-        // then
-        assertThat(actual?.name).isEqualTo("isProperty3")
-    }
-
-    @Test
-    fun `introspect(property) returns property name as is, when getter name does not start with get or is`() {
-        // given
-        val property = EntityClass1::someProperty
-
-        // when
-        val actual = sut.introspect(property)
-
-        // then
-        assertThat(actual?.name).isEqualTo("someProperty")
-    }
-
-    @Test
-    fun `introspect(property) returns null, when property is not KProperty1 or KFunction1`() {
-        // given
-        val property = mockkClass(KProperty0::class)
-
-        // when
-        val actual = sut.introspect(property)
-
-        // then
-        assertThat(actual?.name).isNull()
-    }
-
     @jakarta.persistence.Entity(name = ENTITY_NAME_1)
-    private open class EntityClass1 {
-        val property1: Long = 0
-
-        fun getProperty2(): Long = 100
-
-        fun isProperty3(): Boolean = true
-
-        fun someProperty(): String = "someProperty"
-    }
+    private open class EntityClass1
 
     @jakarta.persistence.Entity
     private open class EntityClass2

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JavaxJpqlIntrospectorTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JavaxJpqlIntrospectorTest.kt
@@ -1,7 +1,9 @@
 package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
 
+import io.mockk.mockkClass
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KProperty0
 
 class JavaxJpqlIntrospectorTest : WithAssertions {
     private val sut = JavaxJpqlIntrospector()
@@ -11,7 +13,7 @@ class JavaxJpqlIntrospectorTest : WithAssertions {
     }
 
     @Test
-    fun introspect() {
+    fun `introspect(type) returns name of entity annotation, when entity annotation has name`() {
         // given
         val type = EntityClass1::class
 
@@ -46,8 +48,76 @@ class JavaxJpqlIntrospectorTest : WithAssertions {
         assertThat(actual?.name).isNull()
     }
 
+    @Test
+    fun `introspect(property) returns property name, when property is KProperty1`() {
+        // given
+        val property = EntityClass1::property1
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("property1")
+    }
+
+    @Test
+    fun `introspect(property) returns property name with prefix removed, when getter name starts with get`() {
+        // given
+        val property = EntityClass1::getProperty2
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("property2")
+    }
+
+    @Test
+    fun `introspect(property) returns property name as is, when getter name starts with is`() {
+        // given
+        val property = EntityClass1::isProperty3
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("isProperty3")
+    }
+
+    @Test
+    fun `introspect(property) returns property name as is, when getter name does not start with get or is`() {
+        // given
+        val property = EntityClass1::someProperty
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("someProperty")
+    }
+
+    @Test
+    fun `introspect(property) returns null, when property is not KProperty1 or KFunction1`() {
+        // given
+        val property = mockkClass(KProperty0::class)
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isNull()
+    }
+
     @javax.persistence.Entity(name = ENTITY_NAME_1)
-    private open class EntityClass1
+    private open class EntityClass1 {
+        val property1: Long = 0
+
+        fun getProperty2(): Long = 100
+
+        fun isProperty3(): Boolean = true
+
+        fun someProperty(): String = "someProperty"
+    }
 
     @javax.persistence.Entity
     private open class EntityClass2

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JavaxJpqlIntrospectorTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/JavaxJpqlIntrospectorTest.kt
@@ -1,9 +1,7 @@
 package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
 
-import io.mockk.mockkClass
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
-import kotlin.reflect.KProperty0
 
 class JavaxJpqlIntrospectorTest : WithAssertions {
     private val sut = JavaxJpqlIntrospector()
@@ -13,7 +11,7 @@ class JavaxJpqlIntrospectorTest : WithAssertions {
     }
 
     @Test
-    fun `introspect(type) returns name of entity annotation, when entity annotation has name`() {
+    fun `introspect() returns name of entity annotation, when entity annotation has name`() {
         // given
         val type = EntityClass1::class
 
@@ -48,76 +46,8 @@ class JavaxJpqlIntrospectorTest : WithAssertions {
         assertThat(actual?.name).isNull()
     }
 
-    @Test
-    fun `introspect(property) returns property name, when property is KProperty1`() {
-        // given
-        val property = EntityClass1::property1
-
-        // when
-        val actual = sut.introspect(property)
-
-        // then
-        assertThat(actual?.name).isEqualTo("property1")
-    }
-
-    @Test
-    fun `introspect(property) returns property name with prefix removed, when getter name starts with get`() {
-        // given
-        val property = EntityClass1::getProperty2
-
-        // when
-        val actual = sut.introspect(property)
-
-        // then
-        assertThat(actual?.name).isEqualTo("property2")
-    }
-
-    @Test
-    fun `introspect(property) returns property name as is, when getter name starts with is`() {
-        // given
-        val property = EntityClass1::isProperty3
-
-        // when
-        val actual = sut.introspect(property)
-
-        // then
-        assertThat(actual?.name).isEqualTo("isProperty3")
-    }
-
-    @Test
-    fun `introspect(property) returns property name as is, when getter name does not start with get or is`() {
-        // given
-        val property = EntityClass1::someProperty
-
-        // when
-        val actual = sut.introspect(property)
-
-        // then
-        assertThat(actual?.name).isEqualTo("someProperty")
-    }
-
-    @Test
-    fun `introspect(property) returns null, when property is not KProperty1 or KFunction1`() {
-        // given
-        val property = mockkClass(KProperty0::class)
-
-        // when
-        val actual = sut.introspect(property)
-
-        // then
-        assertThat(actual?.name).isNull()
-    }
-
     @javax.persistence.Entity(name = ENTITY_NAME_1)
-    private open class EntityClass1 {
-        val property1: Long = 0
-
-        fun getProperty2(): Long = 100
-
-        fun isProperty3(): Boolean = true
-
-        fun someProperty(): String = "someProperty"
-    }
+    private open class EntityClass1
 
     @javax.persistence.Entity
     private open class EntityClass2

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/KotlinStyleJpqlPropertyIntrospectorTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/introspector/impl/KotlinStyleJpqlPropertyIntrospectorTest.kt
@@ -1,0 +1,80 @@
+package com.linecorp.kotlinjdsl.render.jpql.introspector.impl
+
+import io.mockk.mockkClass
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KProperty0
+
+class KotlinStyleJpqlPropertyIntrospectorTest : WithAssertions {
+    private val sut = KotlinStyleJpqlPropertyIntrospector()
+
+    @Test
+    fun `introspect() returns property name, when property is KProperty1`() {
+        // given
+        val property = EntityClass1::property1
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("property1")
+    }
+
+    @Test
+    fun `introspect() returns property name with prefix removed, when getter name starts with get`() {
+        // given
+        val property = EntityClass1::getProperty2
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("property2")
+    }
+
+    @Test
+    fun `introspect() returns property name as is, when getter name starts with is`() {
+        // given
+        val property = EntityClass1::isProperty3
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("isProperty3")
+    }
+
+    @Test
+    fun `introspect() returns property name as is, when getter name does not start with get or is`() {
+        // given
+        val property = EntityClass1::someProperty
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isEqualTo("someProperty")
+    }
+
+    @Test
+    fun `introspect() returns null, when property is not KProperty1 or KFunction1`() {
+        // given
+        val property = mockkClass(KProperty0::class)
+
+        // when
+        val actual = sut.introspect(property)
+
+        // then
+        assertThat(actual?.name).isNull()
+    }
+
+    private class EntityClass1 {
+        val property1: Long = 0
+
+        fun getProperty2(): Long = 100
+
+        fun isProperty3(): Boolean = true
+
+        fun someProperty(): String = "someProperty"
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlEntitySerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlEntitySerializerTest.kt
@@ -18,6 +18,7 @@ import io.mockk.verifySequence
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import kotlin.reflect.KClass
 
 @JpqlSerializerTest
 internal class JpqlEntitySerializerTest : WithAssertions {
@@ -57,7 +58,7 @@ internal class JpqlEntitySerializerTest : WithAssertions {
         clause: JpqlRenderClause,
     ) {
         // given
-        every { introspector.introspect(any()) } returns entityDescription1
+        every { introspector.introspect(any<KClass<*>>()) } returns entityDescription1
 
         val part = Entities.entity(Book::class, alias1)
         val context = TestRenderContext(introspector, statement, clause)

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlEntityTreatSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlEntityTreatSerializerTest.kt
@@ -19,6 +19,7 @@ import io.mockk.verifySequence
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import kotlin.reflect.KClass
 
 @JpqlSerializerTest
 class JpqlEntityTreatSerializerTest : WithAssertions {
@@ -58,7 +59,7 @@ class JpqlEntityTreatSerializerTest : WithAssertions {
         clause: JpqlRenderClause,
     ) {
         // given
-        every { introspector.introspect(any()) } returns entityDescription1
+        every { introspector.introspect(any<KClass<*>>()) } returns entityDescription1
 
         val part = Entities.treat(
             entity1,
@@ -93,7 +94,7 @@ class JpqlEntityTreatSerializerTest : WithAssertions {
         clause: JpqlRenderClause,
     ) {
         // given
-        every { introspector.introspect(any()) } returns entityDescription1
+        every { introspector.introspect(any<KClass<*>>()) } returns entityDescription1
 
         val part = Entities.treat(
             entity1,

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlPathPropertySerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlPathPropertySerializerTest.kt
@@ -5,13 +5,17 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.path.impl.JpqlPathProperty
 import com.linecorp.kotlinjdsl.render.TestRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.entity.book.Book
 import com.linecorp.kotlinjdsl.render.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlPropertyDescription
+import com.linecorp.kotlinjdsl.render.jpql.introspector.JpqlRenderIntrospector
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verifySequence
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KCallable
 
 @JpqlSerializerTest
 class JpqlPathPropertySerializerTest : WithAssertions {
@@ -21,11 +25,18 @@ class JpqlPathPropertySerializerTest : WithAssertions {
     private lateinit var writer: JpqlWriter
 
     @MockK
+    private lateinit var introspector: JpqlRenderIntrospector
+
+    @MockK
     private lateinit var serializer: JpqlRenderSerializer
 
     private val path1 = Paths.path(Book::isbn)
 
     private val property1 = Isbn::value
+
+    private val propertyDescription1 = object : JpqlPropertyDescription {
+        override val name = property1.name
+    }
 
     @Test
     fun handledType() {
@@ -39,11 +50,13 @@ class JpqlPathPropertySerializerTest : WithAssertions {
     @Test
     fun serialize() {
         // given
+        every { introspector.introspect(any<KCallable<*>>()) } returns propertyDescription1
+
         val part = Paths.path(
             path1,
             property1,
         )
-        val context = TestRenderContext(serializer)
+        val context = TestRenderContext(introspector, serializer)
 
         // when
         sut.serialize(part as JpqlPathProperty<*, *>, writer, context)
@@ -52,7 +65,7 @@ class JpqlPathPropertySerializerTest : WithAssertions {
         verifySequence {
             serializer.serialize(path1, writer, context)
             writer.write(".")
-            writer.write(property1.name)
+            writer.write(propertyDescription1.name)
         }
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlPathTreatSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlPathTreatSerializerTest.kt
@@ -15,6 +15,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.verifySequence
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
 
 @JpqlSerializerTest
 class JpqlPathTreatSerializerTest : WithAssertions {
@@ -47,7 +48,7 @@ class JpqlPathTreatSerializerTest : WithAssertions {
     @Test
     fun serialize() {
         // given
-        every { introspector.introspect(any()) } returns entityDescription1
+        every { introspector.introspect(any<KClass<*>>()) } returns entityDescription1
 
         val part = Paths.treat(
             path1,

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlValueSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlValueSerializerTest.kt
@@ -13,6 +13,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.verifySequence
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
 
 @JpqlSerializerTest
 class JpqlValueSerializerTest : WithAssertions {
@@ -59,7 +60,7 @@ class JpqlValueSerializerTest : WithAssertions {
     @Test
     fun `serialize() draws entity name, when value is KClass`() {
         // given
-        every { introspector.introspect(any()) } returns entityDescription1
+        every { introspector.introspect(any<KClass<*>>()) } returns entityDescription1
 
         val part = Expressions.value(
             Book::class,


### PR DESCRIPTION
# Motivation

- See #517 

This pull request has not been completed yet. 
It was created to receive a review to ensure that the work done so far has been implemented correctly.

# Modifications

- Change property type of `JpqlEntityProperty` and `JpqlPathProperty`.
- Add introspector for `KFunction1`

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- User can use KFunction1 to get `Path`.

# Closes

- #517 
