### PR TITLE
Support Datetime function CURRENT_TIMESTAMP

### DIFF
--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -46,6 +46,7 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import java.sql.Date
 import java.sql.Time
+import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -743,6 +744,16 @@ open class Jpql : JpqlDsl {
     @SinceJdsl("3.4.0")
     fun currentTime(): Expression<Time> {
         return Expressions.currentTime()
+    }
+
+    /**
+     * Creates an expression that represents the current timestamp(datetime).
+     *
+     * This is the same as ```CURRENT_TIMESTAMP```.
+     */
+    @SinceJdsl("3.4.0")
+    fun currentTimestamp(): Expression<Timestamp> {
+        return Expressions.currentTimestamp()
     }
 
     /**

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/CurrentTimestampTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/CurrentTimestampTest.kt
@@ -1,0 +1,25 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.expression
+
+import com.linecorp.kotlinjdsl.dsl.jpql.queryPart
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+import java.sql.Timestamp
+
+class CurrentTimestampTest : WithAssertions {
+    @Test
+    fun currentTimestamp() {
+        // when
+        val expression = queryPart {
+            currentTimestamp()
+        }.toExpression()
+
+        val actual: Expression<Timestamp> = expression // for type check
+
+        // then
+        val expected = Expressions.currentTimestamp()
+
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/LocalDateTimeDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/LocalDateTimeDslTest.kt
@@ -1,12 +1,13 @@
-package com.linecorp.kotlinjdsl.dsl.jpql
+package com.linecorp.kotlinjdsl.dsl.jpql.expression
 
+import com.linecorp.kotlinjdsl.dsl.jpql.queryPart
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
-class JpqlLocalDateTimeDslTest {
+class LocalDateTimeDslTest {
     @Test
     fun localDateTime() {
         // when

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
@@ -13,6 +13,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlConcat
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCount
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCurrentDate
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCurrentTime
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCurrentTimestamp
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCustomExpression
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlDivide
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlEntityType
@@ -61,6 +62,7 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import java.sql.Date
 import java.sql.Time
+import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -324,6 +326,16 @@ object Expressions {
     @SinceJdsl("3.4.0")
     fun currentTime(): Expression<Time> {
         return JpqlCurrentTime
+    }
+
+    /**
+     * Creates an expression that represents the current timestamp(datetime).
+     *
+     * This is the same as ```CURRENT_TIMESTAMP```.
+     */
+    @SinceJdsl("3.4.0")
+    fun currentTimestamp(): Expression<Timestamp> {
+        return JpqlCurrentTimestamp
     }
 
     /**

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlCurrentTimestamp.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlCurrentTimestamp.kt
@@ -1,0 +1,8 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import java.sql.Timestamp
+
+@Internal
+object JpqlCurrentTimestamp : Expression<Timestamp>

--- a/query-model/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/ExpressionsTest.kt
+++ b/query-model/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/ExpressionsTest.kt
@@ -15,6 +15,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlConcat
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCount
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCurrentDate
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCurrentTime
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCurrentTimestamp
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCustomExpression
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlDivide
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlEntityType
@@ -497,6 +498,17 @@ class ExpressionsTest : WithAssertions {
 
         // then
         val expected = JpqlCurrentTime
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun currentTimestamp() {
+        // when
+        val actual = Expressions.currentTimestamp()
+
+        // then
+        val expected = JpqlCurrentTimestamp
 
         assertThat(actual).isEqualTo(expected)
     }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
@@ -26,6 +26,7 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlConcatSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCountSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCurrentDateSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCurrentTimeSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCurrentTimestampSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCustomExpressionSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCustomPredicateSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlDeleteQuerySerializer
@@ -286,6 +287,7 @@ private class DefaultModule : JpqlRenderModule {
             JpqlCountSerializer(),
             JpqlCurrentDateSerializer(),
             JpqlCurrentTimeSerializer(),
+            JpqlCurrentTimestampSerializer(),
             JpqlCustomExpressionSerializer(),
             JpqlCustomPredicateSerializer(),
             JpqlDeleteQuerySerializer(),

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlCurrentTimestampSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlCurrentTimestampSerializer.kt
@@ -1,0 +1,19 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCurrentTimestamp
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@Internal
+class JpqlCurrentTimestampSerializer : JpqlSerializer<JpqlCurrentTimestamp> {
+    override fun handledType(): KClass<JpqlCurrentTimestamp> {
+        return JpqlCurrentTimestamp::class
+    }
+
+    override fun serialize(part: JpqlCurrentTimestamp, writer: JpqlWriter, context: RenderContext) {
+        writer.write("CURRENT_TIMESTAMP")
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlCurrentTimestampSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlCurrentTimestampSerializerTest.kt
@@ -1,0 +1,47 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCurrentTimestamp
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.impl.annotations.MockK
+import io.mockk.verifySequence
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+@JpqlSerializerTest
+class JpqlCurrentTimestampSerializerTest : WithAssertions {
+    private val sut = JpqlCurrentTimestampSerializer()
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlCurrentTimestamp::class)
+    }
+
+    @Test
+    fun serialize() {
+        // given
+        val part = Expressions.currentTimestamp()
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlCurrentTimestamp, writer, context)
+
+        // then
+        verifySequence {
+            writer.write("CURRENT_TIMESTAMP")
+        }
+    }
+}


### PR DESCRIPTION
# Motivation

- JDSL doesn't support `CURRENT_TIMESTAMP` in JPQL

# Modifications

- Writing `currentTimestamp()` in Jpql, Expressions
- Creating a `JpqlCurrentTimestampSerializer`
- Add JpqlCurrentTimestampSerializer to `JpqlRenderContext`
- Write the respective test code
- Change FQCN for non-conventional code (`*.jpql.JpqlLocalDateTimeDslTest` -> `*.expression.LocalDateTimeDslTest`)

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- Now supports `CURRENT_TIMESTAMP`.

# Closes

- #601
