### PR TITLE
Support for creating queries via initialized JpqlDsl object

### DIFF
--- a/docs/ko/jpql-with-kotlin-jdsl/custom-dsl.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/custom-dsl.md
@@ -9,9 +9,12 @@
 그리고 [`Expression`](expressions.md) 혹은 [`Predicate`](predicates.md)를 구현한 나만의 `Model` 클래스를 만들고, 이를 반환하는 함수를 만들 수 있습니다.
 이 경우 [`JpqlSerializer`](custom-dsl.md#serializer)를 구현하여 `Model`을 String으로 랜더링하는 방법을 Kotlin JDSL에게 알려줄 수 있습니다.
 
-{% hint style="info" %}
-`jpql()`이 DSL을 인식하기 위해서 `JpqlDsl.Constructor`를 companion object로 구현해야 합니다.
-{% endhint %}
+이렇게 만들어진 나만의 DSL을 `jpql()`에 전달하기 위한 두 가지 방법이 있습니다.
+첫 번째는 DSL 객체를 생성하는 `JpqlDsl.Constructor`를 companion object로 구현하는 것이고, 두 번째는 DSL 인스턴스를 생성하는 것입니다.
+
+### JpqlDsl.Constructor
+
+이 방법을 사용하면 클래스만 선언해 사용할 수 있으며 쿼리 생성 시마다 새로운 인스턴스를 자동으로 생성합니다.
 
 ```kotlin
 class MyJpql : Jpql() {
@@ -39,9 +42,37 @@ val query = jpql(MyJpql) {
 }
 ```
 
+### Jpql Instance
+
+이 방법을 사용하면 쿼리 생성에 하나의 인스턴스를 재활용할 수 있으며 의존성 주입을 활용할 수 있습니다.
+
+```kotlin
+class MyJpql(
+    private val encryptor: Encryptor,
+) : Jpql() {
+    fun Path<String>.equalToEncrypted(value: String): Predicate {
+        val encrypted = encryptor.encrypt(value)
+        return this.eq(encrypted)
+    }
+}
+
+val encryptor = Encryptor()
+val instance = MyJpql(encryptor)
+
+val query = jpql(instance) {
+    select(
+        entity(Book::class)
+    ).from(
+        entity(Book::class)
+    ).where(
+        path(Book::title).equalToEncrypted("plain")
+    )
+}
+```
+
 ### Serializer
 
-나만의 `Model`을 String을 랜더링하기 위해 `JpqlSerializer`를 구현하고 이를 `RenderContext`에 추가해야 합니다.
+나만의 `Model`을 String으로 랜더링하기 위해 `JpqlSerializer`를 구현하고 이를 `RenderContext`에 추가해야 합니다.
 
 `JpqlSerializer`는 랜더링 로직을 구현할 수 있도록 `JpqlWriter`와 `RenderContext`를 제공합니다.
 `RenderContext`를 통해 `JpqlRenderSerializer`를 얻어 나의 `Model`이 가지고 있는 다른 `Model`을 랜더링할 수 있습니다.

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -73,6 +73,14 @@ inline fun <DSL : JpqlDsl, Q : JpqlQuery<Q>> jpql(dsl: JpqlDsl.Constructor<DSL>,
 }
 
 /**
+ * Builds new JPQL query using provided JpqlDsl instance.
+ */
+@SinceJdsl("3.4.0")
+inline fun <DSL : JpqlDsl, Q : JpqlQuery<Q>> jpql(jpql: DSL, init: DSL.() -> JpqlQueryable<Q>): Q {
+    return jpql.init().toQuery()
+}
+
+/**
  * Default implementation of DSL for building a JPQL query.
  */
 @SinceJdsl("3.0.0")

--- a/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/item/database/orm/KotlinJdslQueryProviderFactory.kt
+++ b/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/item/database/orm/KotlinJdslQueryProviderFactory.kt
@@ -64,6 +64,31 @@ class KotlinJdslQueryProviderFactory(
     /**
      * Creates a [KotlinJdslQueryProvider] from a select query.
      */
+    fun <DSL : JpqlDsl, T : Any> create(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): KotlinJdslQueryProvider<T> {
+        val query = jpql(dsl, init)
+
+        return KotlinJdslQueryProvider(query, emptyMap(), context)
+    }
+
+    /**
+     * Creates a [KotlinJdslQueryProvider] from a select query.
+     */
+    fun <DSL : JpqlDsl, T : Any> create(
+        dsl: DSL,
+        queryParams: Map<String, Any?>,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): KotlinJdslQueryProvider<T> {
+        val query = jpql(dsl, init)
+
+        return KotlinJdslQueryProvider(query, queryParams, context)
+    }
+
+    /**
+     * Creates a [KotlinJdslQueryProvider] from a select query.
+     */
     fun <T : Any> create(
         query: SelectQuery<T>,
     ): KotlinJdslQueryProvider<T> {

--- a/support/spring-batch-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/item/database/orm/KotlinJdslQueryProviderFactoryTest.kt
+++ b/support/spring-batch-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/item/database/orm/KotlinJdslQueryProviderFactoryTest.kt
@@ -31,10 +31,16 @@ class KotlinJdslQueryProviderFactoryTest : WithAssertions {
     private lateinit var createSelectQuery2: MyJpql.() -> JpqlQueryable<SelectQuery<String>>
 
     @MockK
+    private lateinit var createSelectQuery3: MyJpqlObject.() -> JpqlQueryable<SelectQuery<String>>
+
+    @MockK
     private lateinit var selectQuery1: SelectQuery<String>
 
     @MockK
     private lateinit var selectQuery2: SelectQuery<String>
+
+    @MockK
+    private lateinit var selectQuery3: SelectQuery<String>
 
     private val queryParams1 = mapOf("authorId" to 1L)
 
@@ -53,18 +59,33 @@ class KotlinJdslQueryProviderFactoryTest : WithAssertions {
         }
     }
 
+    private object MyJpqlObject : Jpql() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            return javaClass == other?.javaClass
+        }
+
+        override fun hashCode(): Int {
+            return javaClass.hashCode()
+        }
+    }
+
     @BeforeEach
     fun setUp() {
         every { createSelectQuery1.invoke(any()) } returns selectQuery1
         every { createSelectQuery2.invoke(any()) } returns selectQuery2
+        every { createSelectQuery3.invoke(any()) } returns selectQuery3
 
         every { selectQuery1.toQuery() } returns selectQuery1
         every { selectQuery2.toQuery() } returns selectQuery2
+        every { selectQuery3.toQuery() } returns selectQuery3
 
         excludeRecords { createSelectQuery1.invoke(any()) }
         excludeRecords { createSelectQuery2.invoke(any()) }
+        excludeRecords { createSelectQuery3.invoke(any()) }
         excludeRecords { selectQuery1.toQuery() }
         excludeRecords { selectQuery2.toQuery() }
+        excludeRecords { selectQuery3.toQuery() }
     }
 
     @Test
@@ -120,6 +141,36 @@ class KotlinJdslQueryProviderFactoryTest : WithAssertions {
         // then
         val expected = KotlinJdslQueryProvider(
             query = jpql(MyJpql, createSelectQuery2),
+            queryParams = queryParams1,
+            context = context,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `create() with an dsl object and a select queryable`() {
+        // when
+        val actual = sut.create(MyJpqlObject, createSelectQuery3)
+
+        // then
+        val expected = KotlinJdslQueryProvider(
+            query = jpql(MyJpqlObject, createSelectQuery3),
+            queryParams = emptyMap(),
+            context = context,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `create() with an dsl object, a select queryable, and query params`() {
+        // when
+        val actual = sut.create(MyJpqlObject, queryParams1, createSelectQuery3)
+
+        // then
+        val expected = KotlinJdslQueryProvider(
+            query = jpql(MyJpqlObject, createSelectQuery3),
             queryParams = queryParams1,
             context = context,
         )

--- a/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/item/database/orm/KotlinJdslQueryProviderFactory.kt
+++ b/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/item/database/orm/KotlinJdslQueryProviderFactory.kt
@@ -64,6 +64,31 @@ class KotlinJdslQueryProviderFactory(
     /**
      * Creates a [KotlinJdslQueryProvider] from a select query.
      */
+    fun <DSL : JpqlDsl, T : Any> create(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): KotlinJdslQueryProvider<T> {
+        val query = jpql(dsl, init)
+
+        return KotlinJdslQueryProvider(query, emptyMap(), context)
+    }
+
+    /**
+     * Creates a [KotlinJdslQueryProvider] from a select query.
+     */
+    fun <DSL : JpqlDsl, T : Any> create(
+        dsl: DSL,
+        queryParams: Map<String, Any?>,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): KotlinJdslQueryProvider<T> {
+        val query = jpql(dsl, init)
+
+        return KotlinJdslQueryProvider(query, queryParams, context)
+    }
+
+    /**
+     * Creates a [KotlinJdslQueryProvider] from a select query.
+     */
     fun <T : Any> create(
         query: SelectQuery<T>,
     ): KotlinJdslQueryProvider<T> {

--- a/support/spring-batch/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/item/database/orm/KotlinJdslQueryProviderFactoryTest.kt
+++ b/support/spring-batch/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/item/database/orm/KotlinJdslQueryProviderFactoryTest.kt
@@ -31,10 +31,16 @@ class KotlinJdslQueryProviderFactoryTest : WithAssertions {
     private lateinit var createSelectQuery2: MyJpql.() -> JpqlQueryable<SelectQuery<String>>
 
     @MockK
+    private lateinit var createSelectQuery3: MyJpqlObject.() -> JpqlQueryable<SelectQuery<String>>
+
+    @MockK
     private lateinit var selectQuery1: SelectQuery<String>
 
     @MockK
     private lateinit var selectQuery2: SelectQuery<String>
+
+    @MockK
+    private lateinit var selectQuery3: SelectQuery<String>
 
     private val queryParams1 = mapOf("authorId" to 1L)
 
@@ -53,18 +59,33 @@ class KotlinJdslQueryProviderFactoryTest : WithAssertions {
         }
     }
 
+    private object MyJpqlObject : Jpql() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            return javaClass == other?.javaClass
+        }
+
+        override fun hashCode(): Int {
+            return javaClass.hashCode()
+        }
+    }
+
     @BeforeEach
     fun setUp() {
         every { createSelectQuery1.invoke(any()) } returns selectQuery1
         every { createSelectQuery2.invoke(any()) } returns selectQuery2
+        every { createSelectQuery3.invoke(any()) } returns selectQuery3
 
         every { selectQuery1.toQuery() } returns selectQuery1
         every { selectQuery2.toQuery() } returns selectQuery2
+        every { selectQuery3.toQuery() } returns selectQuery3
 
         excludeRecords { createSelectQuery1.invoke(any()) }
         excludeRecords { createSelectQuery2.invoke(any()) }
+        excludeRecords { createSelectQuery3.invoke(any()) }
         excludeRecords { selectQuery1.toQuery() }
         excludeRecords { selectQuery2.toQuery() }
+        excludeRecords { selectQuery3.toQuery() }
     }
 
     @Test
@@ -120,6 +141,36 @@ class KotlinJdslQueryProviderFactoryTest : WithAssertions {
         // then
         val expected = KotlinJdslQueryProvider(
             query = jpql(MyJpql, createSelectQuery2),
+            queryParams = queryParams1,
+            context = context,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `create() with an dsl object and a select queryable`() {
+        // when
+        val actual = sut.create(MyJpqlObject, createSelectQuery3)
+
+        // then
+        val expected = KotlinJdslQueryProvider(
+            query = jpql(MyJpqlObject, createSelectQuery3),
+            queryParams = emptyMap(),
+            context = context,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `create() with an dsl object, a select queryable, and query params`() {
+        // when
+        val actual = sut.create(MyJpqlObject, queryParams1, createSelectQuery3)
+
+        // then
+        val expected = KotlinJdslQueryProvider(
+            query = jpql(MyJpqlObject, createSelectQuery3),
             queryParams = queryParams1,
             context = context,
         )

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutor.kt
@@ -35,6 +35,15 @@ interface KotlinJdslJpqlExecutor {
     /**
      * Returns all results of the select query.
      */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
     @SinceJdsl("3.0.0")
     fun <T : Any> findAll(
         pageable: Pageable,
@@ -47,6 +56,16 @@ interface KotlinJdslJpqlExecutor {
     @SinceJdsl("3.0.0")
     fun <T : Any, DSL : JpqlDsl> findAll(
         dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: DSL,
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?>
@@ -71,6 +90,16 @@ interface KotlinJdslJpqlExecutor {
     ): Page<T?>
 
     /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Page<T?>
+
+    /**
      * Returns the slice of the select query.
      */
     @SinceJdsl("3.0.0")
@@ -85,6 +114,16 @@ interface KotlinJdslJpqlExecutor {
     @SinceJdsl("3.0.0")
     fun <T : Any, DSL : JpqlDsl> findSlice(
         dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Slice<T?>
+
+    /**
+     * Returns the slice of the select query.
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> findSlice(
+        dsl: DSL,
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): Slice<T?>
@@ -111,6 +150,17 @@ interface KotlinJdslJpqlExecutor {
     ): Int
 
     /**
+     * Execute the update query.
+     *
+     * @return the number of entities updated
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> update(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
+    ): Int
+
+    /**
      * Execute the delete query.
      *
      * @return the number of entities deleted
@@ -128,6 +178,17 @@ interface KotlinJdslJpqlExecutor {
     @SinceJdsl("3.0.0")
     fun <T : Any, DSL : JpqlDsl> delete(
         dsl: JpqlDsl.Constructor<DSL>,
+        init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
+    ): Int
+
+    /**
+     * Execute the delete query.
+     *
+     * @return the number of entities deleted
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> delete(
+        dsl: DSL,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int
 }

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -40,6 +40,13 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.resultList
     }
 
+    override fun <T : Any, DSL : JpqlDsl> findAll(dsl: DSL, init: DSL.() -> JpqlQueryable<SelectQuery<T>>): List<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+
+        return jpaQuery.resultList
+    }
+
     override fun <T : Any> findAll(
         pageable: Pageable,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
@@ -49,6 +56,16 @@ open class KotlinJdslJpqlExecutorImpl(
 
     override fun <T : Any, DSL : JpqlDsl> findAll(
         dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+
+        return JpqlEntityManagerUtils.queryForList(entityManager, query, pageable, renderContext)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: DSL,
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
@@ -74,6 +91,16 @@ open class KotlinJdslJpqlExecutorImpl(
         return JpqlEntityManagerUtils.queryForPage(entityManager, query, pageable, renderContext)
     }
 
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Page<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+
+        return JpqlEntityManagerUtils.queryForPage(entityManager, query, pageable, renderContext)
+    }
+
     override fun <T : Any> findSlice(
         pageable: Pageable,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
@@ -91,6 +118,15 @@ open class KotlinJdslJpqlExecutorImpl(
         return JpqlEntityManagerUtils.queryForSlice(entityManager, query, pageable, renderContext)
     }
 
+    override fun <T : Any, DSL : JpqlDsl> findSlice(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Slice<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+
+        return JpqlEntityManagerUtils.queryForSlice(entityManager, query, pageable, renderContext)
+    }
     override fun <T : Any> update(
         init: Jpql.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
@@ -107,6 +143,16 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    override fun <T : Any, DSL : JpqlDsl> update(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
+    ): Int {
+        val query: UpdateQuery<T> = jpql(dsl, init)
+        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+
+        return jpaQuery.executeUpdate()
+    }
+
     override fun <T : Any> delete(
         init: Jpql.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
@@ -115,6 +161,16 @@ open class KotlinJdslJpqlExecutorImpl(
 
     override fun <T : Any, DSL : JpqlDsl> delete(
         dsl: JpqlDsl.Constructor<DSL>,
+        init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
+    ): Int {
+        val query: DeleteQuery<T> = jpql(dsl, init)
+        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+
+        return jpaQuery.executeUpdate()
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> delete(
+        dsl: DSL,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
         val query: DeleteQuery<T> = jpql(dsl, init)

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
@@ -35,6 +35,15 @@ interface KotlinJdslJpqlExecutor {
     /**
      * Returns all results of the select query.
      */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
     @SinceJdsl("3.0.0")
     fun <T : Any> findAll(
         pageable: Pageable,
@@ -47,6 +56,16 @@ interface KotlinJdslJpqlExecutor {
     @SinceJdsl("3.0.0")
     fun <T : Any, DSL : JpqlDsl> findAll(
         dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: DSL,
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?>
@@ -71,6 +90,16 @@ interface KotlinJdslJpqlExecutor {
     ): Page<T?>
 
     /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Page<T?>
+
+    /**
      * Returns the slice of the select query.
      */
     @SinceJdsl("3.0.0")
@@ -85,6 +114,16 @@ interface KotlinJdslJpqlExecutor {
     @SinceJdsl("3.0.0")
     fun <T : Any, DSL : JpqlDsl> findSlice(
         dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Slice<T?>
+
+    /**
+     * Returns the slice of the select query.
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> findSlice(
+        dsl: DSL,
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): Slice<T?>
@@ -111,6 +150,17 @@ interface KotlinJdslJpqlExecutor {
     ): Int
 
     /**
+     * Execute the update query.
+     *
+     * @return the number of entities updated
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> update(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
+    ): Int
+
+    /**
      * Execute the delete query.
      *
      * @return the number of entities deleted
@@ -128,6 +178,17 @@ interface KotlinJdslJpqlExecutor {
     @SinceJdsl("3.0.0")
     fun <T : Any, DSL : JpqlDsl> delete(
         dsl: JpqlDsl.Constructor<DSL>,
+        init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
+    ): Int
+
+    /**
+     * Execute the delete query.
+     *
+     * @return the number of entities deleted
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Any, DSL : JpqlDsl> delete(
+        dsl: DSL,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int
 }

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -40,6 +40,13 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.resultList
     }
 
+    override fun <T : Any, DSL : JpqlDsl> findAll(dsl: DSL, init: DSL.() -> JpqlQueryable<SelectQuery<T>>): List<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+
+        return jpaQuery.resultList
+    }
+
     override fun <T : Any> findAll(
         pageable: Pageable,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
@@ -49,6 +56,16 @@ open class KotlinJdslJpqlExecutorImpl(
 
     override fun <T : Any, DSL : JpqlDsl> findAll(
         dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+
+        return JpqlEntityManagerUtils.queryForList(entityManager, query, pageable, renderContext)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: DSL,
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
@@ -74,6 +91,16 @@ open class KotlinJdslJpqlExecutorImpl(
         return JpqlEntityManagerUtils.queryForPage(entityManager, query, pageable, renderContext)
     }
 
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Page<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+
+        return JpqlEntityManagerUtils.queryForPage(entityManager, query, pageable, renderContext)
+    }
+
     override fun <T : Any> findSlice(
         pageable: Pageable,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
@@ -91,6 +118,15 @@ open class KotlinJdslJpqlExecutorImpl(
         return JpqlEntityManagerUtils.queryForSlice(entityManager, query, pageable, renderContext)
     }
 
+    override fun <T : Any, DSL : JpqlDsl> findSlice(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Slice<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+
+        return JpqlEntityManagerUtils.queryForSlice(entityManager, query, pageable, renderContext)
+    }
     override fun <T : Any> update(
         init: Jpql.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
@@ -107,6 +143,16 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    override fun <T : Any, DSL : JpqlDsl> update(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
+    ): Int {
+        val query: UpdateQuery<T> = jpql(dsl, init)
+        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+
+        return jpaQuery.executeUpdate()
+    }
+
     override fun <T : Any> delete(
         init: Jpql.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
@@ -115,6 +161,16 @@ open class KotlinJdslJpqlExecutorImpl(
 
     override fun <T : Any, DSL : JpqlDsl> delete(
         dsl: JpqlDsl.Constructor<DSL>,
+        init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
+    ): Int {
+        val query: DeleteQuery<T> = jpql(dsl, init)
+        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+
+        return jpaQuery.executeUpdate()
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> delete(
+        dsl: DSL,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
         val query: DeleteQuery<T> = jpql(dsl, init)


### PR DESCRIPTION
# Motivation

- related #563

# Modifications

- Add overloading methods that takes jdsl object
- Update documentation

> 영문문서는 한글 내용을 먼저 확인받고 진행해보겠습니다!

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- There will be a new entry point to use the JpqlDsl created and managed by the user.

# Closes

- #563 
