### PR TITLE
docs: fix typo in korean documentation

### DIFF
--- a/docs/ko/jpql-with-kotlin-jdsl/README.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-Kotlin JDSL을 사용하기 위해서는 Java 8 (혹은 그 이상) and Kotlin 1.7 (그 이상)이 요구됩니다.
+Kotlin JDSL을 사용하기 위해서는 Java 8 (혹은 그 이상) 과 Kotlin 1.7 (그 이상)이 요구됩니다.
 
 ## Configure the repositories
 

--- a/docs/ko/jpql-with-kotlin-jdsl/expressions.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/expressions.md
@@ -186,7 +186,7 @@ sumDistinct(path(Book::price))
 
 ## Functions
 
-Kotlin JDSL은 JPA에서 제공하는 여러 함수들을 지원하기 위함 함수들을 제공합니다.
+Kotlin JDSL은 JPA에서 제공하는 여러 함수들을 지원하기 위한 함수들을 제공합니다.
 
 ### String functions
 


### PR DESCRIPTION
# Motivation

There are typos in the Korean documentation

# Modifications

- fix typo in [README.md](https://github.com/line/kotlin-jdsl/blob/main/docs/ko/README.md) and [expressions.md](https://github.com/line/kotlin-jdsl/blob/main/docs/ko/jpql-with-kotlin-jdsl/expressions.md)

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- Fixed typo

# Closes

- N/A
