### PR TITLE
Fix Malfunction - only call writeParam() methods inside writeParentheses() method

### DIFF
--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/writer/impl/DefaultJpqlWriter.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/writer/impl/DefaultJpqlWriter.kt
@@ -76,10 +76,12 @@ internal class DefaultJpqlWriter private constructor(
 
     override fun writeParam(value: Any?) {
         internal.writeParam(value)
+        nodes.add(Node.String())
     }
 
     override fun writeParam(name: String, value: Any?) {
         internal.writeParam(name, value)
+        nodes.add(Node.String())
     }
 
     fun getQuery(): String {

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/writer/impl/DefaultJpqlWriterTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/writer/impl/DefaultJpqlWriterTest.kt
@@ -186,6 +186,115 @@ class DefaultJpqlWriterTest : WithAssertions {
     }
 
     @Test
+    fun `writeParentheses() prints a param inside parentheses, when there is the param with a value`() {
+        // when
+        sut.writeParentheses {
+            sut.writeParam(paramValue1)
+        }
+
+        val actualParam = sut.getParams()
+        val actualQuery = sut.getQuery()
+
+        println(actualParam)
+        println(actualQuery)
+        // then
+        assertThat(actualParam).containsEntry("param1", paramValue1)
+        assertThat(actualQuery).isEqualTo("(:param1)")
+    }
+
+    @Test
+    fun `writeParentheses() prints a param inside parentheses, when there is the param with a name and a value`() {
+        // when
+        sut.writeParentheses {
+            sut.writeParam("param1", paramValue1)
+        }
+
+        val actualParam = sut.getParams()
+        val actualQuery = sut.getQuery()
+
+        println(actualParam)
+        println(actualQuery)
+        // then
+        assertThat(actualParam).containsEntry("param1", paramValue1)
+        assertThat(actualQuery).isEqualTo("(:param1)")
+    }
+
+    @Test
+    fun `writeParentheses() prints all params inside parentheses, when there are params with a value`() {
+        // when
+        sut.writeParentheses {
+            sut.writeParam(paramValue1)
+            sut.writeParam(paramValue2)
+            sut.writeParam(paramValue3)
+        }
+
+        val actualParam = sut.getParams()
+        val actualQuery = sut.getQuery()
+
+        println(actualParam)
+        println(actualQuery)
+        // then
+        assertThat(actualParam).containsAllEntriesOf(
+            mapOf(
+                "param1" to paramValue1,
+                "param2" to paramValue2,
+                "param3" to paramValue3,
+            ),
+        )
+        assertThat(actualQuery).isEqualTo("(:param1:param2:param3)")
+    }
+
+    @Test
+    fun `writeParentheses() prints all params inside parentheses, when there are the params with a name and a value`() {
+        // when
+        sut.writeParentheses {
+            sut.writeParam("param1", paramValue1)
+            sut.writeParam("param2", paramValue2)
+            sut.writeParam("param3", paramValue3)
+        }
+
+        val actualParam = sut.getParams()
+        val actualQuery = sut.getQuery()
+
+        println(actualParam)
+        println(actualQuery)
+        // then
+        assertThat(actualParam).containsAllEntriesOf(
+            mapOf(
+                "param1" to paramValue1,
+                "param2" to paramValue2,
+                "param3" to paramValue3,
+            ),
+        )
+        assertThat(actualQuery).isEqualTo("(:param1:param2:param3)")
+    }
+
+    @Test
+    fun `writeParentheses() prints all params inside parentheses, when there are the params`() {
+        // when
+        sut.writeParentheses {
+            sut.writeParam(paramValue1)
+            sut.writeParam("param2", paramValue2)
+            sut.writeParam("param3", paramValue3)
+        }
+
+        val actualParam = sut.getParams()
+        val actualQuery = sut.getQuery()
+
+        println(actualParam)
+        println(actualQuery)
+        // then
+        assertThat(actualParam).containsAllEntriesOf(
+            mapOf(
+                "param1" to paramValue1,
+                "param2" to paramValue2,
+                "param3" to paramValue3,
+            ),
+        )
+        assertThat(actualQuery).isEqualTo("(:param1:param2:param3)")
+    }
+
+    @Test
     fun writeParam() {
         // when
         sut.writeParam(paramValue1)


### PR DESCRIPTION
# Motivation

- String functions 추가 지원을 위한 작업 중, 예상과 다른 동작을 보이는 부분이 있어서 확인해보니,
   3.0.0 부터 지원했던 비슷한 류의 upper(), lower() 등의 함수들도 이전과 다르게 아래와 같은 예기치 않은 동작을 보이는것을 확인했습니다.
- 기존에 `upper(:param1)` 처럼 렌더링 되던게 `upper:param1` 처럼 괄호가 누락된 채로 렌더링 되는 이슈.
- writer에 의해 writeParentheses() 내부에서 writeParam()만 호출하는 경우에 괄호가 누락 됨.
- 원인을 확인해보니 [d2cbb650](https://github.com/line/kotlin-jdsl/commit/d2cbb650a0c3e0e867282c0705698ff034bb756c#diff-2ec10a4f09b99aad188ce0a910134d75a4a517dd168548380e293920dd0d9531) 커밋의 `DefaultJpqlWriter.kt` 변경 이후 부터 영향을 받은듯합니다.
- develop 브랜치는 현재 3.10.0 준비중으로 보여, 3.0.2(hotfix)를 위해 main 브랜치에 PR 올립니다. 혹시나 문제가 없다면 develop에도 반영해 주시면 감사하겠습니다.

# Modifications

- writeParam() 메서드 호출시에도 write 메서드와 마찬가지로, nodes.add(String()) 추가.
- 이슈와 관련된 writeParentheses() 내부에서 writeParam()만 호출하는 경우에 대한 테스트 추가.

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- 기존의 upper(), lower() 등의 함수나 앞으로 추가되는 기능 구현시, writer에 의해 writeParentheses() 내부에서 writeParam()만 호출하는 경우에도 정상적으로 괄호 렌더링이 되어 정상 작동.

# Closes

- #{issue number} (If this PR resolves an issue.)
