### PR TITLE
[ISSUE-708] change @Transactional readOnly for select query

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ allprojects {
     apply(plugin = "signing")
 
     group = "com.linecorp.kotlin-jdsl"
-    version = "3.4.0"
+    version = "3.4.1"
 
     repositories {
         mavenCentral()

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,5 +1,5 @@
 ---
-description: 'Latest stable version: 3.4.0'
+description: 'Latest stable version: 3.4.1'
 ---
 
 # Kotlin JDSL

--- a/docs/en/jpql-with-kotlin-jdsl/README.md
+++ b/docs/en/jpql-with-kotlin-jdsl/README.md
@@ -99,8 +99,8 @@ The following dependencies are the minimum requirement for all Kotlin JDSL appli
 
 ```kotlin
 dependencies {
-    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.4.0")
-    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.4.0")
+    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.4.1")
+    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.4.1")
 }
 ```
 
@@ -110,8 +110,8 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.linecorp.kotlin-jdsl:jpql-dsl:3.4.0'
-    implementation 'com.linecorp.kotlin-jdsl:jpql-render:3.4.0'
+    implementation 'com.linecorp.kotlin-jdsl:jpql-dsl:3.4.1'
+    implementation 'com.linecorp.kotlin-jdsl:jpql-render:3.4.1'
 }
 ```
 
@@ -125,12 +125,12 @@ dependencies {
     <dependency>
         <groupId>com.linecorp.kotlin-jdsl</groupId>
         <artifactId>jpql-dsl</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1</version>
     </dependency>
     <dependency>
         <groupId>com.linecorp.kotlin-jdsl</groupId>
         <artifactId>jpql-render</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -1,5 +1,5 @@
 ---
-description: 'Latest stable version: 3.4.0'
+description: 'Latest stable version: 3.4.1'
 ---
 
 # Kotlin JDSL

--- a/docs/ko/jpql-with-kotlin-jdsl/README.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/README.md
@@ -100,8 +100,8 @@ Kotlin JDSL을 실행시키기 위해서는 다음 dependency들이 필수로 �
 
 ```kotlin
 dependencies {
-    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.4.0")
-    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.4.0")
+    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.4.1")
+    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.4.1")
 }
 ```
 
@@ -111,8 +111,8 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.linecorp.kotlin-jdsl:jpql-dsl:3.4.0'
-    implementation 'com.linecorp.kotlin-jdsl:jpql-render:3.4.0'
+    implementation 'com.linecorp.kotlin-jdsl:jpql-dsl:3.4.1'
+    implementation 'com.linecorp.kotlin-jdsl:jpql-render:3.4.1'
 }
 ```
 
@@ -126,12 +126,12 @@ dependencies {
     <dependency>
         <groupId>com.linecorp.kotlin-jdsl</groupId>
         <artifactId>jpql-dsl</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1</version>
     </dependency>
     <dependency>
         <groupId>com.linecorp.kotlin-jdsl</groupId>
         <artifactId>jpql-render</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1</version>
     </dependency>
 </dependencies>
 ```

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -30,8 +30,8 @@ import org.springframework.data.support.PageableExecutionUtilsAdaptor
 import org.springframework.transaction.annotation.Transactional
 import kotlin.reflect.KClass
 
-@Transactional
 @NoRepositoryBean
+@Transactional(readOnly = true)
 @SinceJdsl("3.0.0")
 open class KotlinJdslJpqlExecutorImpl(
     private val entityManager: EntityManager,
@@ -145,6 +145,7 @@ open class KotlinJdslJpqlExecutorImpl(
         return createSlice(query, query.returnType, pageable)
     }
 
+    @Transactional
     override fun <T : Any> update(
         init: Jpql.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
@@ -161,6 +162,7 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> update(
         dsl: DSL,
         init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
@@ -171,12 +173,14 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    @Transactional
     override fun <T : Any> delete(
         init: Jpql.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
         return delete(Jpql, init)
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> delete(
         dsl: JpqlDsl.Constructor<DSL>,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
@@ -187,6 +191,7 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> delete(
         dsl: DSL,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,


### PR DESCRIPTION
# Motivation

- in spring data jpa SimpleJpaRepository class declare `@Transactional` but in select query they put readOnly true

# Modifications

- spring data KotlinJdslJpqlExecutor class's `@Transactional` readOnly option changed(false -> true) for select query

# Result

- in select query readOnly option changed true -> false

# Closes

- closes #708
