### PR TITLE
Support Datetime function LOCAL DATETIME

### DIFF
--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -47,6 +47,7 @@ import java.math.BigInteger
 import java.sql.Date
 import java.sql.Time
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.internal.Exact
 import kotlin.internal.LowPriorityInOverloadResolution
 import kotlin.reflect.KClass
@@ -3112,5 +3113,15 @@ open class Jpql : JpqlDsl {
     @SinceJdsl("3.0.0")
     fun <T : Any> deleteFrom(entity: Entityable<T>): DeleteQueryWhereStep<T> {
         return DeleteQueryDsl(entity.toEntity())
+    }
+
+    /**
+     * Creates an expression that represents the local datetime.
+     *
+     * This is the same as ```LOCAL DATETIME```.
+     */
+    @SinceJdsl("3.4.0")
+    fun localDateTime(): Expression<LocalDateTime> {
+        return Expressions.localDateTime()
     }
 }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/JpqlLocalDateTimeDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/JpqlLocalDateTimeDslTest.kt
@@ -1,0 +1,25 @@
+package com.linecorp.kotlinjdsl.dsl.jpql
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class JpqlLocalDateTimeDslTest {
+
+    @Test
+    fun localDateTime() {
+        // when
+        val expression = queryPart {
+            localDateTime()
+        }.toExpression()
+
+        val actual: Expression<LocalDateTime> = expression // for type check
+
+        // then
+        val expected = Expressions.localDateTime()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
@@ -25,6 +25,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLength
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLiteral
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLn
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLocalDate
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLocalDateTime
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLocate
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLower
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMax
@@ -60,6 +61,7 @@ import java.math.BigInteger
 import java.sql.Date
 import java.sql.Time
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.internal.Exact
 import kotlin.reflect.KClass
 
@@ -752,5 +754,13 @@ object Expressions {
     @SinceJdsl("3.0.0")
     fun <T : Any> parentheses(expr: Expression<T>): Expression<T> {
         return JpqlExpressionParentheses(expr)
+    }
+
+    /**
+     * Creates an expression that represents the local datetime in jpql.
+     */
+    @SinceJdsl("3.4.0")
+    fun localDateTime(): Expression<LocalDateTime> {
+        return JpqlLocalDateTime
     }
 }

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlLocalDateTime.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlLocalDateTime.kt
@@ -1,0 +1,8 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import java.time.LocalDateTime
+
+@Internal
+object JpqlLocalDateTime : Expression<LocalDateTime>

--- a/query-model/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/ExpressionsTest.kt
+++ b/query-model/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/ExpressionsTest.kt
@@ -27,6 +27,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLength
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLiteral
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLn
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLocalDate
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLocalDateTime
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLocate
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLower
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMax
@@ -1062,6 +1063,17 @@ class ExpressionsTest : WithAssertions {
         val expected = JpqlExpressionParentheses(
             intExpression1,
         )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun localDateTime() {
+        // when
+        val actual = Expressions.localDateTime()
+
+        // then
+        val expected = JpqlLocalDateTime.toExpression()
 
         assertThat(actual).isEqualTo(expected)
     }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
@@ -78,6 +78,7 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLikeSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLiteralSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLnSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLocalDateSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLocalDateTimeSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLocateSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLowerSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlMaxSerializer
@@ -336,6 +337,7 @@ private class DefaultModule : JpqlRenderModule {
             JpqlLiteralSerializer(),
             JpqlLnSerializer(),
             JpqlLocalDateSerializer(),
+            JpqlLocalDateTimeSerializer(),
             JpqlLocateSerializer(),
             JpqlLowerSerializer(),
             JpqlMaxSerializer(),

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLocalDateTimeSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLocalDateTimeSerializer.kt
@@ -1,0 +1,20 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLocalDateTime
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@Internal
+class JpqlLocalDateTimeSerializer : JpqlSerializer<JpqlLocalDateTime> {
+
+    override fun handledType(): KClass<JpqlLocalDateTime> {
+        return JpqlLocalDateTime::class
+    }
+
+    override fun serialize(part: JpqlLocalDateTime, writer: JpqlWriter, context: RenderContext) {
+        writer.write("LOCAL DATETIME")
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlJpqlLocalDateTimeSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlJpqlLocalDateTimeSerializerTest.kt
@@ -1,0 +1,52 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLocalDateTime
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.runs
+import io.mockk.verifySequence
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@JpqlSerializerTest
+class JpqlJpqlLocalDateTimeSerializerTest {
+    private val sut = JpqlLocalDateTimeSerializer()
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    @Test
+    fun handle() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlLocalDateTime::class)
+    }
+
+    @Test
+    fun serialize() {
+        // given
+        every { writer.write(any<String>()) } just runs
+
+        val part = Expressions.localDateTime() as JpqlLocalDateTime
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part, writer, context)
+
+        // then
+        verifySequence {
+            writer.write("LOCAL DATETIME")
+        }
+    }
+}


### PR DESCRIPTION
# Motivation

- JDSL doesn't support `LOCAL DATETIME` in JPQL

# Modifications

- I create `localDateTime()` & `serializer` to support `LOCAL DATETIME` function 

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- Support `LOCAL DATETIME` function in JPQL

# Closes

- #604
