### PR TITLE
feat: Support 'mod' arithmetic operator

### DIFF
--- a/docs/en/jpql-with-kotlin-jdsl/expressions.md
+++ b/docs/en/jpql-with-kotlin-jdsl/expressions.md
@@ -52,6 +52,7 @@ Use the following functions to build arithmetic operations:
 * \- (minus)
 * \* (times)
 * / (div)
+* % (mod)
 
 ```kotlin
 path(Book::price).plus(path(Book::salePrice))

--- a/docs/ko/jpql-with-kotlin-jdsl/expressions.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/expressions.md
@@ -52,6 +52,7 @@ avg(path(FullTimeEmployee::annualSalary)(EmployeeSalary::value)).`as`(BigDecimal
 * \- (minus)
 * \* (times)
 * / (div)
+* % (mod)
 
 ```kotlin
 path(Book::price).plus(path(Book::salePrice))

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -537,6 +537,54 @@ open class Jpql : JpqlDsl {
     }
 
     /**
+     * Creates an expression that represents the modulo of values.
+     *
+     * This is the same as ```(value1) % (value2)```.
+     */
+    @JvmName("modWithParentheses")
+    @SinceJdsl("3.4.0")
+    fun <T : Number, S : T?> mod(value1: Expressionable<@Exact T>, value2: S): Expression<T> {
+        return Expressions.mod(
+            Expressions.parentheses(value1.toExpression()),
+            Expressions.parentheses(Expressions.value(value2)),
+        )
+    }
+
+    /**
+     * Creates an expression that represents the modulo of values.
+     *
+     * This is the same as ```(value1) % (value2)```.
+     */
+    @JvmName("modWithParentheses")
+    @SinceJdsl("3.4.0")
+    fun <T : Number, S : T> mod(value1: Expressionable<@Exact T>, value2: Expressionable<S>): Expression<T> {
+        return Expressions.mod(
+            Expressions.parentheses(value1.toExpression()),
+            Expressions.parentheses(value2.toExpression()),
+        )
+    }
+
+    /**
+     * Creates an expression that represents the modulo of values.
+     *
+     * This is the same as ```(value1) % (value2)```.
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Number, S : T?> Expressionable<@Exact T>.mod(value: S): Expression<T> {
+        return Expressions.mod(this.toExpression(), Expressions.value(value))
+    }
+
+    /**
+     * Creates an expression that represents the modulo of values.
+     *
+     * This is the same as ```(value1) % (value2)```.
+     */
+    @SinceJdsl("3.4.0")
+    fun <T : Number, S : T> Expressionable<@Exact T>.mod(value: Expressionable<S>): Expression<T> {
+        return Expressions.mod(this.toExpression(), value.toExpression())
+    }
+
+    /**
      * Creates an expression that represents the count of non-null values.
      *
      * If there are no matching rows, it returns 0.
@@ -2896,4 +2944,8 @@ open class Jpql : JpqlDsl {
     fun <T : Any> deleteFrom(entity: Entityable<T>): DeleteQueryWhereStep<T> {
         return DeleteQueryDsl(entity.toEntity())
     }
+
+    /**
+     *
+     */
 }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/ModDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/ModDslTest.kt
@@ -1,0 +1,74 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.expression
+
+import com.linecorp.kotlinjdsl.dsl.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.dsl.jpql.queryPart
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.path.Paths
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class ModDslTest : WithAssertions {
+    private val bigDecimal1 = BigDecimal.valueOf(100)
+
+    private val bigDecimalExpression1 = Expressions.value(bigDecimal1)
+
+    @Test
+    fun `mod() with a property and a bigDecimal`() {
+        // when
+        val expression1 = queryPart {
+            path(Book::price).mod(bigDecimal1)
+        }
+
+        val expression2 = queryPart {
+            mod(path(Book::price), bigDecimal1)
+        }
+
+        val actual1: Expression<BigDecimal> = expression1 // for type check
+        val actual2: Expression<BigDecimal> = expression2 // for type check
+
+        // then
+        val expected1 = Expressions.mod(
+            value1 = Paths.path(Book::price),
+            value2 = Expressions.value(bigDecimal1),
+        )
+
+        val expected2 = Expressions.mod(
+            value1 = Expressions.parentheses(Paths.path(Book::price)),
+            value2 = Expressions.parentheses(Expressions.value(bigDecimal1)),
+        )
+
+        assertThat(actual1).isEqualTo(expected1)
+        assertThat(actual2).isEqualTo(expected2)
+    }
+
+    @Test
+    fun `mod() with a property and a bigDecimal expression`() {
+        // when
+        val expression1 = queryPart {
+            path(Book::price).mod(bigDecimalExpression1)
+        }
+
+        val expression2 = queryPart {
+            mod(path(Book::price), bigDecimalExpression1)
+        }
+
+        val actual1: Expression<BigDecimal> = expression1 // for type check
+        val actual2: Expression<BigDecimal> = expression2 // for type check
+
+        // then
+        val expected1 = Expressions.mod(
+            value1 = Paths.path(Book::price),
+            value2 = bigDecimalExpression1,
+        )
+
+        val expected2 = Expressions.mod(
+            value1 = Expressions.parentheses(Paths.path(Book::price)),
+            value2 = Expressions.parentheses(bigDecimalExpression1),
+        )
+
+        assertThat(actual1).isEqualTo(expected1)
+        assertThat(actual2).isEqualTo(expected2)
+    }
+}

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
@@ -22,6 +22,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLower
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMax
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMin
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMinus
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlModulo
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlNew
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlNull
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlNullIf
@@ -204,6 +205,16 @@ object Expressions {
     @SinceJdsl("3.0.0")
     fun <T : Number, S : T> div(value1: Expression<T>, value2: Expression<S>): Expression<T> {
         return JpqlDivide(value1, value2)
+    }
+
+    /**
+     * Creates an expression that represents the modulo of values.
+     *
+     * This is the same as ```(value1) % (value2)```.
+     */
+    @SinceJdsl("3.0.0")
+    fun <T : Number, S : T> mod(value1: Expression<T>, value2: Expression<S>): Expression<T> {
+        return JpqlModulo(value1, value2)
     }
 
     /**

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlModulo.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlModulo.kt
@@ -1,0 +1,13 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+
+/**
+ * Expression that mods [value1] by [value2].
+ */
+@Internal
+data class JpqlModulo<T : Number> internal constructor(
+    val value1: Expression<*>,
+    val value2: Expression<*>,
+) : Expression<T>

--- a/query-model/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/ExpressionsTest.kt
+++ b/query-model/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/ExpressionsTest.kt
@@ -24,6 +24,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLower
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMax
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMin
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlMinus
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlModulo
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlNew
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlNull
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlNullIf
@@ -325,6 +326,20 @@ class ExpressionsTest : WithAssertions {
 
         // then
         val expected = JpqlDivide<Int>(
+            intExpression1,
+            intExpression2,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun mod() {
+        // when
+        val actual = Expressions.mod(intExpression1, intExpression2)
+
+        // then
+        val expected = JpqlModulo<Int>(
             intExpression1,
             intExpression2,
         )

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlModuloSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlModuloSerializer.kt
@@ -1,0 +1,28 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlModulo
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@Internal
+class JpqlModuloSerializer : JpqlSerializer<JpqlModulo<*>> {
+    override fun handledType(): KClass<JpqlModulo<*>> {
+        return JpqlModulo::class
+    }
+
+    override fun serialize(part: JpqlModulo<*>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        delegate.serialize(part.value1, writer, context)
+
+        writer.write(" ")
+        writer.write("%")
+        writer.write(" ")
+
+        delegate.serialize(part.value2, writer, context)
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlModuloSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlModuloSerializerTest.kt
@@ -1,0 +1,59 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlModulo
+import com.linecorp.kotlinjdsl.querymodel.jpql.path.Paths
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.impl.annotations.MockK
+import io.mockk.verifySequence
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+@JpqlSerializerTest
+class JpqlModuloSerializerTest : WithAssertions {
+    private val sut = JpqlModuloSerializer()
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    private val expression1 = Paths.path(Book::price)
+    private val expression2 = Paths.path(Book::salePrice)
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlModulo::class)
+    }
+
+    @Test
+    fun serialize() {
+        // given
+        val part = Expressions.mod(
+            expression1,
+            expression2,
+        )
+        val context = TestRenderContext(serializer)
+
+        // when
+        sut.serialize(part as JpqlModulo<*>, writer, context)
+
+        // then
+        verifySequence {
+            serializer.serialize(expression1, writer, context)
+            writer.write(" ")
+            writer.write("%")
+            writer.write(" ")
+            serializer.serialize(expression2, writer, context)
+        }
+    }
+}


### PR DESCRIPTION
# Motivation

- Missing arithmetic operator mod in JDSL.

# Modifications

- Add Jpql function, expression and serializer for mod operator.
- Add tests.
- Update documentation (English and Korean).

# Result

- The arithmetic operator mod is added.

# Closes

- #581 
