### PR TITLE
[ISSUE-708] change @Transactional readOnly for select query

### DIFF
--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -28,9 +28,9 @@ import javax.persistence.Query
 import javax.persistence.TypedQuery
 import kotlin.reflect.KClass
 
-@Transactional
 @NoRepositoryBean
 @SinceJdsl("3.0.0")
+@Transactional(readOnly = true)
 open class KotlinJdslJpqlExecutorImpl(
     private val entityManager: EntityManager,
     private val renderContext: RenderContext,
@@ -143,12 +143,14 @@ open class KotlinJdslJpqlExecutorImpl(
         return createSlice(query, query.returnType, pageable)
     }
 
+    @Transactional
     override fun <T : Any> update(
         init: Jpql.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
         return update(Jpql, init)
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> update(
         dsl: JpqlDsl.Constructor<DSL>,
         init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
@@ -159,6 +161,7 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> update(
         dsl: DSL,
         init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
@@ -169,12 +172,14 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    @Transactional
     override fun <T : Any> delete(
         init: Jpql.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
         return delete(Jpql, init)
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> delete(
         dsl: JpqlDsl.Constructor<DSL>,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
@@ -185,6 +190,7 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> delete(
         dsl: DSL,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -30,9 +30,9 @@ import org.springframework.data.support.PageableExecutionUtilsAdaptor
 import org.springframework.transaction.annotation.Transactional
 import kotlin.reflect.KClass
 
-@Transactional
 @NoRepositoryBean
 @SinceJdsl("3.0.0")
+@Transactional(readOnly = true)
 open class KotlinJdslJpqlExecutorImpl(
     private val entityManager: EntityManager,
     private val renderContext: RenderContext,
@@ -145,12 +145,14 @@ open class KotlinJdslJpqlExecutorImpl(
         return createSlice(query, query.returnType, pageable)
     }
 
+    @Transactional
     override fun <T : Any> update(
         init: Jpql.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
         return update(Jpql, init)
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> update(
         dsl: JpqlDsl.Constructor<DSL>,
         init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
@@ -161,6 +163,7 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> update(
         dsl: DSL,
         init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
@@ -171,12 +174,14 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    @Transactional
     override fun <T : Any> delete(
         init: Jpql.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
         return delete(Jpql, init)
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> delete(
         dsl: JpqlDsl.Constructor<DSL>,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
@@ -187,6 +192,7 @@ open class KotlinJdslJpqlExecutorImpl(
         return jpaQuery.executeUpdate()
     }
 
+    @Transactional
     override fun <T : Any, DSL : JpqlDsl> delete(
         dsl: DSL,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,


### PR DESCRIPTION
# Motivation

- in spring data jpa SimpleJpaRepository class declare `@Transactional` but in select query they put readOnly true

# Modifications

- spring data KotlinJdslJpqlExecutor class's `@Transactional` readOnly option changed(false -> true) for select query

# Result

- in select query readOnly option changed true -> false

# Closes

- closes #708
