### PR TITLE
fix: render false condition for in condition if the compare values is empty

### DIFF
--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInSerializer.kt
@@ -19,18 +19,18 @@ class JpqlInSerializer : JpqlSerializer<JpqlIn<*>> {
         val delegate = context.getValue(JpqlRenderSerializer)
 
         if (IterableUtils.isEmpty(part.compareValues)) {
-            return
-        }
+            writer.write("0 = 1")
+        } else {
+            delegate.serialize(part.value, writer, context)
 
-        delegate.serialize(part.value, writer, context)
+            writer.write(" ")
+            writer.write("IN")
+            writer.write(" ")
 
-        writer.write(" ")
-        writer.write("IN")
-        writer.write(" ")
-
-        writer.writeParentheses {
-            writer.writeEach(part.compareValues, separator = ", ") {
-                delegate.serialize(it, writer, context)
+            writer.writeParentheses {
+                writer.writeEach(part.compareValues, separator = ", ") {
+                    delegate.serialize(it, writer, context)
+                }
             }
         }
     }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlNotInSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlNotInSerializer.kt
@@ -19,18 +19,18 @@ class JpqlNotInSerializer : JpqlSerializer<JpqlNotIn<*>> {
         val delegate = context.getValue(JpqlRenderSerializer)
 
         if (IterableUtils.isEmpty(part.compareValues)) {
-            return
-        }
+            writer.write("0 = 1")
+        } else {
+            delegate.serialize(part.value, writer, context)
 
-        delegate.serialize(part.value, writer, context)
+            writer.write(" ")
+            writer.write("NOT IN")
+            writer.write(" ")
 
-        writer.write(" ")
-        writer.write("NOT IN")
-        writer.write(" ")
-
-        writer.writeParentheses {
-            writer.writeEach(part.compareValues, separator = ", ") {
-                delegate.serialize(it, writer, context)
+            writer.writeParentheses {
+                writer.writeEach(part.compareValues, separator = ", ") {
+                    delegate.serialize(it, writer, context)
+                }
             }
         }
     }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInSerializerTest.kt
@@ -9,7 +9,6 @@ import com.linecorp.kotlinjdsl.render.jpql.entity.book.Book
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
-import io.mockk.called
 import io.mockk.impl.annotations.MockK
 import io.mockk.verifySequence
 import org.assertj.core.api.WithAssertions
@@ -73,7 +72,7 @@ class JpqlInSerializerTest : WithAssertions {
     }
 
     @Test
-    fun `serialize() draws nothing, when the compareValues is empty`() {
+    fun `serialize() draws 0 = 1, when the compareValues is empty`() {
         // Given
         val part = Predicates.`in`(
             expression1,
@@ -86,7 +85,7 @@ class JpqlInSerializerTest : WithAssertions {
 
         // Then
         verifySequence {
-            writer wasNot called
+            writer.write("0 = 1")
         }
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlNotInSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlNotInSerializerTest.kt
@@ -9,7 +9,6 @@ import com.linecorp.kotlinjdsl.render.jpql.entity.book.Book
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
-import io.mockk.called
 import io.mockk.impl.annotations.MockK
 import io.mockk.verifySequence
 import org.assertj.core.api.WithAssertions
@@ -73,7 +72,7 @@ class JpqlNotInSerializerTest : WithAssertions {
     }
 
     @Test
-    fun `serialize() draws nothing, when the compareValues is empty`() {
+    fun `serialize() draws 0 = 1, when the compareValues is empty`() {
         // Given
         val part = Predicates.notIn(
             expression1,
@@ -86,7 +85,7 @@ class JpqlNotInSerializerTest : WithAssertions {
 
         // Then
         verifySequence {
-            writer wasNot called
+            writer.write("0 = 1")
         }
     }
 }


### PR DESCRIPTION
# Motivation

- If in condition is used alone in the where clause and the compare values is empty, a malformed query is generated. 

# Modifications

- If compare values is empty, it renders 0 = 1 instead of nothing. 

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- If in condition is used alone in the where clause and the compare values is empty, the malformed query is no longer generated. 
- For those who didn't use the in condition alone in the where clause, their query might not work as expected, as it would have been the same as if 1 = 1 was printed. 

# Closes

- #702
