### PR TITLE
feat: support kotlin 1.7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import java.nio.file.Files
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 import org.gradle.internal.os.OperatingSystem
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -44,6 +45,11 @@ allprojects {
 
     kotlin {
         jvmToolchain(8)
+
+        compilerOptions {
+            apiVersion = KotlinVersion.KOTLIN_1_7
+            languageVersion = KotlinVersion.KOTLIN_1_7
+        }
     }
 
     tasks.withType<KotlinCompile> {

--- a/example/eclipselink-javax/build.gradle.kts
+++ b/example/eclipselink-javax/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(exampleLibs.plugins.kotlin.noarg)
     alias(exampleLibs.plugins.kotlin.allopen)
@@ -20,6 +22,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(11)
+
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_9
+        languageVersion = KotlinVersion.KOTLIN_1_9
+    }
 }
 
 noArg {

--- a/example/eclipselink/build.gradle.kts
+++ b/example/eclipselink/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(exampleLibs.plugins.kotlin.noarg)
     alias(exampleLibs.plugins.kotlin.allopen)
@@ -20,6 +22,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
+
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_9
+        languageVersion = KotlinVersion.KOTLIN_1_9
+    }
 }
 
 noArg {

--- a/example/hibernate-javax/build.gradle.kts
+++ b/example/hibernate-javax/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(exampleLibs.plugins.kotlin.noarg)
     alias(exampleLibs.plugins.kotlin.allopen)
@@ -20,6 +22,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(11)
+
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_9
+        languageVersion = KotlinVersion.KOTLIN_1_9
+    }
 }
 
 noArg {

--- a/example/hibernate-reactive-javax/build.gradle.kts
+++ b/example/hibernate-reactive-javax/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(exampleLibs.plugins.kotlin.noarg)
     alias(exampleLibs.plugins.kotlin.allopen)
@@ -22,6 +24,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(11)
+
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_9
+        languageVersion = KotlinVersion.KOTLIN_1_9
+    }
 }
 
 noArg {

--- a/example/hibernate-reactive/build.gradle.kts
+++ b/example/hibernate-reactive/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(exampleLibs.plugins.kotlin.noarg)
     alias(exampleLibs.plugins.kotlin.allopen)
@@ -22,6 +24,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(11)
+
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_9
+        languageVersion = KotlinVersion.KOTLIN_1_9
+    }
 }
 
 noArg {

--- a/example/hibernate/build.gradle.kts
+++ b/example/hibernate/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(exampleLibs.plugins.kotlin.noarg)
     alias(exampleLibs.plugins.kotlin.allopen)
@@ -20,6 +22,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
+
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_9
+        languageVersion = KotlinVersion.KOTLIN_1_9
+    }
 }
 
 noArg {

--- a/example/spring-batch-javax/build.gradle.kts
+++ b/example/spring-batch-javax/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(exampleLibs.plugins.spring.boot2)
     alias(exampleLibs.plugins.kotlin.noarg)
@@ -24,6 +26,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(8)
+
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_9
+        languageVersion = KotlinVersion.KOTLIN_1_9
+    }
 }
 
 noArg {

--- a/example/spring-batch/build.gradle.kts
+++ b/example/spring-batch/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(exampleLibs.plugins.spring.boot3)
     alias(exampleLibs.plugins.kotlin.noarg)
@@ -24,6 +26,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
+
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_9
+        languageVersion = KotlinVersion.KOTLIN_1_9
+    }
 }
 
 noArg {

--- a/example/spring-data-jpa-javax/build.gradle.kts
+++ b/example/spring-data-jpa-javax/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(exampleLibs.plugins.spring.boot2)
     alias(exampleLibs.plugins.kotlin.noarg)
@@ -22,6 +24,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(8)
+
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_9
+        languageVersion = KotlinVersion.KOTLIN_1_9
+    }
 }
 
 noArg {

--- a/example/spring-data-jpa/build.gradle.kts
+++ b/example/spring-data-jpa/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(exampleLibs.plugins.spring.boot3)
     alias(exampleLibs.plugins.kotlin.noarg)
@@ -22,6 +24,11 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
+
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_9
+        languageVersion = KotlinVersion.KOTLIN_1_9
+    }
 }
 
 noArg {

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlLiteral.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlLiteral.kt
@@ -56,5 +56,7 @@ sealed interface JpqlLiteral<T : Any> : Expression<T> {
         val enum: T,
     ) : JpqlLiteral<T>
 
-    data object NullLiteral : JpqlLiteral<Any>
+    object NullLiteral : JpqlLiteral<Any> {
+        override fun toString(): String = "NullLiteral"
+    }
 }

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlNull.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlNull.kt
@@ -4,4 +4,6 @@ import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
 
 @Internal
-data object JpqlNull : Expression<Any>
+object JpqlNull : Expression<Any> {
+    override fun toString() = "JpqlNull"
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/JpqlRenderClause.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/JpqlRenderClause.kt
@@ -39,47 +39,65 @@ sealed class JpqlRenderClause : AbstractRenderContextElement(Key) {
     open fun isOrderBy(): Boolean = false
 
     @SinceJdsl("3.0.0")
-    data object Select : JpqlRenderClause() {
+    object Select : JpqlRenderClause() {
         override fun isSelect(): Boolean = true
+
+        override fun toString(): String = "Select"
     }
 
     @SinceJdsl("3.0.0")
-    data object Update : JpqlRenderClause() {
+    object Update : JpqlRenderClause() {
         override fun isUpdate(): Boolean = true
+
+        override fun toString(): String = "Update"
     }
 
     @SinceJdsl("3.0.0")
-    data object DeleteFrom : JpqlRenderClause() {
+    object DeleteFrom : JpqlRenderClause() {
         override fun isDeleteFrom(): Boolean = true
+
+        override fun toString(): String = "DeleteFrom"
     }
 
     @SinceJdsl("3.0.0")
-    data object Set : JpqlRenderClause() {
+    object Set : JpqlRenderClause() {
         override fun isSet(): Boolean = true
+
+        override fun toString(): String = "Set"
     }
 
     @SinceJdsl("3.0.0")
-    data object From : JpqlRenderClause() {
+    object From : JpqlRenderClause() {
         override fun isFrom(): Boolean = true
+
+        override fun toString(): String = "From"
     }
 
     @SinceJdsl("3.0.0")
-    data object Where : JpqlRenderClause() {
+    object Where : JpqlRenderClause() {
         override fun isWhere(): Boolean = true
+
+        override fun toString(): String = "Where"
     }
 
     @SinceJdsl("3.0.0")
-    data object Having : JpqlRenderClause() {
+    object Having : JpqlRenderClause() {
         override fun isHaving(): Boolean = true
+
+        override fun toString(): String = "Having"
     }
 
     @SinceJdsl("3.0.0")
-    data object GroupBy : JpqlRenderClause() {
+    object GroupBy : JpqlRenderClause() {
         override fun isGroupBy(): Boolean = true
+
+        override fun toString(): String = "GroupBy"
     }
 
     @SinceJdsl("3.0.0")
-    data object OrderBy : JpqlRenderClause() {
+    object OrderBy : JpqlRenderClause() {
         override fun isOrderBy(): Boolean = true
+
+        override fun toString(): String = "OrderBy"
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/JpqlRenderStatement.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/JpqlRenderStatement.kt
@@ -21,17 +21,23 @@ sealed class JpqlRenderStatement : AbstractRenderContextElement(Key) {
     open fun isDelete(): Boolean = false
 
     @SinceJdsl("3.0.0")
-    data object Select : JpqlRenderStatement() {
+    object Select : JpqlRenderStatement() {
         override fun isSelect(): Boolean = true
+
+        override fun toString(): String = "Select"
     }
 
     @SinceJdsl("3.0.0")
-    data object Update : JpqlRenderStatement() {
+    object Update : JpqlRenderStatement() {
         override fun isUpdate(): Boolean = true
+
+        override fun toString(): String = "Update"
     }
 
     @SinceJdsl("3.0.0")
-    data object Delete : JpqlRenderStatement() {
+    object Delete : JpqlRenderStatement() {
         override fun isDelete(): Boolean = true
+
+        override fun toString(): String = "Delete"
     }
 }

--- a/render/src/main/kotlin/com/linecorp/kotlinjdsl/render/RenderContextImpl.kt
+++ b/render/src/main/kotlin/com/linecorp/kotlinjdsl/render/RenderContextImpl.kt
@@ -8,11 +8,13 @@ abstract class AbstractRenderContextElement(
 ) : RenderContext.Element
 
 @SinceJdsl("3.0.0")
-data object EmptyRenderContext : RenderContext {
+object EmptyRenderContext : RenderContext {
     override fun <E : RenderContext.Element> get(key: RenderContext.Key<E>): E? = null
     override fun <R> fold(initial: R, operation: (R, RenderContext.Element) -> R): R = initial
     override fun plus(context: RenderContext): RenderContext = context
     override fun minusKey(key: RenderContext.Key<*>): RenderContext = this
+
+    override fun toString(): String = "EmptyRenderContext"
 }
 
 internal class CombinedRenderContext(


### PR DESCRIPTION
# Motivation
- Kotlin JDSL is compiled with the latest version of Kotlin, even if the latest version of the Kotlin API is not required.
- This makes Kotlin JDSL unusable for users on older versions of Kotlin.

# Modifications
- Compile with the lowest version of Kotlin that the Kotlin JDSL can support.

# Result
- Kotlin JDSL is now available for users on 1.7 and later versions who were unable to use it before.

# Closes
- #560
