### PR TITLE
Add findOne function in spring boot jpa supporter

### DIFF
--- a/example/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/javax/jpql/select/SelectExample.kt
+++ b/example/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/javax/jpql/select/SelectExample.kt
@@ -12,8 +12,10 @@ import com.linecorp.kotlinjdsl.example.spring.data.jpa.javax.jpql.repository.boo
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.javax.jpql.repository.employee.EmployeeRepository
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.dao.IncorrectResultSizeDataAccessException
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.transaction.annotation.Transactional
@@ -30,6 +32,39 @@ class SelectExample : WithAssertions {
 
     @Autowired
     private lateinit var employeeRepository: EmployeeRepository
+
+    @Test
+    fun `only one author by id`() {
+        // when
+        val actual = authorRepository.findOne {
+            select(
+                path(Author::authorId),
+            ).from(
+                entity(Author::class),
+            ).where(
+                path(Author::authorId).equal(1L),
+            )
+        }
+
+        // then
+        assertThat(actual).isEqualTo(1L)
+    }
+
+    @Test
+    fun `throw if result has more than 2 rows`() {
+        // when, then
+        assertThrows<IncorrectResultSizeDataAccessException> {
+            authorRepository.findOne {
+                select(
+                    path(BookAuthor::authorId),
+                ).from(
+                    entity(BookAuthor::class),
+                ).where(
+                    path(BookAuthor::authorId).equal(1L),
+                )
+            }
+        }
+    }
 
     @Test
     fun `the most prolific author`() {

--- a/example/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/SelectExample.kt
+++ b/example/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/SelectExample.kt
@@ -12,8 +12,10 @@ import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.repository.book.Book
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.repository.employee.EmployeeRepository
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.dao.IncorrectResultSizeDataAccessException
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.transaction.annotation.Transactional
@@ -30,6 +32,39 @@ class SelectExample : WithAssertions {
 
     @Autowired
     private lateinit var employeeRepository: EmployeeRepository
+
+    @Test
+    fun `only one author by id`() {
+        // when
+        val actual = authorRepository.findOne {
+            select(
+                path(Author::authorId),
+            ).from(
+                entity(Author::class),
+            ).where(
+                path(Author::authorId).equal(1L),
+            )
+        }
+
+        // then
+        assertThat(actual).isEqualTo(1L)
+    }
+
+    @Test
+    fun `throw if result has more than 2 rows`() {
+        // when, then
+        assertThrows<IncorrectResultSizeDataAccessException> {
+            authorRepository.findOne {
+                select(
+                    path(BookAuthor::authorId),
+                ).from(
+                    entity(BookAuthor::class),
+                ).where(
+                    path(BookAuthor::authorId).equal(1L),
+                )
+            }
+        }
+    }
 
     @Test
     fun `the most prolific author`() {

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutor.kt
@@ -15,6 +15,11 @@ import org.springframework.data.repository.NoRepositoryBean
 @NoRepositoryBean
 @SinceJdsl("3.0.0")
 interface KotlinJdslJpqlExecutor {
+    @SinceJdsl("3.1.0")
+    fun <T : Any> findOne(
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): T?
+
     /**
      * Returns all results of the select query.
      */

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -10,6 +10,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
 import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.javax.JpqlEntityManagerUtils
+import org.springframework.dao.IncorrectResultSizeDataAccessException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
@@ -24,6 +25,14 @@ open class KotlinJdslJpqlExecutorImpl(
     private val entityManager: EntityManager,
     private val renderContext: RenderContext,
 ) : KotlinJdslJpqlExecutor {
+    override fun <T : Any> findOne(
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): T? {
+        return findAll(Jpql, init)
+            .also { if (it.size > 1) throw IncorrectResultSizeDataAccessException(it.size) }
+            .firstOrNull()
+    }
+
     override fun <T : Any> findAll(
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {

--- a/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImplTest.kt
+++ b/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImplTest.kt
@@ -19,7 +19,9 @@ import io.mockk.verifySequence
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.dao.IncorrectResultSizeDataAccessException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
@@ -127,6 +129,41 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         excludeRecords { updateQuery2.toQuery() }
         excludeRecords { deleteQuery1.toQuery() }
         excludeRecords { deleteQuery2.toQuery() }
+    }
+
+    @Test
+    fun findOne() {
+        // given
+        val result = listOf("1")
+        every { JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any()) } returns typedQuery1
+        every { typedQuery1.resultList } returns result
+
+        // when
+        val actual = sut.findOne(createSelectQuery1)
+
+        // then
+        assertThat(actual).isEqualTo("1")
+        verifySequence {
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, renderContext)
+            typedQuery1.resultList
+        }
+    }
+
+    @Test
+    fun `findOne() throw if result has more than 2 rows`() {
+        // given
+        val result = listOf("1", "2")
+        every { JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any()) } returns typedQuery1
+        every { typedQuery1.resultList } returns result
+
+        // when, then
+        assertThrows<IncorrectResultSizeDataAccessException> {
+            sut.findOne(createSelectQuery1)
+        }
+        verifySequence {
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, renderContext)
+            typedQuery1.resultList
+        }
     }
 
     @Test

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
@@ -16,6 +16,14 @@ import org.springframework.data.repository.NoRepositoryBean
 @SinceJdsl("3.0.0")
 interface KotlinJdslJpqlExecutor {
     /**
+     * Returns one result of the select query if greather than one then throw.
+     */
+    @SinceJdsl("3.1.0")
+    fun <T : Any> findOne(
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): T?
+
+    /**
      * Returns all results of the select query.
      */
     @SinceJdsl("3.0.0")

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -11,6 +11,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.JpqlEntityManagerUtils
 import jakarta.persistence.EntityManager
+import org.springframework.dao.IncorrectResultSizeDataAccessException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
@@ -24,6 +25,14 @@ open class KotlinJdslJpqlExecutorImpl(
     private val entityManager: EntityManager,
     private val renderContext: RenderContext,
 ) : KotlinJdslJpqlExecutor {
+    override fun <T : Any> findOne(
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): T? {
+        return findAll(Jpql, init)
+            .also { if (it.size > 1) throw IncorrectResultSizeDataAccessException(it.size) }
+            .firstOrNull()
+    }
+
     override fun <T : Any> findAll(
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {


### PR DESCRIPTION
# Motivation

- [Eng] motivated spring data jpa `fun findByUsername(username: String): User?` function
- [Kor] spring data jpa의  `fun findByUsername(username: String): User?` 함수로 부터 염감을 받았습니다

# Modifications

- [Eng] when I use unique key and if I use findAll then I need to check in (one/null/more than two rows) application/adapter layer or using extension function in repository layer, I thinks it's not simple so I create new function

- [Kor] unique key 를 사용할 때 그리고 findAll를 사용할 경우에는 1개/null/2개이상 검증을 application/adpater 레이어에서 확인하던지 아니면 repository layer의 확장함수를 만들어야 합니다, 간단한 방식이 더 조아 하기 때문에 새로운 기능을 개발 하였습니다

# Result

- findOne 함수 처리 완료

# Closes

- #530
