### PR TITLE
fix the missing single quotation surrounding the function name of JpqlFunctionSerializer.

### DIFF
--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlFunctionSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlFunctionSerializer.kt
@@ -21,7 +21,9 @@ class JpqlFunctionSerializer : JpqlSerializer<JpqlFunction<*>> {
         writer.write("FUNCTION")
 
         writer.writeParentheses {
+            writer.write("'")
             writer.write(part.name)
+            writer.write("'")
 
             if (IterableUtils.isNotEmpty(part.args)) {
                 writer.write(",")

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlFunctionSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlFunctionSerializerTest.kt
@@ -59,7 +59,9 @@ class JpqlFunctionSerializerTest : WithAssertions {
         verifySequence {
             writer.write("FUNCTION")
             writer.writeParentheses(any())
+            writer.write("'")
             writer.write(functionName1)
+            writer.write("'")
             writer.write(",")
             writer.write(" ")
             writer.writeEach(expressions, ", ", "", "", any())
@@ -86,7 +88,9 @@ class JpqlFunctionSerializerTest : WithAssertions {
         verifySequence {
             writer.write("FUNCTION")
             writer.writeParentheses(any())
+            writer.write("'")
             writer.write(functionName1)
+            writer.write("'")
         }
     }
 }


### PR DESCRIPTION
# Motivation
- The JPQL Function function is not operating properly. It should be created as function('function_name', ...), but it is created as function(function_name), making normal query execution impossible.

-- korean
- JPQL Function 기능이 정상적으로 동작하고 있지 않습니다. function('function_name', ...) 으로 생성 되어야 하지만 function(function_name) 으로 생성되고 있어 정상적인 쿼리 수행이 불가능합니다.

# Modifications
- Added a modification to wrap a single quotation in front of part.name of JpqlFunctionSerializer.

-- korean
- JpqlFunctionSerializer 의 part.name 앞에 single quotation 을 감싸는 수정을 추가하였습니다.

# Result

- You can now use JPQL functions normally.

-- korean
- JPQL의 function 을 정상적으로 사용할 수 있게 됩니다.

# Closes

