### PR TITLE
feat: support crud method metadata of spring

### DIFF
--- a/example/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/repository/book/BookRepository.kt
+++ b/example/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/repository/book/BookRepository.kt
@@ -1,21 +1,8 @@
 package com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.repository.book
 
-import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Book
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Isbn
-import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
-import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
-import jakarta.persistence.LockModeType
-import jakarta.persistence.QueryHint
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Lock
-import org.springframework.data.jpa.repository.QueryHints
 
-interface BookRepository : JpaRepository<Book, Isbn>, KotlinJdslJpqlExecutor {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints(QueryHint(name = "foo", value = "bar"))
-    override fun <T : Any> findAll(
-        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
-    ): List<T?>
-}
+interface BookRepository : JpaRepository<Book, Isbn>, KotlinJdslJpqlExecutor

--- a/example/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/repository/book/BookRepository.kt
+++ b/example/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/repository/book/BookRepository.kt
@@ -1,8 +1,21 @@
 package com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.repository.book
 
+import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Book
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.QueryHints
 
-interface BookRepository : JpaRepository<Book, Isbn>, KotlinJdslJpqlExecutor
+interface BookRepository : JpaRepository<Book, Isbn>, KotlinJdslJpqlExecutor {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(QueryHint(name = "foo", value = "bar"))
+    override fun <T : Any> findAll(
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?>
+}

--- a/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/JpqlEntityManagerUtils.kt
@@ -1,6 +1,6 @@
 package com.linecorp.kotlinjdsl.support.spring.batch.javax
 
-import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
@@ -12,13 +12,14 @@ import kotlin.reflect.KClass
 internal object JpqlEntityManagerUtils {
     fun <T : Any> createQuery(
         entityManager: EntityManager,
-        query: SelectQuery<T>,
+        query: JpqlQuery<*>,
         queryParams: Map<String, Any?>,
+        returnType: KClass<T>,
         context: RenderContext,
     ): TypedQuery<T> {
         val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
 
-        return createQuery(entityManager, rendered, query.returnType)
+        return createQuery(entityManager, rendered, returnType)
     }
 
     private fun <T : Any> createQuery(

--- a/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/item/database/orm/KotlinJdslQueryProvider.kt
+++ b/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/item/database/orm/KotlinJdslQueryProvider.kt
@@ -15,7 +15,7 @@ class KotlinJdslQueryProvider<T : Any>(
     private val context: RenderContext,
 ) : AbstractJpaQueryProvider() {
     override fun createQuery(): Query {
-        return JpqlEntityManagerUtils.createQuery(entityManager, query, queryParams, context)
+        return JpqlEntityManagerUtils.createQuery(entityManager, query, queryParams, query.returnType, context)
     }
 
     override fun afterPropertiesSet() {

--- a/support/spring-batch-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-batch-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/JpqlEntityManagerUtilsTest.kt
@@ -59,20 +59,18 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
         every { renderer.render(any(), any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
 
         // when
         val actual = JpqlEntityManagerUtils
-            .createQuery(entityManager, selectQuery1, mapOf(queryParam1, queryParam2), context)
+            .createQuery(entityManager, selectQuery1, mapOf(queryParam1, queryParam2), String::class, context)
 
         // then
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
             renderer.render(selectQuery1, mapOf(queryParam1, queryParam2), context)
-            selectQuery1.returnType
             entityManager.createQuery(rendered1.query, String::class.java)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)

--- a/support/spring-batch-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/item/database/orm/KotlinJdslQueryProviderTest.kt
+++ b/support/spring-batch-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/item/database/orm/KotlinJdslQueryProviderTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import javax.persistence.EntityManager
 import javax.persistence.TypedQuery
+import kotlin.reflect.KClass
 
 @ExtendWith(MockKExtension::class)
 class KotlinJdslQueryProviderTest : WithAssertions {
@@ -46,8 +47,9 @@ class KotlinJdslQueryProviderTest : WithAssertions {
     @Test
     fun createQuery() {
         // given
+        every { query1.returnType } returns String::class
         every {
-            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any(), any())
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any(), any<KClass<*>>(), any())
         } returns stringTypedQuery1
 
         // when
@@ -57,10 +59,12 @@ class KotlinJdslQueryProviderTest : WithAssertions {
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
+            query1.returnType
             JpqlEntityManagerUtils.createQuery(
                 entityManager = entityManager,
                 query = query1,
                 queryParams = queryParams1,
+                String::class,
                 context = context,
             )
         }

--- a/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtils.kt
+++ b/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtils.kt
@@ -1,6 +1,6 @@
 package com.linecorp.kotlinjdsl.support.spring.batch
 
-import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
@@ -12,13 +12,14 @@ import kotlin.reflect.KClass
 internal object JpqlEntityManagerUtils {
     fun <T : Any> createQuery(
         entityManager: EntityManager,
-        query: SelectQuery<T>,
+        query: JpqlQuery<*>,
         queryParams: Map<String, Any?>,
+        returnType: KClass<T>,
         context: RenderContext,
     ): TypedQuery<T> {
         val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
 
-        return createQuery(entityManager, rendered, query.returnType)
+        return createQuery(entityManager, rendered, returnType)
     }
 
     private fun <T : Any> createQuery(

--- a/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/item/database/orm/KotlinJdslQueryProvider.kt
+++ b/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/item/database/orm/KotlinJdslQueryProvider.kt
@@ -15,7 +15,7 @@ class KotlinJdslQueryProvider<T : Any>(
     private val context: RenderContext,
 ) : AbstractJpaQueryProvider() {
     override fun createQuery(): Query {
-        return JpqlEntityManagerUtils.createQuery(entityManager, query, queryParams, context)
+        return JpqlEntityManagerUtils.createQuery(entityManager, query, queryParams, query.returnType, context)
     }
 
     override fun afterPropertiesSet() {

--- a/support/spring-batch/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-batch/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtilsTest.kt
@@ -59,20 +59,18 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
         every { renderer.render(any(), any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
 
         // when
         val actual = JpqlEntityManagerUtils
-            .createQuery(entityManager, selectQuery1, mapOf(queryParam1, queryParam2), context)
+            .createQuery(entityManager, selectQuery1, mapOf(queryParam1, queryParam2), String::class, context)
 
         // then
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
             renderer.render(selectQuery1, mapOf(queryParam1, queryParam2), context)
-            selectQuery1.returnType
             entityManager.createQuery(rendered1.query, String::class.java)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)

--- a/support/spring-batch/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/item/database/orm/KotlinJdslQueryProviderTest.kt
+++ b/support/spring-batch/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/item/database/orm/KotlinJdslQueryProviderTest.kt
@@ -15,6 +15,7 @@ import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.reflect.KClass
 
 @ExtendWith(MockKExtension::class)
 class KotlinJdslQueryProviderTest : WithAssertions {
@@ -46,8 +47,9 @@ class KotlinJdslQueryProviderTest : WithAssertions {
     @Test
     fun createQuery() {
         // given
+        every { query1.returnType } returns String::class
         every {
-            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any(), any())
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any(), any<KClass<*>>(), any())
         } returns stringTypedQuery1
 
         // when
@@ -57,10 +59,12 @@ class KotlinJdslQueryProviderTest : WithAssertions {
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
+            query1.returnType
             JpqlEntityManagerUtils.createQuery(
                 entityManager = entityManager,
                 query = query1,
                 queryParams = queryParams1,
+                String::class,
                 context = context,
             )
         }

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/EnhancedTypedQuery.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/EnhancedTypedQuery.kt
@@ -1,0 +1,10 @@
+package com.linecorp.kotlinjdsl.support.spring.data.jpa.javax
+
+import javax.persistence.TypedQuery
+
+internal class EnhancedTypedQuery<T : Any>(
+    val sortedQuery: TypedQuery<T>,
+    countQuery: () -> TypedQuery<Long>,
+) {
+    val countQuery: TypedQuery<Long> by lazy(LazyThreadSafetyMode.NONE) { countQuery() }
+}

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -2,18 +2,10 @@
 
 package com.linecorp.kotlinjdsl.support.spring.data.jpa.javax
 
-import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
-import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
-import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
-import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
-import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
-import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.query.QueryEnhancerFactoryAdaptor
-import org.springframework.data.support.PageableExecutionUtilsAdaptor
 import javax.persistence.EntityManager
 import javax.persistence.Query
 import javax.persistence.TypedQuery
@@ -22,206 +14,89 @@ import kotlin.reflect.KClass
 internal object JpqlEntityManagerUtils {
     fun <T : Any> createQuery(
         entityManager: EntityManager,
-        query: SelectQuery<T>,
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
         context: RenderContext,
     ): TypedQuery<T> {
         val rendered = JpqlRendererHolder.get().render(query, context)
 
-        return createQuery(entityManager, rendered, query.returnType)
+        return createQuery(entityManager, rendered.query, rendered.params, returnType.java)
     }
 
     fun <T : Any> createQuery(
         entityManager: EntityManager,
-        query: SelectQuery<T>,
+        query: JpqlQuery<*>,
         queryParams: Map<String, Any?>,
+        returnType: KClass<T>,
         context: RenderContext,
     ): TypedQuery<T> {
         val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
 
-        return createQuery(entityManager, rendered, query.returnType)
+        return createQuery(entityManager, rendered.query, rendered.params, returnType.java)
     }
 
-    fun <T : Any> createQuery(
+    fun createQuery(
         entityManager: EntityManager,
-        query: UpdateQuery<T>,
+        query: JpqlQuery<*>,
         context: RenderContext,
     ): Query {
         val rendered = JpqlRendererHolder.get().render(query, context)
 
-        return createQuery(entityManager, rendered)
+        return createQuery(entityManager, rendered.query, rendered.params)
     }
 
-    fun <T : Any> createQuery(
+    fun createQuery(
         entityManager: EntityManager,
-        query: UpdateQuery<T>,
+        query: JpqlQuery<*>,
         queryParams: Map<String, Any?>,
         context: RenderContext,
     ): Query {
         val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
 
-        return createQuery(entityManager, rendered)
+        return createQuery(entityManager, rendered.query, rendered.params)
     }
 
-    fun <T : Any> createQuery(
+    fun <T : Any> createEnhancedQuery(
         entityManager: EntityManager,
-        query: DeleteQuery<T>,
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        sort: Sort,
         context: RenderContext,
-    ): Query {
+    ): EnhancedTypedQuery<T> {
         val rendered = JpqlRendererHolder.get().render(query, context)
 
-        return createQuery(entityManager, rendered)
-    }
+        val queryEnhancer = QueryEnhancerFactoryAdaptor.forQuery(rendered.query)
 
-    fun <T : Any> createQuery(
-        entityManager: EntityManager,
-        query: DeleteQuery<T>,
-        queryParams: Map<String, Any?>,
-        context: RenderContext,
-    ): Query {
-        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
-
-        return createQuery(entityManager, rendered)
+        return EnhancedTypedQuery(
+            createQuery(entityManager, queryEnhancer.applySorting(sort), rendered.params, returnType.java),
+        ) {
+            // Lazy
+            createQuery(entityManager, queryEnhancer.createCountQueryFor(), rendered.params, Long::class.javaObjectType)
+        }
     }
 
     private fun <T : Any> createQuery(
         entityManager: EntityManager,
-        rendered: JpqlRendered,
-        resultClass: KClass<T>,
+        query: String,
+        queryParams: Map<String, Any?>,
+        returnType: Class<T>,
     ): TypedQuery<T> {
-        return entityManager.createQuery(rendered.query, resultClass.java).apply {
-            setParams(this, rendered.params)
+        return entityManager.createQuery(query, returnType).apply {
+            setParams(this, queryParams)
         }
     }
 
     private fun createQuery(
         entityManager: EntityManager,
-        rendered: JpqlRendered,
+        query: String,
+        queryParams: Map<String, Any?>,
     ): Query {
-        return entityManager.createQuery(rendered.query).apply {
-            setParams(this, rendered.params)
+        return entityManager.createQuery(query).apply {
+            setParams(this, queryParams)
         }
     }
 
-    fun <T : Any> queryForList(
-        entityManager: EntityManager,
-        query: SelectQuery<T>,
-        pageable: Pageable,
-        context: RenderContext,
-    ): List<T?> {
-        val rendered = JpqlRendererHolder.get().render(query, context)
-
-        return queryForList(entityManager, rendered, pageable, query.returnType)
-    }
-
-    fun <T : Any> queryForPage(
-        entityManager: EntityManager,
-        query: SelectQuery<T>,
-        pageable: Pageable,
-        context: RenderContext,
-    ): Page<T?> {
-        val rendered = JpqlRendererHolder.get().render(query, context)
-
-        return queryForPage(entityManager, rendered, pageable, query.returnType)
-    }
-
-    fun <T : Any> queryForSlice(
-        entityManager: EntityManager,
-        query: SelectQuery<T>,
-        pageable: Pageable,
-        context: RenderContext,
-    ): Slice<T?> {
-        val rendered = JpqlRendererHolder.get().render(query, context)
-
-        return queryForSlice(entityManager, rendered, pageable, query.returnType)
-    }
-
-    private fun <T : Any> queryForList(
-        entityManager: EntityManager,
-        rendered: JpqlRendered,
-        pageable: Pageable,
-        resultClass: KClass<T>,
-    ): List<T?> {
-        val queryEnhancer = QueryEnhancerFactoryAdaptor.forQuery(rendered.query)
-
-        val sortedQuery = queryEnhancer.applySorting(pageable.sort)
-
-        val jpaQuery = entityManager.createQuery(sortedQuery, resultClass.java).apply {
-            setParams(this, rendered.params)
-        }
-
-        if (pageable.isPaged) {
-            jpaQuery.firstResult = pageable.offset.toInt()
-            jpaQuery.maxResults = pageable.pageSize
-        }
-
-        return jpaQuery.resultList
-    }
-
-    private fun <T : Any> queryForPage(
-        entityManager: EntityManager,
-        rendered: JpqlRendered,
-        pageable: Pageable,
-        resultClass: KClass<T>,
-    ): Page<T?> {
-        val queryEnhancer = QueryEnhancerFactoryAdaptor.forQuery(rendered.query)
-
-        val sortedQuery = queryEnhancer.applySorting(pageable.sort)
-        val countQuery = queryEnhancer.createCountQueryFor()
-
-        val sortedJpaQuery = entityManager.createQuery(sortedQuery, resultClass.java).apply {
-            setParams(this, rendered.params)
-
-            if (pageable.isPaged) {
-                firstResult = pageable.offset.toInt()
-                maxResults = pageable.pageSize
-            }
-        }
-
-        val countJpaQuery = entityManager.createQuery(countQuery, Long::class.javaObjectType).apply {
-            setParams(this, rendered.params)
-        }
-
-        return PageableExecutionUtilsAdaptor.getPage(sortedJpaQuery.resultList, pageable) {
-            val counts = countJpaQuery.resultList
-
-            if (counts.size == 1) {
-                counts.first()
-            } else {
-                counts.count().toLong()
-            }
-        }
-    }
-
-    private fun <T : Any> queryForSlice(
-        entityManager: EntityManager,
-        rendered: JpqlRendered,
-        pageable: Pageable,
-        resultClass: KClass<T>,
-    ): Slice<T?> {
-        val queryEnhancer = QueryEnhancerFactoryAdaptor.forQuery(rendered.query)
-
-        val sortedQuery = queryEnhancer.applySorting(pageable.sort)
-
-        val jpaQuery = entityManager.createQuery(sortedQuery, resultClass.java).apply {
-            setParams(this, rendered.params)
-        }
-
-        return if (pageable.isPaged) {
-            jpaQuery.firstResult = pageable.offset.toInt()
-            jpaQuery.maxResults = pageable.pageSize + 1
-
-            val results = jpaQuery.resultList
-            val hasNext = results.size > pageable.pageSize
-
-            SliceImpl(takeIf { hasNext }?.let { results.dropLast(1) } ?: results, pageable, hasNext)
-        } else {
-            val results = jpaQuery.resultList
-
-            SliceImpl(results, pageable, false)
-        }
-    }
-
-    private fun setParams(query: Query, params: JpqlRenderedParams) {
+    private fun setParams(query: Query, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
             query.setParameter(name, value)
         }

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/autoconfigure/KotlinJdslAutoConfiguration.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/autoconfigure/KotlinJdslAutoConfiguration.kt
@@ -13,6 +13,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
+import org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessorAdaptor
 import javax.persistence.EntityManager
 
 @AutoConfiguration
@@ -48,10 +49,12 @@ open class KotlinJdslAutoConfiguration {
         renderContexts: List<RenderContext>,
     ): KotlinJdslJpqlExecutor {
         val renderContext = renderContexts.reversed().reduce { acc, renderContext -> acc + renderContext }
+        val metadata = CrudMethodMetadataPostProcessorAdaptor().getCrudMethodMetadata()
 
         return KotlinJdslJpqlExecutorImpl(
             entityManager = entityManager,
             renderContext = renderContext,
+            metadata = metadata,
         )
     }
 }

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/extension/EntityManagerExtensions.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/extension/EntityManagerExtensions.kt
@@ -17,7 +17,7 @@ import javax.persistence.TypedQuery
 fun <T : Any> EntityManager.createQuery(
     query: SelectQuery<T>,
     context: RenderContext,
-): TypedQuery<T> = JpqlEntityManagerUtils.createQuery(this, query, context)
+): TypedQuery<T> = JpqlEntityManagerUtils.createQuery(this, query, query.returnType, context)
 
 /**
  * Creates a [javax.persistence.TypedQuery] from the [SelectQuery] and [RenderContext].
@@ -27,7 +27,7 @@ fun <T : Any> EntityManager.createQuery(
     query: SelectQuery<T>,
     queryParams: Map<String, Any?>,
     context: RenderContext,
-): TypedQuery<T> = JpqlEntityManagerUtils.createQuery(this, query, queryParams, context)
+): Query = JpqlEntityManagerUtils.createQuery(this, query, queryParams, query.returnType, context)
 
 /**
  * Creates a [javax.persistence.Query] from the [UpdateQuery] and [RenderContext].

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -4,18 +4,29 @@ import com.linecorp.kotlinjdsl.SinceJdsl
 import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
 import com.linecorp.kotlinjdsl.dsl.jpql.JpqlDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
 import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
 import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.javax.EnhancedTypedQuery
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.javax.JpqlEntityManagerUtils
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.repository.support.CrudMethodMetadata
+import org.springframework.data.jpa.repository.support.QueryHints
 import org.springframework.data.repository.NoRepositoryBean
+import org.springframework.data.support.PageableExecutionUtilsAdaptor
 import org.springframework.transaction.annotation.Transactional
 import javax.persistence.EntityManager
+import javax.persistence.LockModeType
+import javax.persistence.Query
+import javax.persistence.TypedQuery
+import kotlin.reflect.KClass
 
 @Transactional
 @NoRepositoryBean
@@ -23,6 +34,7 @@ import javax.persistence.EntityManager
 open class KotlinJdslJpqlExecutorImpl(
     private val entityManager: EntityManager,
     private val renderContext: RenderContext,
+    private val metadata: CrudMethodMetadata?,
 ) : KotlinJdslJpqlExecutor {
     override fun <T : Any> findAll(
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
@@ -35,14 +47,17 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query, query.returnType)
 
         return jpaQuery.resultList
     }
 
-    override fun <T : Any, DSL : JpqlDsl> findAll(dsl: DSL, init: DSL.() -> JpqlQueryable<SelectQuery<T>>): List<T?> {
+    override fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query, query.returnType)
 
         return jpaQuery.resultList
     }
@@ -61,7 +76,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForList(entityManager, query, pageable, renderContext)
+        return createList(query, query.returnType, pageable)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findAll(
@@ -71,7 +86,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForList(entityManager, query, pageable, renderContext)
+        return createList(query, query.returnType, pageable)
     }
 
     override fun <T : Any> findPage(
@@ -88,7 +103,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): Page<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForPage(entityManager, query, pageable, renderContext)
+        return createPage(query, query.returnType, pageable)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findPage(
@@ -98,7 +113,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): Page<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForPage(entityManager, query, pageable, renderContext)
+        return createPage(query, query.returnType, pageable)
     }
 
     override fun <T : Any> findSlice(
@@ -115,7 +130,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): Slice<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForSlice(entityManager, query, pageable, renderContext)
+        return createSlice(query, query.returnType, pageable)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findSlice(
@@ -125,8 +140,9 @@ open class KotlinJdslJpqlExecutorImpl(
     ): Slice<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForSlice(entityManager, query, pageable, renderContext)
+        return createSlice(query, query.returnType, pageable)
     }
+
     override fun <T : Any> update(
         init: Jpql.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
@@ -138,7 +154,7 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
         val query: UpdateQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query)
 
         return jpaQuery.executeUpdate()
     }
@@ -148,7 +164,7 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
         val query: UpdateQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query)
 
         return jpaQuery.executeUpdate()
     }
@@ -164,7 +180,7 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
         val query: DeleteQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query)
 
         return jpaQuery.executeUpdate()
     }
@@ -174,8 +190,137 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
         val query: DeleteQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query)
 
         return jpaQuery.executeUpdate()
+    }
+
+    private fun <T : Any> createJpaQuery(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+    ): TypedQuery<T> {
+        return JpqlEntityManagerUtils.createQuery(entityManager, query, returnType, renderContext).apply {
+            setMetadata(this, metadata)
+        }
+    }
+
+    private fun createJpaQuery(
+        query: JpqlQuery<*>,
+    ): Query {
+        return JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext).apply {
+            setMetadata(this, metadata)
+        }
+    }
+
+    private fun <T : Any> createJpaEnhancedQuery(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        sort: Sort,
+    ): EnhancedTypedQuery<T> {
+        val enhancedQuery = JpqlEntityManagerUtils.createEnhancedQuery(
+            entityManager,
+            query,
+            returnType,
+            sort,
+            renderContext,
+        )
+
+        return EnhancedTypedQuery(
+            enhancedQuery.sortedQuery.apply { setMetadata(this, metadata) },
+        ) {
+            // Lazy
+            enhancedQuery.countQuery.apply { setMetadataForCount(this, metadata) }
+        }
+    }
+
+    private fun setMetadata(query: Query, metadata: CrudMethodMetadata?) {
+        if (metadata == null) return
+
+        setLockMode(query, metadata.lockModeType)
+        setQueryHints(query, metadata.queryHints)
+    }
+
+    private fun setMetadataForCount(query: Query, metadata: CrudMethodMetadata?) {
+        if (metadata == null) return
+
+        setQueryHints(query, metadata.queryHintsForCount)
+    }
+
+    private fun setLockMode(query: Query, lockMode: LockModeType?) {
+        if (lockMode != null) {
+            query.lockMode = lockMode
+        }
+    }
+
+    private fun setQueryHints(query: Query, hints: QueryHints?) {
+        hints?.forEach { name, value ->
+            query.setHint(name, value)
+        }
+    }
+
+    private fun <T : Any> createList(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        pageable: Pageable,
+    ): List<T?> {
+        val enhancedQuery = createJpaEnhancedQuery(query, returnType, pageable.sort)
+
+        val sortedQuery = enhancedQuery.sortedQuery
+
+        if (pageable.isPaged) {
+            sortedQuery.firstResult = pageable.offset.toInt()
+            sortedQuery.maxResults = pageable.pageSize
+        }
+
+        return sortedQuery.resultList
+    }
+
+    private fun <T : Any> createPage(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        pageable: Pageable,
+    ): Page<T?> {
+        val enhancedQuery = createJpaEnhancedQuery(query, returnType, pageable.sort)
+
+        val sortedQuery = enhancedQuery.sortedQuery
+
+        if (pageable.isPaged) {
+            sortedQuery.firstResult = pageable.offset.toInt()
+            sortedQuery.maxResults = pageable.pageSize
+        }
+
+        return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
+            val counts = enhancedQuery.countQuery.resultList
+
+            if (counts.size == 1) {
+                counts.first()
+            } else {
+                counts.count().toLong()
+            }
+        }
+    }
+
+    private fun <T : Any> createSlice(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        pageable: Pageable,
+    ): Slice<T?> {
+        val enhancedQuery = createJpaEnhancedQuery(query, returnType, pageable.sort)
+
+        val sortedQuery = enhancedQuery.sortedQuery
+
+        return if (pageable.isPaged) {
+            sortedQuery.firstResult = pageable.offset.toInt()
+            sortedQuery.maxResults = pageable.pageSize + 1
+
+            val results = sortedQuery.resultList
+            val hasNext = results.size > pageable.pageSize
+
+            SliceImpl(takeIf { hasNext }?.let { results.dropLast(1) } ?: results, pageable, hasNext)
+        } else {
+            val results = sortedQuery.resultList
+
+            SliceImpl(results, pageable, false)
+        }
     }
 }

--- a/support/spring-data-jpa-javax/src/main/kotlin/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessorAdaptor.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessorAdaptor.kt
@@ -1,0 +1,9 @@
+package org.springframework.data.jpa.repository.support
+
+internal class CrudMethodMetadataPostProcessorAdaptor {
+    private val delegate = CrudMethodMetadataPostProcessor()
+
+    fun getCrudMethodMetadata(): CrudMethodMetadata? {
+        return delegate.crudMethodMetadata
+    }
+}

--- a/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtilsTest.kt
@@ -1,8 +1,6 @@
 package com.linecorp.kotlinjdsl.support.spring.data.jpa.javax
 
-import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
-import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
-import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
@@ -17,13 +15,9 @@ import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.query.QueryEnhancer
 import org.springframework.data.jpa.repository.query.QueryEnhancerFactoryAdaptor
-import org.springframework.data.support.PageableExecutionUtilsAdaptor
-import java.util.function.LongSupplier
 import javax.persistence.EntityManager
 import javax.persistence.TypedQuery
 
@@ -42,13 +36,7 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     private lateinit var queryEnhancer: QueryEnhancer
 
     @MockK
-    private lateinit var selectQuery1: SelectQuery<String>
-
-    @MockK
-    private lateinit var updateQuery1: UpdateQuery<String>
-
-    @MockK
-    private lateinit var deleteQuery1: DeleteQuery<String>
+    private lateinit var query1: JpqlQuery<*>
 
     @MockK
     private lateinit var stringTypedQuery1: TypedQuery<String>
@@ -56,8 +44,7 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     @MockK
     private lateinit var longTypedQuery1: TypedQuery<Long>
 
-    @MockK
-    private lateinit var page1: Page<String>
+    private val sort1 = Sort.by("property1")
 
     private val renderedQuery1 = "query"
     private val renderedParam1 = "queryParam1" to "queryParamValue1"
@@ -74,33 +61,31 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     fun setUp() {
         mockkObject(JpqlRendererHolder)
         mockkObject(QueryEnhancerFactoryAdaptor)
-        mockkObject(PageableExecutionUtilsAdaptor)
 
         every { JpqlRendererHolder.get() } returns renderer
 
         excludeRecords { JpqlRendererHolder.get() }
         excludeRecords { stringTypedQuery1.equals(any()) }
+        excludeRecords { longTypedQuery1.equals(any()) }
     }
 
     @Test
-    fun `createQuery() with a select query`() {
+    fun `createQuery() with a query and a return type`() {
         // given
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
         every { renderer.render(any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
 
         // when
-        val actual = JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, context)
+        val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, String::class, context)
 
         // then
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
-            renderer.render(selectQuery1, context)
-            selectQuery1.returnType
+            renderer.render(query1, context)
             entityManager.createQuery(rendered1.query, String::class.java)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
@@ -108,25 +93,23 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
-    fun `createQuery() with a select query and query params`() {
+    fun `createQuery() with a query and query params and a return type`() {
         // given
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
         every { renderer.render(any(), any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
 
         // when
-        val actual =
-            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, mapOf(queryParam1, queryParam2), context)
+        val actual = JpqlEntityManagerUtils
+            .createQuery(entityManager, query1, mapOf(queryParam1, queryParam2), String::class, context)
 
         // then
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
-            renderer.render(selectQuery1, mapOf(queryParam1, queryParam2), context)
-            selectQuery1.returnType
+            renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query, String::class.java)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
@@ -134,7 +117,7 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
-    fun `createQuery() with an update query`() {
+    fun `createQuery() with a query`() {
         // given
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
@@ -143,13 +126,13 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
 
         // when
-        val actual = JpqlEntityManagerUtils.createQuery(entityManager, updateQuery1, context)
+        val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, context)
 
         // then
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
-            renderer.render(updateQuery1, context)
+            renderer.render(query1, context)
             entityManager.createQuery(rendered1.query)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
@@ -157,7 +140,7 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
-    fun `createQuery() with an update query and query params`() {
+    fun `createQuery() with a query and query params`() {
         // given
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
@@ -166,14 +149,14 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
 
         // when
-        val actual =
-            JpqlEntityManagerUtils.createQuery(entityManager, updateQuery1, mapOf(queryParam1, queryParam2), context)
+        val actual = JpqlEntityManagerUtils
+            .createQuery(entityManager, query1, mapOf(queryParam1, queryParam2), context)
 
         // then
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
-            renderer.render(updateQuery1, mapOf(queryParam1, queryParam2), context)
+            renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
@@ -181,104 +164,11 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
-    fun `createQuery() with a delete query`() {
+    fun createEnhancedQuery() {
         // given
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
         every { renderer.render(any(), any()) } returns rendered1
-        every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
-
-        // when
-        val actual = JpqlEntityManagerUtils.createQuery(entityManager, deleteQuery1, context)
-
-        // then
-        assertThat(actual).isEqualTo(stringTypedQuery1)
-
-        verifySequence {
-            renderer.render(deleteQuery1, context)
-            entityManager.createQuery(rendered1.query)
-            stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
-            stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-        }
-    }
-
-    @Test
-    fun `createQuery() with a delete query and query params`() {
-        // given
-        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
-
-        every { renderer.render(any(), any(), any()) } returns rendered1
-        every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
-
-        // when
-        val actual =
-            JpqlEntityManagerUtils.createQuery(entityManager, deleteQuery1, mapOf(queryParam1, queryParam2), context)
-
-        // then
-        assertThat(actual).isEqualTo(stringTypedQuery1)
-
-        verifySequence {
-            renderer.render(deleteQuery1, mapOf(queryParam1, queryParam2), context)
-            entityManager.createQuery(rendered1.query)
-            stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
-            stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-        }
-    }
-
-    @Test
-    fun queryForList() {
-        // given
-        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
-
-        val pageable1 = PageRequest.of(1, 10)
-        val list1 = listOf("1", "2", "3")
-
-        every { renderer.render(any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
-        every { QueryEnhancerFactoryAdaptor.forQuery(any()) } returns queryEnhancer
-        every { queryEnhancer.applySorting(any()) } returns sortedQuery1
-        every { entityManager.createQuery(any<String>(), any<Class<*>>()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.resultList } returns list1
-
-        // when
-        val actual = JpqlEntityManagerUtils.queryForList(entityManager, selectQuery1, pageable1, context)
-
-        // then
-        assertThat(actual).isEqualTo(list1)
-
-        verifySequence {
-            renderer.render(selectQuery1, context)
-            selectQuery1.returnType
-
-            QueryEnhancerFactoryAdaptor.forQuery(rendered1.query)
-            queryEnhancer.applySorting(pageable1.sort)
-
-            entityManager.createQuery(sortedQuery1, String::class.java)
-            stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
-            stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-            stringTypedQuery1.firstResult = pageable1.offset.toInt()
-            stringTypedQuery1.maxResults = pageable1.pageSize
-
-            stringTypedQuery1.resultList
-        }
-    }
-
-    @Test
-    fun queryForPage() {
-        // given
-        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
-
-        val pageable1 = PageRequest.of(1, 10)
-        val list1 = listOf("1", "2", "3")
-        val counts1 = listOf(1L, 1L, 1L)
-
-        every { renderer.render(any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
         every { QueryEnhancerFactoryAdaptor.forQuery(any()) } returns queryEnhancer
         every { queryEnhancer.applySorting(any()) } returns sortedQuery1
         every { queryEnhancer.createCountQueryFor() } returns countQuery1
@@ -286,85 +176,30 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
             entityManager.createQuery(any<String>(), any<Class<*>>())
         } returns stringTypedQuery1 andThen longTypedQuery1
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.resultList } returns list1
         every { longTypedQuery1.setParameter(any<String>(), any()) } returns longTypedQuery1
-        every { longTypedQuery1.resultList } returns counts1
-        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
-            lastArg<LongSupplier>().asLong
-
-            page1
-        }
 
         // when
-        val actual = JpqlEntityManagerUtils.queryForPage(entityManager, selectQuery1, pageable1, context)
+        val actual = JpqlEntityManagerUtils
+            .createEnhancedQuery(entityManager, query1, String::class, sort1, context)
 
         // then
-        assertThat(actual).isEqualTo(page1)
+        assertThat(actual.sortedQuery).isEqualTo(stringTypedQuery1)
+        assertThat(actual.countQuery).isEqualTo(longTypedQuery1)
 
         verifySequence {
-            renderer.render(selectQuery1, context)
-            selectQuery1.returnType
+            renderer.render(query1, context)
 
             QueryEnhancerFactoryAdaptor.forQuery(rendered1.query)
-            queryEnhancer.applySorting(pageable1.sort)
-            queryEnhancer.createCountQueryFor()
 
+            queryEnhancer.applySorting(sort1)
             entityManager.createQuery(sortedQuery1, String::class.java)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-            stringTypedQuery1.firstResult = pageable1.offset.toInt()
-            stringTypedQuery1.maxResults = pageable1.pageSize
 
+            queryEnhancer.createCountQueryFor()
             entityManager.createQuery(countQuery1, Long::class.javaObjectType)
             longTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             longTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-
-            stringTypedQuery1.resultList
-            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
-            longTypedQuery1.resultList
-        }
-    }
-
-    @Test
-    fun queryForSlice() {
-        // given
-        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
-
-        val pageable1 = PageRequest.of(1, 3)
-        val list1 = listOf("1", "2", "3", "4")
-
-        every { renderer.render(any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
-        every { QueryEnhancerFactoryAdaptor.forQuery(any()) } returns queryEnhancer
-        every { queryEnhancer.applySorting(any()) } returns sortedQuery1
-        every { entityManager.createQuery(any<String>(), any<Class<*>>()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.resultList } returns list1
-
-        // when
-        val actual = JpqlEntityManagerUtils.queryForSlice(entityManager, selectQuery1, pageable1, context)
-
-        // then
-        assertThat(actual).isEqualTo(SliceImpl(list1.dropLast(1), pageable1, true))
-
-        verifySequence {
-            renderer.render(selectQuery1, context)
-            selectQuery1.returnType
-
-            QueryEnhancerFactoryAdaptor.forQuery(rendered1.query)
-            queryEnhancer.applySorting(pageable1.sort)
-
-            entityManager.createQuery(sortedQuery1, String::class.java)
-            stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
-            stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-            stringTypedQuery1.firstResult = pageable1.offset.toInt()
-            stringTypedQuery1.maxResults = pageable1.pageSize + 1
-
-            stringTypedQuery1.resultList
         }
     }
 }

--- a/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/extension/EntityManagerExtensionsTest.kt
+++ b/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/extension/EntityManagerExtensionsTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import javax.persistence.EntityManager
 import javax.persistence.Query
 import javax.persistence.TypedQuery
+import kotlin.reflect.KClass
 
 @ExtendWith(MockKExtension::class)
 class EntityManagerExtensionsTest : WithAssertions {
@@ -53,8 +54,9 @@ class EntityManagerExtensionsTest : WithAssertions {
     fun `createQuery() with a select query`() {
         // given
         every {
-            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any())
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
         } returns typedQuery1
+        every { selectQuery1.returnType } returns String::class
 
         // when
         val actual = entityManager.createQuery(selectQuery1, context)
@@ -63,7 +65,8 @@ class EntityManagerExtensionsTest : WithAssertions {
         assertThat(actual).isEqualTo(typedQuery1)
 
         verifySequence {
-            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, context)
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, String::class, context)
         }
     }
 
@@ -71,8 +74,9 @@ class EntityManagerExtensionsTest : WithAssertions {
     fun `createQuery() with a select query and query params`() {
         // given
         every {
-            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any(), any())
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any(), any<KClass<*>>(), any())
         } returns typedQuery1
+        every { selectQuery1.returnType } returns String::class
 
         // when
         val actual = entityManager.createQuery(selectQuery1, queryParams1, context)
@@ -81,7 +85,8 @@ class EntityManagerExtensionsTest : WithAssertions {
         assertThat(actual).isEqualTo(typedQuery1)
 
         verifySequence {
-            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, queryParams1, context)
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, queryParams1, String::class, context)
         }
     }
 

--- a/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImplTest.kt
+++ b/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImplTest.kt
@@ -7,13 +7,13 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
 import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.javax.EnhancedTypedQuery
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.javax.JpqlEntityManagerUtils
 import io.mockk.every
 import io.mockk.excludeRecords
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.verifySequence
 import org.assertj.core.api.WithAssertions
@@ -22,10 +22,18 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.repository.support.CrudMethodMetadata
+import org.springframework.data.jpa.repository.support.QueryHints
+import org.springframework.data.support.PageableExecutionUtilsAdaptor
+import java.util.function.BiConsumer
+import java.util.function.LongSupplier
 import javax.persistence.EntityManager
+import javax.persistence.LockModeType
 import javax.persistence.Query
 import javax.persistence.TypedQuery
+import kotlin.reflect.KClass
 
 @ExtendWith(MockKExtension::class)
 class KotlinJdslJpqlExecutorImplTest : WithAssertions {
@@ -37,6 +45,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
 
     @MockK
     private lateinit var renderContext: RenderContext
+
+    @MockK
+    private lateinit var metadata: CrudMethodMetadata
 
     @MockK
     private lateinit var createSelectQuery1: Jpql.() -> JpqlQueryable<SelectQuery<String>>
@@ -93,16 +104,90 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     private lateinit var deleteQuery3: DeleteQuery<String>
 
     @MockK
-    private lateinit var typedQuery1: TypedQuery<String>
+    private lateinit var stringTypedQuery1: TypedQuery<String>
 
     @MockK
-    private lateinit var typedQuery2: TypedQuery<String>
+    private lateinit var stringTypedQuery2: TypedQuery<String>
 
     @MockK
-    private lateinit var typedQuery3: TypedQuery<String>
+    private lateinit var stringTypedQuery3: TypedQuery<String>
+
+    @MockK
+    private lateinit var longTypedQuery1: TypedQuery<Long>
+
+    @MockK
+    private lateinit var longTypedQuery2: TypedQuery<Long>
+
+    @MockK
+    private lateinit var longTypedQuery3: TypedQuery<Long>
 
     @MockK
     private lateinit var query1: Query
+
+    @MockK
+    private lateinit var query2: Query
+
+    @MockK
+    private lateinit var query3: Query
+
+    @MockK
+    private lateinit var page1: Page<String>
+
+    private val lockModeType1 = LockModeType.READ
+
+    private val queryHint1 = "queryHintName1" to "queryHintValue1"
+    private val queryHint2 = "queryHintName2" to "queryHintValue2"
+    private val queryHint3 = "queryHintName3" to "queryHintValue3"
+
+    private val queryHints1 = object : QueryHints {
+        override fun withFetchGraphs(em: EntityManager): QueryHints = throw UnsupportedOperationException()
+        override fun forCounts(): QueryHints = throw UnsupportedOperationException()
+
+        override fun forEach(action: BiConsumer<String, Any>) {
+            listOf(
+                queryHint1,
+                queryHint2,
+                queryHint3,
+            ).forEach { (name, value) ->
+                action.accept(name, value)
+            }
+        }
+    }
+
+    private val queryHintForCount1 = "queryHintForCountName1" to "queryHintForCountValue1"
+    private val queryHintForCount2 = "queryHintForCountName2" to "queryHintForCountValue2"
+    private val queryHintForCount3 = "queryHintForCountName3" to "queryHintForCountValue3"
+
+    private val queryHintsForCount1 = object : QueryHints {
+        override fun withFetchGraphs(em: EntityManager): QueryHints = throw UnsupportedOperationException()
+        override fun forCounts(): QueryHints = throw UnsupportedOperationException()
+
+        override fun forEach(action: BiConsumer<String, Any>) {
+            listOf(
+                queryHintForCount1,
+                queryHintForCount2,
+                queryHintForCount3,
+            ).forEach { (name, value) ->
+                action.accept(name, value)
+            }
+        }
+    }
+
+    private val sort1 = Sort.by("property1")
+    private val pageable1 = PageRequest.of(1, 10, sort1)
+
+    private val list1 = listOf("1", "2", "3")
+    private val counts1 = listOf(1L, 1L, 1L)
+
+    private val enhancedTypedQuery1: EnhancedTypedQuery<String> by lazy(LazyThreadSafetyMode.NONE) {
+        EnhancedTypedQuery(stringTypedQuery1) { longTypedQuery1 }
+    }
+    private val enhancedTypedQuery2: EnhancedTypedQuery<String> by lazy(LazyThreadSafetyMode.NONE) {
+        EnhancedTypedQuery(stringTypedQuery2) { longTypedQuery2 }
+    }
+    private val enhancedTypedQuery3: EnhancedTypedQuery<String> by lazy(LazyThreadSafetyMode.NONE) {
+        EnhancedTypedQuery(stringTypedQuery3) { longTypedQuery3 }
+    }
 
     private class MyJpql : Jpql() {
         companion object Constructor : JpqlDsl.Constructor<MyJpql> {
@@ -133,6 +218,7 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     @BeforeEach
     fun setUp() {
         mockkObject(JpqlEntityManagerUtils)
+        mockkObject(PageableExecutionUtilsAdaptor)
 
         every { createSelectQuery1.invoke(any()) } returns selectQuery1
         every { createSelectQuery2.invoke(any()) } returns selectQuery2
@@ -176,10 +262,15 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     @Test
     fun findAll() {
         // given
-        val list1 = listOf("1", "2", "3")
-
-        every { JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any()) } returns typedQuery1
-        every { typedQuery1.resultList } returns list1
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
+        } returns stringTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultList } returns list1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.findAll(createSelectQuery1)
@@ -188,18 +279,30 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         assertThat(actual).isEqualTo(list1)
 
         verifySequence {
-            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, renderContext)
-            typedQuery1.resultList
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, String::class, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.resultList
         }
     }
 
     @Test
     fun `findAll() with a dsl`() {
         // given
-        val list1 = listOf("1", "2", "3")
-
-        every { JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any()) } returns typedQuery2
-        every { typedQuery2.resultList } returns list1
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
+        } returns stringTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultList } returns list1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.findAll(MyJpql, createSelectQuery2)
@@ -208,18 +311,30 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         assertThat(actual).isEqualTo(list1)
 
         verifySequence {
-            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery2, renderContext)
-            typedQuery2.resultList
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery2, String::class, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.resultList
         }
     }
 
     @Test
     fun `findAll() with a dsl object`() {
         // given
-        val list1 = listOf("1", "2", "3")
-
-        every { JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any()) } returns typedQuery3
-        every { typedQuery3.resultList } returns list1
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
+        } returns stringTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultList } returns list1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.findAll(MyJpqlObject, createSelectQuery3)
@@ -228,18 +343,34 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         assertThat(actual).isEqualTo(list1)
 
         verifySequence {
-            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery3, renderContext)
-            typedQuery3.resultList
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery3, String::class, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.resultList
         }
     }
 
     @Test
     fun `findAll() with a pageable`() {
         // given
-        val pageable1 = PageRequest.of(0, 10)
-        val list1 = listOf("1", "2", "3")
-
-        every { JpqlEntityManagerUtils.queryForList(any(), any<SelectQuery<String>>(), any(), any()) } returns list1
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultList } returns list1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.findAll(pageable1, createSelectQuery1)
@@ -248,17 +379,36 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         assertThat(actual).isEqualTo(list1)
 
         verifySequence {
-            JpqlEntityManagerUtils.queryForList(entityManager, selectQuery1, pageable1, renderContext)
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery1, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.firstResult = pageable1.offset.toInt()
+            stringTypedQuery1.maxResults = pageable1.pageSize
+            stringTypedQuery1.resultList
         }
     }
 
     @Test
     fun `findAll() with a dsl and a pageable`() {
         // given
-        val pageable1 = PageRequest.of(0, 10)
-        val list1 = listOf("1", "2", "3")
-
-        every { JpqlEntityManagerUtils.queryForList(any(), any<SelectQuery<String>>(), any(), any()) } returns list1
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultList } returns list1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.findAll(MyJpql, pageable1, createSelectQuery2)
@@ -267,17 +417,36 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         assertThat(actual).isEqualTo(list1)
 
         verifySequence {
-            JpqlEntityManagerUtils.queryForList(entityManager, selectQuery2, pageable1, renderContext)
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery2, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.firstResult = pageable1.offset.toInt()
+            stringTypedQuery2.maxResults = pageable1.pageSize
+            stringTypedQuery2.resultList
         }
     }
 
     @Test
     fun `findAll() with a dsl object and a pageable`() {
         // given
-        val pageable1 = PageRequest.of(0, 10)
-        val list1 = listOf("1", "2", "3")
-
-        every { JpqlEntityManagerUtils.queryForList(any(), any<SelectQuery<String>>(), any(), any()) } returns list1
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultList } returns list1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.findAll(MyJpqlObject, pageable1, createSelectQuery3)
@@ -286,17 +455,45 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         assertThat(actual).isEqualTo(list1)
 
         verifySequence {
-            JpqlEntityManagerUtils.queryForList(entityManager, selectQuery3, pageable1, renderContext)
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery3, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.firstResult = pageable1.offset.toInt()
+            stringTypedQuery3.maxResults = pageable1.pageSize
+            stringTypedQuery3.resultList
         }
     }
 
     @Test
     fun findPage() {
         // given
-        val pageable1 = PageRequest.of(0, 10)
-        val page1: Page<String?> = mockk()
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultList } returns list1
+        every { longTypedQuery1.setHint(any(), any()) } returns longTypedQuery1
+        every { longTypedQuery1.setFirstResult(any()) } returns longTypedQuery1
+        every { longTypedQuery1.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
 
-        every { JpqlEntityManagerUtils.queryForPage(any(), any<SelectQuery<String>>(), any(), any()) } returns page1
+            page1
+        }
 
         // when
         val actual = sut.findPage(pageable1, createSelectQuery1)
@@ -305,17 +502,51 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         assertThat(actual).isEqualTo(page1)
 
         verifySequence {
-            JpqlEntityManagerUtils.queryForPage(entityManager, selectQuery1, pageable1, renderContext)
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery1, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.firstResult = pageable1.offset.toInt()
+            stringTypedQuery1.maxResults = pageable1.pageSize
+            stringTypedQuery1.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
+            metadata.queryHintsForCount
+            longTypedQuery1.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery1.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery1.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            longTypedQuery1.resultList
         }
     }
 
     @Test
     fun `findPage() with a dsl`() {
         // given
-        val pageable1 = PageRequest.of(0, 10)
-        val page1: Page<String?> = mockk()
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultList } returns list1
+        every { longTypedQuery2.setHint(any(), any()) } returns longTypedQuery2
+        every { longTypedQuery2.setFirstResult(any()) } returns longTypedQuery2
+        every { longTypedQuery2.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
 
-        every { JpqlEntityManagerUtils.queryForPage(any(), any<SelectQuery<String>>(), any(), any()) } returns page1
+            page1
+        }
 
         // when
         val actual = sut.findPage(MyJpql, pageable1, createSelectQuery2)
@@ -324,17 +555,51 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         assertThat(actual).isEqualTo(page1)
 
         verifySequence {
-            JpqlEntityManagerUtils.queryForPage(entityManager, selectQuery2, pageable1, renderContext)
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery2, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.firstResult = pageable1.offset.toInt()
+            stringTypedQuery2.maxResults = pageable1.pageSize
+            stringTypedQuery2.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
+            metadata.queryHintsForCount
+            longTypedQuery2.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery2.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery2.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            longTypedQuery2.resultList
         }
     }
 
     @Test
     fun `findPage() with a dsl object`() {
         // given
-        val pageable1 = PageRequest.of(0, 10)
-        val page1: Page<String?> = mockk()
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultList } returns list1
+        every { longTypedQuery3.setHint(any(), any()) } returns longTypedQuery3
+        every { longTypedQuery3.setFirstResult(any()) } returns longTypedQuery3
+        every { longTypedQuery3.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
 
-        every { JpqlEntityManagerUtils.queryForPage(any(), any<SelectQuery<String>>(), any(), any()) } returns page1
+            page1
+        }
 
         // when
         val actual = sut.findPage(MyJpqlObject, pageable1, createSelectQuery3)
@@ -343,64 +608,146 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         assertThat(actual).isEqualTo(page1)
 
         verifySequence {
-            JpqlEntityManagerUtils.queryForPage(entityManager, selectQuery3, pageable1, renderContext)
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery3, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.firstResult = pageable1.offset.toInt()
+            stringTypedQuery3.maxResults = pageable1.pageSize
+            stringTypedQuery3.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
+            metadata.queryHintsForCount
+            longTypedQuery3.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery3.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery3.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            longTypedQuery3.resultList
         }
     }
 
     @Test
     fun findSlice() {
         // given
-        val pageable1 = PageRequest.of(0, 10)
-        val slice: Slice<String?> = mockk()
+        val pageable1 = PageRequest.of(1, 3, sort1)
+        val list1 = listOf("1", "2", "3", "4")
 
-        every { JpqlEntityManagerUtils.queryForSlice(any(), any<SelectQuery<String>>(), any(), any()) } returns slice
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultList } returns list1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.findSlice(pageable1, createSelectQuery1)
 
         // then
-        assertThat(actual).isEqualTo(slice)
+        assertThat(actual).isEqualTo(SliceImpl(list1.dropLast(1), pageable1, true))
 
         verifySequence {
-            JpqlEntityManagerUtils.queryForSlice(entityManager, selectQuery1, pageable1, renderContext)
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery1, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.firstResult = pageable1.offset.toInt()
+            stringTypedQuery1.maxResults = pageable1.pageSize + 1
+            stringTypedQuery1.resultList
         }
     }
 
     @Test
     fun `findSlice() with a dsl`() {
         // given
-        val pageable1 = PageRequest.of(0, 10)
-        val slice1: Slice<String?> = mockk()
+        val pageable1 = PageRequest.of(1, 3, sort1)
+        val list1 = listOf("1", "2", "3", "4")
 
-        every { JpqlEntityManagerUtils.queryForSlice(any(), any<SelectQuery<String>>(), any(), any()) } returns slice1
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultList } returns list1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.findSlice(MyJpql, pageable1, createSelectQuery2)
 
         // then
-        assertThat(actual).isEqualTo(slice1)
+        assertThat(actual).isEqualTo(SliceImpl(list1.dropLast(1), pageable1, true))
 
         verifySequence {
-            JpqlEntityManagerUtils.queryForSlice(entityManager, selectQuery2, pageable1, renderContext)
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery2, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.firstResult = pageable1.offset.toInt()
+            stringTypedQuery2.maxResults = pageable1.pageSize + 1
+            stringTypedQuery2.resultList
         }
     }
 
     @Test
     fun `findSlice() with a dsl object`() {
         // given
-        val pageable1 = PageRequest.of(0, 10)
-        val slice1: Slice<String?> = mockk()
+        val pageable1 = PageRequest.of(1, 3, sort1)
+        val list1 = listOf("1", "2", "3", "4")
 
-        every { JpqlEntityManagerUtils.queryForSlice(any(), any<SelectQuery<String>>(), any(), any()) } returns slice1
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultList } returns list1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.findSlice(MyJpqlObject, pageable1, createSelectQuery3)
 
         // then
-        assertThat(actual).isEqualTo(slice1)
+        assertThat(actual).isEqualTo(SliceImpl(list1.dropLast(1), pageable1, true))
 
         verifySequence {
-            JpqlEntityManagerUtils.queryForSlice(entityManager, selectQuery3, pageable1, renderContext)
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery3, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.firstResult = pageable1.offset.toInt()
+            stringTypedQuery3.maxResults = pageable1.pageSize + 1
+            stringTypedQuery3.resultList
         }
     }
 
@@ -408,7 +755,11 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     fun update() {
         // given
         every { JpqlEntityManagerUtils.createQuery(any(), any<UpdateQuery<String>>(), any()) } returns query1
+        every { query1.setLockMode(any()) } returns query1
+        every { query1.setHint(any(), any()) } returns query1
         every { query1.executeUpdate() } returns 1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.update(createUpdateQuery1)
@@ -418,14 +769,25 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
 
         verifySequence {
             JpqlEntityManagerUtils.createQuery(entityManager, updateQuery1, renderContext)
+            metadata.lockModeType
+            query1.setLockMode(lockModeType1)
+            metadata.queryHints
+            query1.setHint(queryHint1.first, queryHint1.second)
+            query1.setHint(queryHint2.first, queryHint2.second)
+            query1.setHint(queryHint3.first, queryHint3.second)
+            query1.executeUpdate()
         }
     }
 
     @Test
     fun `update() with a dsl`() {
         // given
-        every { JpqlEntityManagerUtils.createQuery(any(), any<UpdateQuery<String>>(), any()) } returns query1
-        every { query1.executeUpdate() } returns 1
+        every { JpqlEntityManagerUtils.createQuery(any(), any<UpdateQuery<String>>(), any()) } returns query2
+        every { query2.setLockMode(any()) } returns query2
+        every { query2.setHint(any(), any()) } returns query2
+        every { query2.executeUpdate() } returns 1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.update(MyJpql, createUpdateQuery2)
@@ -435,14 +797,25 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
 
         verifySequence {
             JpqlEntityManagerUtils.createQuery(entityManager, updateQuery2, renderContext)
+            metadata.lockModeType
+            query2.setLockMode(lockModeType1)
+            metadata.queryHints
+            query2.setHint(queryHint1.first, queryHint1.second)
+            query2.setHint(queryHint2.first, queryHint2.second)
+            query2.setHint(queryHint3.first, queryHint3.second)
+            query2.executeUpdate()
         }
     }
 
     @Test
     fun `update() with a dsl object`() {
         // given
-        every { JpqlEntityManagerUtils.createQuery(any(), any<UpdateQuery<String>>(), any()) } returns query1
-        every { query1.executeUpdate() } returns 1
+        every { JpqlEntityManagerUtils.createQuery(any(), any<UpdateQuery<String>>(), any()) } returns query3
+        every { query3.setLockMode(any()) } returns query3
+        every { query3.setHint(any(), any()) } returns query3
+        every { query3.executeUpdate() } returns 1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.update(MyJpqlObject, createUpdateQuery3)
@@ -452,6 +825,13 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
 
         verifySequence {
             JpqlEntityManagerUtils.createQuery(entityManager, updateQuery3, renderContext)
+            metadata.lockModeType
+            query3.setLockMode(lockModeType1)
+            metadata.queryHints
+            query3.setHint(queryHint1.first, queryHint1.second)
+            query3.setHint(queryHint2.first, queryHint2.second)
+            query3.setHint(queryHint3.first, queryHint3.second)
+            query3.executeUpdate()
         }
     }
 
@@ -459,7 +839,11 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     fun delete() {
         // given
         every { JpqlEntityManagerUtils.createQuery(any(), any<DeleteQuery<String>>(), any()) } returns query1
+        every { query1.setLockMode(any()) } returns query1
+        every { query1.setHint(any(), any()) } returns query1
         every { query1.executeUpdate() } returns 1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.delete(createDeleteQuery1)
@@ -469,14 +853,25 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
 
         verifySequence {
             JpqlEntityManagerUtils.createQuery(entityManager, deleteQuery1, renderContext)
+            metadata.lockModeType
+            query1.setLockMode(lockModeType1)
+            metadata.queryHints
+            query1.setHint(queryHint1.first, queryHint1.second)
+            query1.setHint(queryHint2.first, queryHint2.second)
+            query1.setHint(queryHint3.first, queryHint3.second)
+            query1.executeUpdate()
         }
     }
 
     @Test
     fun `delete() with a dsl`() {
         // given
-        every { JpqlEntityManagerUtils.createQuery(any(), any<DeleteQuery<String>>(), any()) } returns query1
-        every { query1.executeUpdate() } returns 1
+        every { JpqlEntityManagerUtils.createQuery(any(), any<DeleteQuery<String>>(), any()) } returns query2
+        every { query2.setLockMode(any()) } returns query2
+        every { query2.setHint(any(), any()) } returns query2
+        every { query2.executeUpdate() } returns 1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.delete(MyJpql, createDeleteQuery2)
@@ -486,14 +881,25 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
 
         verifySequence {
             JpqlEntityManagerUtils.createQuery(entityManager, deleteQuery2, renderContext)
+            metadata.lockModeType
+            query2.setLockMode(lockModeType1)
+            metadata.queryHints
+            query2.setHint(queryHint1.first, queryHint1.second)
+            query2.setHint(queryHint2.first, queryHint2.second)
+            query2.setHint(queryHint3.first, queryHint3.second)
+            query2.executeUpdate()
         }
     }
 
     @Test
     fun `delete() with a dsl object`() {
         // given
-        every { JpqlEntityManagerUtils.createQuery(any(), any<DeleteQuery<String>>(), any()) } returns query1
-        every { query1.executeUpdate() } returns 1
+        every { JpqlEntityManagerUtils.createQuery(any(), any<DeleteQuery<String>>(), any()) } returns query3
+        every { query3.setLockMode(any()) } returns query3
+        every { query3.setHint(any(), any()) } returns query3
+        every { query3.executeUpdate() } returns 1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
 
         // when
         val actual = sut.delete(MyJpqlObject, createDeleteQuery3)
@@ -503,6 +909,13 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
 
         verifySequence {
             JpqlEntityManagerUtils.createQuery(entityManager, deleteQuery3, renderContext)
+            metadata.lockModeType
+            query3.setLockMode(lockModeType1)
+            metadata.queryHints
+            query3.setHint(queryHint1.first, queryHint1.second)
+            query3.setHint(queryHint2.first, queryHint2.second)
+            query3.setHint(queryHint3.first, queryHint3.second)
+            query3.executeUpdate()
         }
     }
 }

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/EnhancedTypedQuery.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/EnhancedTypedQuery.kt
@@ -1,0 +1,10 @@
+package com.linecorp.kotlinjdsl.support.spring.data.jpa
+
+import jakarta.persistence.TypedQuery
+
+internal class EnhancedTypedQuery<T : Any>(
+    val sortedQuery: TypedQuery<T>,
+    countQuery: () -> TypedQuery<Long>,
+) {
+    val countQuery: TypedQuery<Long> by lazy(LazyThreadSafetyMode.NONE) { countQuery() }
+}

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -2,226 +2,101 @@
 
 package com.linecorp.kotlinjdsl.support.spring.data.jpa
 
-import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
-import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
-import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
-import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
-import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
 import jakarta.persistence.EntityManager
 import jakarta.persistence.Query
 import jakarta.persistence.TypedQuery
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
-import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.query.QueryEnhancerFactoryAdaptor
-import org.springframework.data.support.PageableExecutionUtilsAdaptor
 import kotlin.reflect.KClass
 
 internal object JpqlEntityManagerUtils {
     fun <T : Any> createQuery(
         entityManager: EntityManager,
-        query: SelectQuery<T>,
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
         context: RenderContext,
     ): TypedQuery<T> {
         val rendered = JpqlRendererHolder.get().render(query, context)
 
-        return createQuery(entityManager, rendered, query.returnType)
+        return createQuery(entityManager, rendered.query, rendered.params, returnType.java)
     }
 
     fun <T : Any> createQuery(
         entityManager: EntityManager,
-        query: SelectQuery<T>,
+        query: JpqlQuery<*>,
         queryParams: Map<String, Any?>,
+        returnType: KClass<T>,
         context: RenderContext,
     ): TypedQuery<T> {
         val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
 
-        return createQuery(entityManager, rendered, query.returnType)
+        return createQuery(entityManager, rendered.query, rendered.params, returnType.java)
     }
 
-    fun <T : Any> createQuery(
+    fun createQuery(
         entityManager: EntityManager,
-        query: UpdateQuery<T>,
+        query: JpqlQuery<*>,
         context: RenderContext,
     ): Query {
         val rendered = JpqlRendererHolder.get().render(query, context)
 
-        return createQuery(entityManager, rendered)
+        return createQuery(entityManager, rendered.query, rendered.params)
     }
 
-    fun <T : Any> createQuery(
+    fun createQuery(
         entityManager: EntityManager,
-        query: UpdateQuery<T>,
+        query: JpqlQuery<*>,
         queryParams: Map<String, Any?>,
         context: RenderContext,
     ): Query {
         val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
 
-        return createQuery(entityManager, rendered)
+        return createQuery(entityManager, rendered.query, rendered.params)
     }
 
-    fun <T : Any> createQuery(
+    fun <T : Any> createEnhancedQuery(
         entityManager: EntityManager,
-        query: DeleteQuery<T>,
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        sort: Sort,
         context: RenderContext,
-    ): Query {
+    ): EnhancedTypedQuery<T> {
         val rendered = JpqlRendererHolder.get().render(query, context)
 
-        return createQuery(entityManager, rendered)
-    }
+        val queryEnhancer = QueryEnhancerFactoryAdaptor.forQuery(rendered.query)
 
-    fun <T : Any> createQuery(
-        entityManager: EntityManager,
-        query: DeleteQuery<T>,
-        queryParams: Map<String, Any?>,
-        context: RenderContext,
-    ): Query {
-        val rendered = JpqlRendererHolder.get().render(query, queryParams, context)
-
-        return createQuery(entityManager, rendered)
+        return EnhancedTypedQuery(
+            createQuery(entityManager, queryEnhancer.applySorting(sort), rendered.params, returnType.java),
+        ) {
+            // Lazy
+            createQuery(entityManager, queryEnhancer.createCountQueryFor(), rendered.params, Long::class.javaObjectType)
+        }
     }
 
     private fun <T : Any> createQuery(
         entityManager: EntityManager,
-        rendered: JpqlRendered,
-        resultClass: KClass<T>,
+        query: String,
+        queryParams: Map<String, Any?>,
+        returnType: Class<T>,
     ): TypedQuery<T> {
-        return entityManager.createQuery(rendered.query, resultClass.java).apply {
-            setParams(this, rendered.params)
+        return entityManager.createQuery(query, returnType).apply {
+            setParams(this, queryParams)
         }
     }
 
     private fun createQuery(
         entityManager: EntityManager,
-        rendered: JpqlRendered,
+        query: String,
+        queryParams: Map<String, Any?>,
     ): Query {
-        return entityManager.createQuery(rendered.query).apply {
-            setParams(this, rendered.params)
+        return entityManager.createQuery(query).apply {
+            setParams(this, queryParams)
         }
     }
 
-    fun <T : Any> queryForList(
-        entityManager: EntityManager,
-        query: SelectQuery<T>,
-        pageable: Pageable,
-        context: RenderContext,
-    ): List<T?> {
-        val rendered = JpqlRendererHolder.get().render(query, context)
-
-        return queryForList(entityManager, rendered, pageable, query.returnType)
-    }
-
-    fun <T : Any> queryForPage(
-        entityManager: EntityManager,
-        query: SelectQuery<T>,
-        pageable: Pageable,
-        context: RenderContext,
-    ): Page<T?> {
-        val rendered = JpqlRendererHolder.get().render(query, context)
-
-        return queryForPage(entityManager, rendered, pageable, query.returnType)
-    }
-
-    fun <T : Any> queryForSlice(
-        entityManager: EntityManager,
-        query: SelectQuery<T>,
-        pageable: Pageable,
-        context: RenderContext,
-    ): Slice<T?> {
-        val rendered = JpqlRendererHolder.get().render(query, context)
-
-        return queryForSlice(entityManager, rendered, pageable, query.returnType)
-    }
-
-    private fun <T : Any> queryForList(
-        entityManager: EntityManager,
-        rendered: JpqlRendered,
-        pageable: Pageable,
-        resultClass: KClass<T>,
-    ): List<T?> {
-        val queryEnhancer = QueryEnhancerFactoryAdaptor.forQuery(rendered.query)
-
-        val sortedQuery = queryEnhancer.applySorting(pageable.sort)
-
-        val jpaQuery = entityManager.createQuery(sortedQuery, resultClass.java).apply {
-            setParams(this, rendered.params)
-        }
-
-        if (pageable.isPaged) {
-            jpaQuery.firstResult = pageable.offset.toInt()
-            jpaQuery.maxResults = pageable.pageSize
-        }
-
-        return jpaQuery.resultList
-    }
-
-    private fun <T : Any> queryForPage(
-        entityManager: EntityManager,
-        rendered: JpqlRendered,
-        pageable: Pageable,
-        resultClass: KClass<T>,
-    ): Page<T?> {
-        val queryEnhancer = QueryEnhancerFactoryAdaptor.forQuery(rendered.query)
-
-        val sortedQuery = queryEnhancer.applySorting(pageable.sort)
-        val countQuery = queryEnhancer.createCountQueryFor()
-
-        val sortedJpaQuery = entityManager.createQuery(sortedQuery, resultClass.java).apply {
-            setParams(this, rendered.params)
-
-            if (pageable.isPaged) {
-                firstResult = pageable.offset.toInt()
-                maxResults = pageable.pageSize
-            }
-        }
-
-        val countJpaQuery = entityManager.createQuery(countQuery, Long::class.javaObjectType).apply {
-            setParams(this, rendered.params)
-        }
-
-        return PageableExecutionUtilsAdaptor.getPage(sortedJpaQuery.resultList, pageable) {
-            val counts = countJpaQuery.resultList
-
-            if (counts.size == 1) {
-                counts.first()
-            } else {
-                counts.count().toLong()
-            }
-        }
-    }
-
-    private fun <T : Any> queryForSlice(
-        entityManager: EntityManager,
-        rendered: JpqlRendered,
-        pageable: Pageable,
-        resultClass: KClass<T>,
-    ): Slice<T?> {
-        val queryEnhancer = QueryEnhancerFactoryAdaptor.forQuery(rendered.query)
-
-        val sortedQuery = queryEnhancer.applySorting(pageable.sort)
-
-        val jpaQuery = entityManager.createQuery(sortedQuery, resultClass.java).apply {
-            setParams(this, rendered.params)
-        }
-
-        return if (pageable.isPaged) {
-            jpaQuery.firstResult = pageable.offset.toInt()
-            jpaQuery.maxResults = pageable.pageSize + 1
-
-            val results = jpaQuery.resultList
-            val hasNext = results.size > pageable.pageSize
-
-            SliceImpl(takeIf { hasNext }?.let { results.dropLast(1) } ?: results, pageable, hasNext)
-        } else {
-            val results = jpaQuery.resultList
-
-            SliceImpl(results, pageable, false)
-        }
-    }
-
-    private fun setParams(query: Query, params: JpqlRenderedParams) {
+    private fun setParams(query: Query, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
             query.setParameter(name, value)
         }

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/autoconfigure/KotlinJdslAutoConfiguration.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/autoconfigure/KotlinJdslAutoConfiguration.kt
@@ -14,6 +14,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
+import org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessorAdaptor
 
 @AutoConfiguration
 @ConditionalOnClass(EntityManager::class, JpqlRenderContext::class)
@@ -48,10 +49,12 @@ open class KotlinJdslAutoConfiguration {
         renderContexts: List<RenderContext>,
     ): KotlinJdslJpqlExecutor {
         val renderContext = renderContexts.reversed().reduce { acc, renderContext -> acc + renderContext }
+        val metadata = CrudMethodMetadataPostProcessorAdaptor().getCrudMethodMetadata()
 
         return KotlinJdslJpqlExecutorImpl(
             entityManager = entityManager,
             renderContext = renderContext,
+            metadata = metadata,
         )
     }
 }

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/extension/EntityManagerExtensions.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/extension/EntityManagerExtensions.kt
@@ -17,7 +17,7 @@ import jakarta.persistence.TypedQuery
 fun <T : Any> EntityManager.createQuery(
     query: SelectQuery<T>,
     context: RenderContext,
-): TypedQuery<T> = JpqlEntityManagerUtils.createQuery(this, query, context)
+): TypedQuery<T> = JpqlEntityManagerUtils.createQuery(this, query, query.returnType, context)
 
 /**
  * Creates [jakarta.persistence.TypedQuery] from the [SelectQuery] and [RenderContext].
@@ -27,7 +27,7 @@ fun <T : Any> EntityManager.createQuery(
     query: SelectQuery<T>,
     queryParams: Map<String, Any?>,
     context: RenderContext,
-): Query = JpqlEntityManagerUtils.createQuery(this, query, queryParams, context)
+): Query = JpqlEntityManagerUtils.createQuery(this, query, queryParams, query.returnType, context)
 
 /**
  * Creates [jakarta.persistence.TypedQuery] from the [UpdateQuery] and [RenderContext].

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -1,21 +1,34 @@
+@file:Suppress("SqlSourceToSinkFlow")
+
 package com.linecorp.kotlinjdsl.support.spring.data.jpa.repository
 
 import com.linecorp.kotlinjdsl.SinceJdsl
 import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
 import com.linecorp.kotlinjdsl.dsl.jpql.JpqlDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
 import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
 import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.EnhancedTypedQuery
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.JpqlEntityManagerUtils
 import jakarta.persistence.EntityManager
+import jakarta.persistence.LockModeType
+import jakarta.persistence.Query
+import jakarta.persistence.TypedQuery
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Sort
+import org.springframework.data.jpa.repository.support.CrudMethodMetadata
+import org.springframework.data.jpa.repository.support.QueryHints
 import org.springframework.data.repository.NoRepositoryBean
+import org.springframework.data.support.PageableExecutionUtilsAdaptor
 import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.KClass
 
 @Transactional
 @NoRepositoryBean
@@ -23,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional
 open class KotlinJdslJpqlExecutorImpl(
     private val entityManager: EntityManager,
     private val renderContext: RenderContext,
+    private val metadata: CrudMethodMetadata?,
 ) : KotlinJdslJpqlExecutor {
     override fun <T : Any> findAll(
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
@@ -35,14 +49,17 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query, query.returnType)
 
         return jpaQuery.resultList
     }
 
-    override fun <T : Any, DSL : JpqlDsl> findAll(dsl: DSL, init: DSL.() -> JpqlQueryable<SelectQuery<T>>): List<T?> {
+    override fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query, query.returnType)
 
         return jpaQuery.resultList
     }
@@ -61,7 +78,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForList(entityManager, query, pageable, renderContext)
+        return createList(query, query.returnType, pageable)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findAll(
@@ -71,7 +88,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForList(entityManager, query, pageable, renderContext)
+        return createList(query, query.returnType, pageable)
     }
 
     override fun <T : Any> findPage(
@@ -88,7 +105,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): Page<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForPage(entityManager, query, pageable, renderContext)
+        return createPage(query, query.returnType, pageable)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findPage(
@@ -98,7 +115,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): Page<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForPage(entityManager, query, pageable, renderContext)
+        return createPage(query, query.returnType, pageable)
     }
 
     override fun <T : Any> findSlice(
@@ -115,7 +132,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): Slice<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForSlice(entityManager, query, pageable, renderContext)
+        return createSlice(query, query.returnType, pageable)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findSlice(
@@ -125,8 +142,9 @@ open class KotlinJdslJpqlExecutorImpl(
     ): Slice<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return JpqlEntityManagerUtils.queryForSlice(entityManager, query, pageable, renderContext)
+        return createSlice(query, query.returnType, pageable)
     }
+
     override fun <T : Any> update(
         init: Jpql.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
@@ -138,7 +156,7 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
         val query: UpdateQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query)
 
         return jpaQuery.executeUpdate()
     }
@@ -148,7 +166,7 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
         val query: UpdateQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query)
 
         return jpaQuery.executeUpdate()
     }
@@ -164,7 +182,7 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
         val query: DeleteQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query)
 
         return jpaQuery.executeUpdate()
     }
@@ -174,8 +192,137 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
         val query: DeleteQuery<T> = jpql(dsl, init)
-        val jpaQuery = JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext)
+        val jpaQuery = createJpaQuery(query)
 
         return jpaQuery.executeUpdate()
+    }
+
+    private fun <T : Any> createJpaQuery(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+    ): TypedQuery<T> {
+        return JpqlEntityManagerUtils.createQuery(entityManager, query, returnType, renderContext).apply {
+            setMetadata(this, metadata)
+        }
+    }
+
+    private fun createJpaQuery(
+        query: JpqlQuery<*>,
+    ): Query {
+        return JpqlEntityManagerUtils.createQuery(entityManager, query, renderContext).apply {
+            setMetadata(this, metadata)
+        }
+    }
+
+    private fun <T : Any> createJpaEnhancedQuery(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        sort: Sort,
+    ): EnhancedTypedQuery<T> {
+        val enhancedQuery = JpqlEntityManagerUtils.createEnhancedQuery(
+            entityManager,
+            query,
+            returnType,
+            sort,
+            renderContext,
+        )
+
+        return EnhancedTypedQuery(
+            enhancedQuery.sortedQuery.apply { setMetadata(this, metadata) },
+        ) {
+            // Lazy
+            enhancedQuery.countQuery.apply { setMetadataForCount(this, metadata) }
+        }
+    }
+
+    private fun setMetadata(query: Query, metadata: CrudMethodMetadata?) {
+        if (metadata == null) return
+
+        setLockMode(query, metadata.lockModeType)
+        setQueryHints(query, metadata.queryHints)
+    }
+
+    private fun setMetadataForCount(query: Query, metadata: CrudMethodMetadata?) {
+        if (metadata == null) return
+
+        setQueryHints(query, metadata.queryHintsForCount)
+    }
+
+    private fun setLockMode(query: Query, lockMode: LockModeType?) {
+        if (lockMode != null) {
+            query.lockMode = lockMode
+        }
+    }
+
+    private fun setQueryHints(query: Query, hints: QueryHints?) {
+        hints?.forEach { name, value ->
+            query.setHint(name, value)
+        }
+    }
+
+    private fun <T : Any> createList(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        pageable: Pageable,
+    ): List<T?> {
+        val enhancedQuery = createJpaEnhancedQuery(query, returnType, pageable.sort)
+
+        val sortedQuery = enhancedQuery.sortedQuery
+
+        if (pageable.isPaged) {
+            sortedQuery.firstResult = pageable.offset.toInt()
+            sortedQuery.maxResults = pageable.pageSize
+        }
+
+        return sortedQuery.resultList
+    }
+
+    private fun <T : Any> createPage(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        pageable: Pageable,
+    ): Page<T?> {
+        val enhancedQuery = createJpaEnhancedQuery(query, returnType, pageable.sort)
+
+        val sortedQuery = enhancedQuery.sortedQuery
+
+        if (pageable.isPaged) {
+            sortedQuery.firstResult = pageable.offset.toInt()
+            sortedQuery.maxResults = pageable.pageSize
+        }
+
+        return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
+            val counts = enhancedQuery.countQuery.resultList
+
+            if (counts.size == 1) {
+                counts.first()
+            } else {
+                counts.count().toLong()
+            }
+        }
+    }
+
+    private fun <T : Any> createSlice(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        pageable: Pageable,
+    ): Slice<T?> {
+        val enhancedQuery = createJpaEnhancedQuery(query, returnType, pageable.sort)
+
+        val sortedQuery = enhancedQuery.sortedQuery
+
+        return if (pageable.isPaged) {
+            sortedQuery.firstResult = pageable.offset.toInt()
+            sortedQuery.maxResults = pageable.pageSize + 1
+
+            val results = sortedQuery.resultList
+            val hasNext = results.size > pageable.pageSize
+
+            SliceImpl(takeIf { hasNext }?.let { results.dropLast(1) } ?: results, pageable, hasNext)
+        } else {
+            val results = sortedQuery.resultList
+
+            SliceImpl(results, pageable, false)
+        }
     }
 }

--- a/support/spring-data-jpa/src/main/kotlin/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessorAdaptor.kt
+++ b/support/spring-data-jpa/src/main/kotlin/org/springframework/data/jpa/repository/support/CrudMethodMetadataPostProcessorAdaptor.kt
@@ -1,0 +1,9 @@
+package org.springframework.data.jpa.repository.support
+
+internal class CrudMethodMetadataPostProcessorAdaptor {
+    private val delegate = CrudMethodMetadataPostProcessor()
+
+    fun getCrudMethodMetadata(): CrudMethodMetadata? {
+        return delegate.crudMethodMetadata
+    }
+}

--- a/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtilsTest.kt
@@ -1,8 +1,6 @@
 package com.linecorp.kotlinjdsl.support.spring.data.jpa
 
-import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
-import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
-import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
@@ -19,13 +17,9 @@ import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.query.QueryEnhancer
 import org.springframework.data.jpa.repository.query.QueryEnhancerFactoryAdaptor
-import org.springframework.data.support.PageableExecutionUtilsAdaptor
-import java.util.function.LongSupplier
 
 @ExtendWith(MockKExtension::class)
 class JpqlEntityManagerUtilsTest : WithAssertions {
@@ -42,13 +36,7 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     private lateinit var queryEnhancer: QueryEnhancer
 
     @MockK
-    private lateinit var selectQuery1: SelectQuery<String>
-
-    @MockK
-    private lateinit var updateQuery1: UpdateQuery<String>
-
-    @MockK
-    private lateinit var deleteQuery1: DeleteQuery<String>
+    private lateinit var query1: JpqlQuery<*>
 
     @MockK
     private lateinit var stringTypedQuery1: TypedQuery<String>
@@ -56,8 +44,7 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     @MockK
     private lateinit var longTypedQuery1: TypedQuery<Long>
 
-    @MockK
-    private lateinit var page1: Page<String>
+    private val sort1 = Sort.by("property1")
 
     private val renderedQuery1 = "query"
     private val renderedParam1 = "queryParam1" to "queryParamValue1"
@@ -74,33 +61,31 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     fun setUp() {
         mockkObject(JpqlRendererHolder)
         mockkObject(QueryEnhancerFactoryAdaptor)
-        mockkObject(PageableExecutionUtilsAdaptor)
 
         every { JpqlRendererHolder.get() } returns renderer
 
         excludeRecords { JpqlRendererHolder.get() }
         excludeRecords { stringTypedQuery1.equals(any()) }
+        excludeRecords { longTypedQuery1.equals(any()) }
     }
 
     @Test
-    fun `createQuery() with a select query`() {
+    fun `createQuery() with a query and a return type`() {
         // given
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
         every { renderer.render(any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
 
         // when
-        val actual = JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, context)
+        val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, String::class, context)
 
         // then
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
-            renderer.render(selectQuery1, context)
-            selectQuery1.returnType
+            renderer.render(query1, context)
             entityManager.createQuery(rendered1.query, String::class.java)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
@@ -108,25 +93,23 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
-    fun `createQuery() with a select query and query params`() {
+    fun `createQuery() with a query and query params and a return type`() {
         // given
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
         every { renderer.render(any(), any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
 
         // when
         val actual = JpqlEntityManagerUtils
-            .createQuery(entityManager, selectQuery1, mapOf(queryParam1, queryParam2), context)
+            .createQuery(entityManager, query1, mapOf(queryParam1, queryParam2), String::class, context)
 
         // then
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
-            renderer.render(selectQuery1, mapOf(queryParam1, queryParam2), context)
-            selectQuery1.returnType
+            renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query, String::class.java)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
@@ -134,7 +117,7 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
-    fun `createQuery() with an update query`() {
+    fun `createQuery() with a query`() {
         // given
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
@@ -143,13 +126,13 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
 
         // when
-        val actual = JpqlEntityManagerUtils.createQuery(entityManager, updateQuery1, context)
+        val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, context)
 
         // then
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
-            renderer.render(updateQuery1, context)
+            renderer.render(query1, context)
             entityManager.createQuery(rendered1.query)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
@@ -157,7 +140,7 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
-    fun `createQuery() with an update query and query params`() {
+    fun `createQuery() with a query and query params`() {
         // given
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
@@ -167,13 +150,13 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         // when
         val actual = JpqlEntityManagerUtils
-            .createQuery(entityManager, updateQuery1, mapOf(queryParam1, queryParam2), context)
+            .createQuery(entityManager, query1, mapOf(queryParam1, queryParam2), context)
 
         // then
         assertThat(actual).isEqualTo(stringTypedQuery1)
 
         verifySequence {
-            renderer.render(updateQuery1, mapOf(queryParam1, queryParam2), context)
+            renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
@@ -181,104 +164,11 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
-    fun `createQuery() with a delete query`() {
+    fun createEnhancedQuery() {
         // given
         val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
 
         every { renderer.render(any(), any()) } returns rendered1
-        every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
-
-        // when
-        val actual = JpqlEntityManagerUtils.createQuery(entityManager, deleteQuery1, context)
-
-        // then
-        assertThat(actual).isEqualTo(stringTypedQuery1)
-
-        verifySequence {
-            renderer.render(deleteQuery1, context)
-            entityManager.createQuery(rendered1.query)
-            stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
-            stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-        }
-    }
-
-    @Test
-    fun `createQuery() with a delete query and query params`() {
-        // given
-        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
-
-        every { renderer.render(any(), any(), any()) } returns rendered1
-        every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
-
-        // when
-        val actual = JpqlEntityManagerUtils
-            .createQuery(entityManager, deleteQuery1, mapOf(queryParam1, queryParam2), context)
-
-        // then
-        assertThat(actual).isEqualTo(stringTypedQuery1)
-
-        verifySequence {
-            renderer.render(deleteQuery1, mapOf(queryParam1, queryParam2), context)
-            entityManager.createQuery(rendered1.query)
-            stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
-            stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-        }
-    }
-
-    @Test
-    fun queryForList() {
-        // given
-        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
-
-        val pageable1 = PageRequest.of(1, 10)
-        val list1 = listOf("1", "2", "3")
-
-        every { renderer.render(any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
-        every { QueryEnhancerFactoryAdaptor.forQuery(any()) } returns queryEnhancer
-        every { queryEnhancer.applySorting(any()) } returns sortedQuery1
-        every { entityManager.createQuery(any<String>(), any<Class<*>>()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.resultList } returns list1
-
-        // when
-        val actual = JpqlEntityManagerUtils.queryForList(entityManager, selectQuery1, pageable1, context)
-
-        // then
-        assertThat(actual).isEqualTo(list1)
-
-        verifySequence {
-            renderer.render(selectQuery1, context)
-            selectQuery1.returnType
-
-            QueryEnhancerFactoryAdaptor.forQuery(rendered1.query)
-            queryEnhancer.applySorting(pageable1.sort)
-
-            entityManager.createQuery(sortedQuery1, String::class.java)
-            stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
-            stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-            stringTypedQuery1.firstResult = pageable1.offset.toInt()
-            stringTypedQuery1.maxResults = pageable1.pageSize
-
-            stringTypedQuery1.resultList
-        }
-    }
-
-    @Test
-    fun queryForPage() {
-        // given
-        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
-
-        val pageable1 = PageRequest.of(1, 10)
-        val list1 = listOf("1", "2", "3")
-        val counts1 = listOf(1L, 1L, 1L)
-
-        every { renderer.render(any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
         every { QueryEnhancerFactoryAdaptor.forQuery(any()) } returns queryEnhancer
         every { queryEnhancer.applySorting(any()) } returns sortedQuery1
         every { queryEnhancer.createCountQueryFor() } returns countQuery1
@@ -286,85 +176,30 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
             entityManager.createQuery(any<String>(), any<Class<*>>())
         } returns stringTypedQuery1 andThen longTypedQuery1
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.resultList } returns list1
         every { longTypedQuery1.setParameter(any<String>(), any()) } returns longTypedQuery1
-        every { longTypedQuery1.resultList } returns counts1
-        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
-            lastArg<LongSupplier>().asLong
-
-            page1
-        }
 
         // when
-        val actual = JpqlEntityManagerUtils.queryForPage(entityManager, selectQuery1, pageable1, context)
+        val actual = JpqlEntityManagerUtils
+            .createEnhancedQuery(entityManager, query1, String::class, sort1, context)
 
         // then
-        assertThat(actual).isEqualTo(page1)
+        assertThat(actual.sortedQuery).isEqualTo(stringTypedQuery1)
+        assertThat(actual.countQuery).isEqualTo(longTypedQuery1)
 
         verifySequence {
-            renderer.render(selectQuery1, context)
-            selectQuery1.returnType
+            renderer.render(query1, context)
 
             QueryEnhancerFactoryAdaptor.forQuery(rendered1.query)
-            queryEnhancer.applySorting(pageable1.sort)
-            queryEnhancer.createCountQueryFor()
 
+            queryEnhancer.applySorting(sort1)
             entityManager.createQuery(sortedQuery1, String::class.java)
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-            stringTypedQuery1.firstResult = pageable1.offset.toInt()
-            stringTypedQuery1.maxResults = pageable1.pageSize
 
+            queryEnhancer.createCountQueryFor()
             entityManager.createQuery(countQuery1, Long::class.javaObjectType)
             longTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             longTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-
-            stringTypedQuery1.resultList
-            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
-            longTypedQuery1.resultList
-        }
-    }
-
-    @Test
-    fun queryForSlice() {
-        // given
-        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
-
-        val pageable1 = PageRequest.of(1, 3)
-        val list1 = listOf("1", "2", "3", "4")
-
-        every { renderer.render(any(), any()) } returns rendered1
-        every { selectQuery1.returnType } returns String::class
-        every { QueryEnhancerFactoryAdaptor.forQuery(any()) } returns queryEnhancer
-        every { queryEnhancer.applySorting(any()) } returns sortedQuery1
-        every { entityManager.createQuery(any<String>(), any<Class<*>>()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
-        every { stringTypedQuery1.resultList } returns list1
-
-        // when
-        val actual = JpqlEntityManagerUtils.queryForSlice(entityManager, selectQuery1, pageable1, context)
-
-        // then
-        assertThat(actual).isEqualTo(SliceImpl(list1.dropLast(1), pageable1, true))
-
-        verifySequence {
-            renderer.render(selectQuery1, context)
-            selectQuery1.returnType
-
-            QueryEnhancerFactoryAdaptor.forQuery(rendered1.query)
-            queryEnhancer.applySorting(pageable1.sort)
-
-            entityManager.createQuery(sortedQuery1, String::class.java)
-            stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
-            stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
-            stringTypedQuery1.firstResult = pageable1.offset.toInt()
-            stringTypedQuery1.maxResults = pageable1.pageSize + 1
-
-            stringTypedQuery1.resultList
         }
     }
 }

--- a/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/extension/EntityManagerExtensionsTest.kt
+++ b/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/extension/EntityManagerExtensionsTest.kt
@@ -17,6 +17,7 @@ import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.reflect.KClass
 
 @ExtendWith(MockKExtension::class)
 class EntityManagerExtensionsTest : WithAssertions {
@@ -53,8 +54,9 @@ class EntityManagerExtensionsTest : WithAssertions {
     fun `createQuery() with a select query`() {
         // given
         every {
-            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any())
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
         } returns typedQuery1
+        every { selectQuery1.returnType } returns String::class
 
         // when
         val actual = entityManager.createQuery(selectQuery1, context)
@@ -63,7 +65,8 @@ class EntityManagerExtensionsTest : WithAssertions {
         assertThat(actual).isEqualTo(typedQuery1)
 
         verifySequence {
-            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, context)
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, String::class, context)
         }
     }
 
@@ -71,8 +74,9 @@ class EntityManagerExtensionsTest : WithAssertions {
     fun `createQuery() with a select query and query params`() {
         // given
         every {
-            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any(), any())
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any(), any<KClass<*>>(), any())
         } returns typedQuery1
+        every { selectQuery1.returnType } returns String::class
 
         // when
         val actual = entityManager.createQuery(selectQuery1, queryParams1, context)
@@ -81,7 +85,8 @@ class EntityManagerExtensionsTest : WithAssertions {
         assertThat(actual).isEqualTo(typedQuery1)
 
         verifySequence {
-            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, queryParams1, context)
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, queryParams1, String::class, context)
         }
     }
 


### PR DESCRIPTION
# Motivation

- Kotlin JDSL does not support CrudMethodMetadata of Spring Data.

# Modifications

- Support `@Lock` of Spring Data.
- Support `@QueryHints` of Spring Data.

# Closes

- #664
