### PR TITLE
docs: fix typo

### DIFF
--- a/docs/en/jpql-with-kotlin-jdsl/spring-supports.md
+++ b/docs/en/jpql-with-kotlin-jdsl/spring-supports.md
@@ -40,7 +40,7 @@ bookRepository.findPage(pageable) {
 ## Spring Batch
 
 Spring Batch provides `JpaPagingItemReader` and `JpaCursorItemReader` for querying data with JPQL.
-Kotlin JDSL provides `KotlinJdslQueryProvider` so that a JPQL query created in DSL can be executed on it.
+Kotlin JDSL provides `KotlinJdslQueryProvider` so that a JPQL query created in DSL can be executed on them.
 
 ```kotlin
 @Auwoired

--- a/docs/ko/jpql-with-kotlin-jdsl/spring-supports.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/spring-supports.md
@@ -3,7 +3,7 @@
 ## Spring Boot AutoConfigure
 
 Kotlin JDSL은 Spring Boot AutoConfigure를 지원합니다.
-만약 프로젝트가 Spring Boot와 `com.linecorp.kotlin-jdsl:spring-data-jpa-support` dependency를 같이 포함하고 있다면, `JpqlRenderContext` bean이 `KotlinJdslAutoConfiguration`를 통해 자동 생성 됩니다.
+만약 프로젝트가 Spring Boot와 `com.linecorp.kotlin-jdsl:spring-data-jpa-support` dependency를 같이 포함하고 있다면, `JpqlRenderContext` bean이 `KotlinJdslAutoConfiguration`을 통해 자동 생성 됩니다.
 
 만약 `JpqlSerializer` 또는 `JpqlIntrospector`를 bean으로 선언했다면, 자동으로 `JpqlRenderContext`에 해당 bean이 포함됩니다.
 
@@ -40,7 +40,7 @@ bookRepository.findPage(pageable) {
 ## Spring Batch
 
 SpringBatch는 JPQL로 쿼리를 할 수 있도록 `JpaPagingItemReader`와 `JpaCursorItemReader`를 제공합니다.
-Kotlin JDSL은 DSL로 생성된 JPQL 쿼리가 JpqReader들에서 실행될 수 있도록 `KotlinJdslQueryProvider`을 제공합니다.
+Kotlin JDSL은 DSL로 생성된 JPQL 쿼리가 위 ItemReader들에서 실행될 수 있도록 `KotlinJdslQueryProvider`를 제공합니다.
 
 ```kotlin
 @Auwoired


### PR DESCRIPTION
# Modifications

- 한글 문서에서 오타로 의심되는 항목을 수정했습니다.
- 영어 원문은 `Kotlin JDSL provides KotlinJdslQueryProvider so that a JPQL query created in DSL can be executed on it.` 인데 마지막 it이 them 이 되어야 하는건지 확실하지 않네요 

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**
