### PR TITLE
modify entity, join serializers to allow specify entity() as the on clause predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-Visit [the gitbook](https://kotlin-jdsl.gitbook.io/docs/) for more information.
+Visit [the gitbook](https://kotlin-jdsl.gitbook.io/snapshot-docs/) for more information.
 
 # Kotlin JDSL
 
 <a href="https://github.com/line/kotlin-jdsl"><img src="https://img.shields.io/github/stars/line/kotlin-jdsl.svg?style=social" /></a>
 <a href="https://discord.gg/7FH8c6npmg"><img src="https://img.shields.io/badge/chat-on%20Discord-brightgreen.svg?style=social&amp;logo=discord" /></a>
 <a href="https://github.com/line/kotlin-jdsl/contributors"><img src="https://img.shields.io/github/contributors/line/kotlin-jdsl.svg" /></a>
-<a href="https://codecov.io/gh/line/kotlin-jdsl"><img src="https://codecov.io/gh/line/kotlin-jdsl/branch/main/graph/badge.svg"/></a>
+<a href="https://codecov.io/gh/line/kotlin-jdsl"><img src="https://codecov.io/gh/line/kotlin-jdsl/branch/develop/graph/badge.svg"/></a>
 <a href="https://github.com/line/kotlin-jdsl/pulse"><img src="https://img.shields.io/github/commit-activity/m/line/kotlin-jdsl.svg?label=commits" /></a>
 <a href="https://search.maven.org/search?q=g:com.linecorp.kotlin-jdsl"><img src="https://img.shields.io/maven-central/v/com.linecorp.kotlin-jdsl/kotlin-jdsl.svg?label=version" /></a>
 <a href="https://github.com/line/kotlin-jdsl/commits"><img src="https://img.shields.io/github/release-date/line/kotlin-jdsl.svg?label=release" /></a>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ allprojects {
     apply(plugin = "signing")
 
     group = "com.linecorp.kotlin-jdsl"
-    version = "3.5.0"
+    version = "3.6.0-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,5 +1,5 @@
 ---
-description: 'Latest stable version: 3.5.0'
+description: 'Latest stable version: 3.6.0-SNAPSHOT'
 ---
 
 # Kotlin JDSL

--- a/docs/en/jpql-with-kotlin-jdsl/README.md
+++ b/docs/en/jpql-with-kotlin-jdsl/README.md
@@ -99,8 +99,8 @@ The following dependencies are the minimum requirement for all Kotlin JDSL appli
 
 ```kotlin
 dependencies {
-    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.5.0")
-    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.5.0")
+    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.6.0-SNAPSHOT")
+    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.6.0-SNAPSHOT")
 }
 ```
 
@@ -110,8 +110,8 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.linecorp.kotlin-jdsl:jpql-dsl:3.5.0'
-    implementation 'com.linecorp.kotlin-jdsl:jpql-render:3.5.0'
+    implementation 'com.linecorp.kotlin-jdsl:jpql-dsl:3.6.0-SNAPSHOT'
+    implementation 'com.linecorp.kotlin-jdsl:jpql-render:3.6.0-SNAPSHOT'
 }
 ```
 
@@ -125,12 +125,12 @@ dependencies {
     <dependency>
         <groupId>com.linecorp.kotlin-jdsl</groupId>
         <artifactId>jpql-dsl</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
         <groupId>com.linecorp.kotlin-jdsl</groupId>
         <artifactId>jpql-render</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -1,5 +1,5 @@
 ---
-description: 'Latest stable version: 3.5.0'
+description: 'Latest stable version: 3.6.0-SNAPSHOT'
 ---
 
 # Kotlin JDSL

--- a/docs/ko/jpql-with-kotlin-jdsl/README.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/README.md
@@ -100,8 +100,8 @@ Kotlin JDSL을 실행시키기 위해서는 다음 dependency들이 필수로 �
 
 ```kotlin
 dependencies {
-    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.5.0")
-    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.5.0")
+    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.6.0-SNAPSHOT")
+    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.6.0-SNAPSHOT")
 }
 ```
 
@@ -111,8 +111,8 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.linecorp.kotlin-jdsl:jpql-dsl:3.5.0'
-    implementation 'com.linecorp.kotlin-jdsl:jpql-render:3.5.0'
+    implementation 'com.linecorp.kotlin-jdsl:jpql-dsl:3.6.0-SNAPSHOT'
+    implementation 'com.linecorp.kotlin-jdsl:jpql-render:3.6.0-SNAPSHOT'
 }
 ```
 
@@ -126,12 +126,12 @@ dependencies {
     <dependency>
         <groupId>com.linecorp.kotlin-jdsl</groupId>
         <artifactId>jpql-dsl</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0-SNAPSHOT</version>
     </dependency>
     <dependency>
         <groupId>com.linecorp.kotlin-jdsl</groupId>
         <artifactId>jpql-render</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```

--- a/example/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/SelectExample.kt
+++ b/example/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/SelectExample.kt
@@ -4,6 +4,7 @@ import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.author.Author
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Book
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.BookAuthor
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.BookPublisher
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Isbn
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.employee.Employee
 import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.employee.EmployeeDepartment
@@ -49,6 +50,24 @@ class SelectExample : WithAssertions {
 
         // then
         assertThat(actual).isEqualTo(1L)
+    }
+
+    @Test
+    fun `books reference specific book publisher entity`() {
+        // when
+        val actual = bookRepository.findAll {
+            select(
+                path(Book::isbn),
+            ).from(
+                entity(Book::class),
+                join(entity(BookPublisher::class)).on(path(BookPublisher::book).eq(entity(Book::class))),
+            ).where(
+                path(BookPublisher::publisherId).eq(3),
+            )
+        }
+
+        // then
+        assertThat(actual).isEqualTo(listOf(Isbn("10"), Isbn("11"), Isbn("12")))
     }
 
     @Test

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/JpqlRenderClause.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/JpqlRenderClause.kt
@@ -26,10 +26,10 @@ sealed class JpqlRenderClause : AbstractRenderContextElement(Key) {
     @SinceJdsl("3.0.0")
     open fun isFrom(): Boolean = false
 
-    @SinceJdsl("3.0.0")
+    @SinceJdsl("3.5.1")
     open fun isJoin(): Boolean = false
 
-    @SinceJdsl("3.0.0")
+    @SinceJdsl("3.5.1")
     open fun isOn(): Boolean = false
 
     @SinceJdsl("3.0.0")
@@ -79,14 +79,14 @@ sealed class JpqlRenderClause : AbstractRenderContextElement(Key) {
         override fun toString(): String = "From"
     }
 
-    @SinceJdsl("3.5.0")
+    @SinceJdsl("3.5.1")
     object Join : JpqlRenderClause() {
         override fun isJoin(): Boolean = true
 
         override fun toString(): String = "Join"
     }
 
-    @SinceJdsl("3.5.0")
+    @SinceJdsl("3.5.1")
     object On : JpqlRenderClause() {
         override fun isOn(): Boolean = true
 

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/JpqlRenderClause.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/JpqlRenderClause.kt
@@ -27,6 +27,12 @@ sealed class JpqlRenderClause : AbstractRenderContextElement(Key) {
     open fun isFrom(): Boolean = false
 
     @SinceJdsl("3.0.0")
+    open fun isJoin(): Boolean = false
+
+    @SinceJdsl("3.0.0")
+    open fun isOn(): Boolean = false
+
+    @SinceJdsl("3.0.0")
     open fun isWhere(): Boolean = false
 
     @SinceJdsl("3.0.0")
@@ -71,6 +77,20 @@ sealed class JpqlRenderClause : AbstractRenderContextElement(Key) {
         override fun isFrom(): Boolean = true
 
         override fun toString(): String = "From"
+    }
+
+    @SinceJdsl("3.5.0")
+    object Join : JpqlRenderClause() {
+        override fun isJoin(): Boolean = true
+
+        override fun toString(): String = "Join"
+    }
+
+    @SinceJdsl("3.5.0")
+    object On : JpqlRenderClause() {
+        override fun isOn(): Boolean = true
+
+        override fun toString(): String = "On"
     }
 
     @SinceJdsl("3.0.0")

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlDerivedEntitySerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlDerivedEntitySerializer.kt
@@ -24,6 +24,7 @@ class JpqlDerivedEntitySerializer : JpqlSerializer<JpqlDerivedEntity<*>> {
 
         if (
             (statement.isSelect() && clause.isFrom()) ||
+            (statement.isSelect() && clause.isJoin()) ||
             (statement.isUpdate() && clause.isUpdate()) ||
             (statement.isDelete() && clause.isDeleteFrom())
         ) {

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlEntitySerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlEntitySerializer.kt
@@ -22,6 +22,7 @@ class JpqlEntitySerializer : JpqlSerializer<JpqlEntity<*>> {
 
         if (
             (statement.isSelect() && clause.isFrom()) ||
+            (statement.isSelect() && clause.isJoin()) ||
             (statement.isUpdate() && clause.isUpdate()) ||
             (statement.isDelete() && clause.isDeleteFrom())
         ) {

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerAssociationFetchJoinSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerAssociationFetchJoinSerializer.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.join.impl.JpqlInnerAssociationFetchJoin
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -20,7 +21,8 @@ class JpqlInnerAssociationFetchJoinSerializer : JpqlSerializer<JpqlInnerAssociat
         writer.write("INNER JOIN FETCH")
         writer.write(" ")
 
-        delegate.serialize(part.association, writer, context)
+        val newJoinContext = context + JpqlRenderClause.Join
+        delegate.serialize(part.association, writer, newJoinContext)
 
         writer.write(" ")
         writer.write("AS")
@@ -35,7 +37,8 @@ class JpqlInnerAssociationFetchJoinSerializer : JpqlSerializer<JpqlInnerAssociat
             writer.write("ON")
             writer.write(" ")
 
-            delegate.serialize(on, writer, context)
+            val newOnContext = context + JpqlRenderClause.On
+            delegate.serialize(on, writer, newOnContext)
         }
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerAssociationJoinSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerAssociationJoinSerializer.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.join.impl.JpqlInnerAssociationJoin
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -20,7 +21,8 @@ class JpqlInnerAssociationJoinSerializer : JpqlSerializer<JpqlInnerAssociationJo
         writer.write("INNER JOIN")
         writer.write(" ")
 
-        delegate.serialize(part.association, writer, context)
+        val newJoinContext = context + JpqlRenderClause.Join
+        delegate.serialize(part.association, writer, newJoinContext)
 
         writer.write(" ")
         writer.write("AS")
@@ -35,7 +37,8 @@ class JpqlInnerAssociationJoinSerializer : JpqlSerializer<JpqlInnerAssociationJo
             writer.write("ON")
             writer.write(" ")
 
-            delegate.serialize(on, writer, context)
+            val newOnContext = context + JpqlRenderClause.On
+            delegate.serialize(on, writer, newOnContext)
         }
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerFetchJoinSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerFetchJoinSerializer.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.join.impl.JpqlInnerFetchJoin
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -20,12 +21,14 @@ class JpqlInnerFetchJoinSerializer : JpqlSerializer<JpqlInnerFetchJoin<*>> {
         writer.write("INNER JOIN FETCH")
         writer.write(" ")
 
-        delegate.serialize(part.entity, writer, context)
+        val newJoinContext = context + JpqlRenderClause.Join
+        delegate.serialize(part.entity, writer, newJoinContext)
 
         writer.write(" ")
         writer.write("ON")
         writer.write(" ")
 
-        delegate.serialize(part.on, writer, context)
+        val newOnContext = context + JpqlRenderClause.On
+        delegate.serialize(part.on, writer, newOnContext)
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerJoinSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerJoinSerializer.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.join.impl.JpqlInnerJoin
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -20,12 +21,14 @@ class JpqlInnerJoinSerializer : JpqlSerializer<JpqlInnerJoin<*>> {
         writer.write("INNER JOIN")
         writer.write(" ")
 
-        delegate.serialize(part.entity, writer, context)
+        val newJoinContext = context + JpqlRenderClause.Join
+        delegate.serialize(part.entity, writer, newJoinContext)
 
         writer.write(" ")
         writer.write("ON")
         writer.write(" ")
 
-        delegate.serialize(part.on, writer, context)
+        val newOnContext = context + JpqlRenderClause.On
+        delegate.serialize(part.on, writer, newOnContext)
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftAssociationFetchJoinSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftAssociationFetchJoinSerializer.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.join.impl.JpqlLeftAssociationFetchJoin
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -20,7 +21,8 @@ class JpqlLeftAssociationFetchJoinSerializer : JpqlSerializer<JpqlLeftAssociatio
         writer.write("LEFT JOIN FETCH")
         writer.write(" ")
 
-        delegate.serialize(part.association, writer, context)
+        val newJoinContext = context + JpqlRenderClause.Join
+        delegate.serialize(part.association, writer, newJoinContext)
 
         writer.write(" ")
         writer.write("AS")
@@ -35,7 +37,8 @@ class JpqlLeftAssociationFetchJoinSerializer : JpqlSerializer<JpqlLeftAssociatio
             writer.write("ON")
             writer.write(" ")
 
-            delegate.serialize(on, writer, context)
+            val newOnContext = context + JpqlRenderClause.On
+            delegate.serialize(on, writer, newOnContext)
         }
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftAssociationJoinSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftAssociationJoinSerializer.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.join.impl.JpqlLeftAssociationJoin
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -20,7 +21,8 @@ class JpqlLeftAssociationJoinSerializer : JpqlSerializer<JpqlLeftAssociationJoin
         writer.write("LEFT JOIN")
         writer.write(" ")
 
-        delegate.serialize(part.association, writer, context)
+        val newJoinContext = context + JpqlRenderClause.Join
+        delegate.serialize(part.association, writer, newJoinContext)
 
         writer.write(" ")
         writer.write("AS")
@@ -35,7 +37,8 @@ class JpqlLeftAssociationJoinSerializer : JpqlSerializer<JpqlLeftAssociationJoin
             writer.write("ON")
             writer.write(" ")
 
-            delegate.serialize(on, writer, context)
+            val newOnContext = context + JpqlRenderClause.On
+            delegate.serialize(on, writer, newOnContext)
         }
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftFetchJoinSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftFetchJoinSerializer.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.join.impl.JpqlLeftFetchJoin
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -20,12 +21,14 @@ class JpqlLeftFetchJoinSerializer : JpqlSerializer<JpqlLeftFetchJoin<*>> {
         writer.write("LEFT JOIN FETCH")
         writer.write(" ")
 
-        delegate.serialize(part.entity, writer, context)
+        val newJoinContext = context + JpqlRenderClause.Join
+        delegate.serialize(part.entity, writer, newJoinContext)
 
         writer.write(" ")
         writer.write("ON")
         writer.write(" ")
 
-        delegate.serialize(part.on, writer, context)
+        val newOnContext = context + JpqlRenderClause.On
+        delegate.serialize(part.on, writer, newOnContext)
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftJoinSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftJoinSerializer.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.join.impl.JpqlLeftJoin
 import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -16,16 +17,17 @@ class JpqlLeftJoinSerializer : JpqlSerializer<JpqlLeftJoin<*>> {
 
     override fun serialize(part: JpqlLeftJoin<*>, writer: JpqlWriter, context: RenderContext) {
         val delegate = context.getValue(JpqlRenderSerializer)
-
         writer.write("LEFT JOIN")
         writer.write(" ")
 
-        delegate.serialize(part.entity, writer, context)
+        val newJoinContext = context + JpqlRenderClause.Join
+        delegate.serialize(part.entity, writer, newJoinContext)
 
         writer.write(" ")
         writer.write("ON")
         writer.write(" ")
 
-        delegate.serialize(part.on, writer, context)
+        val newOnContext = context + JpqlRenderClause.On
+        delegate.serialize(part.on, writer, newOnContext)
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlDerivedEntitySerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlDerivedEntitySerializerTest.kt
@@ -51,6 +51,7 @@ class JpqlDerivedEntitySerializerTest : WithAssertions {
     @StatementClauseSource(
         includes = [
             StatementClause(JpqlRenderStatement.Select::class, JpqlRenderClause.From::class),
+            StatementClause(JpqlRenderStatement.Select::class, JpqlRenderClause.Join::class),
             StatementClause(JpqlRenderStatement.Update::class, JpqlRenderClause.Update::class),
             StatementClause(JpqlRenderStatement.Delete::class, JpqlRenderClause.DeleteFrom::class),
         ],
@@ -84,6 +85,7 @@ class JpqlDerivedEntitySerializerTest : WithAssertions {
     @StatementClauseSource(
         excludes = [
             StatementClause(JpqlRenderStatement.Select::class, JpqlRenderClause.From::class),
+            StatementClause(JpqlRenderStatement.Select::class, JpqlRenderClause.Join::class),
             StatementClause(JpqlRenderStatement.Update::class, JpqlRenderClause.Update::class),
             StatementClause(JpqlRenderStatement.Delete::class, JpqlRenderClause.DeleteFrom::class),
         ],

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlEntitySerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlEntitySerializerTest.kt
@@ -49,6 +49,7 @@ internal class JpqlEntitySerializerTest : WithAssertions {
     @StatementClauseSource(
         includes = [
             StatementClause(JpqlRenderStatement.Select::class, JpqlRenderClause.From::class),
+            StatementClause(JpqlRenderStatement.Select::class, JpqlRenderClause.Join::class),
             StatementClause(JpqlRenderStatement.Update::class, JpqlRenderClause.Update::class),
             StatementClause(JpqlRenderStatement.Delete::class, JpqlRenderClause.DeleteFrom::class),
         ],
@@ -81,6 +82,7 @@ internal class JpqlEntitySerializerTest : WithAssertions {
     @StatementClauseSource(
         excludes = [
             StatementClause(JpqlRenderStatement.Select::class, JpqlRenderClause.From::class),
+            StatementClause(JpqlRenderStatement.Select::class, JpqlRenderClause.Join::class),
             StatementClause(JpqlRenderStatement.Update::class, JpqlRenderClause.Update::class),
             StatementClause(JpqlRenderStatement.Delete::class, JpqlRenderClause.DeleteFrom::class),
         ],

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerAssociationFetchJoinSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerAssociationFetchJoinSerializerTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.path.Paths
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
 import com.linecorp.kotlinjdsl.render.TestRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -60,7 +61,7 @@ class JpqlInnerAssociationFetchJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("INNER JOIN FETCH")
             writer.write(" ")
-            serializer.serialize(path1, writer, context)
+            serializer.serialize(path1, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("AS")
             writer.write(" ")
@@ -85,7 +86,7 @@ class JpqlInnerAssociationFetchJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("INNER JOIN FETCH")
             writer.write(" ")
-            serializer.serialize(path1, writer, context)
+            serializer.serialize(path1, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("AS")
             writer.write(" ")
@@ -93,7 +94,7 @@ class JpqlInnerAssociationFetchJoinSerializerTest : WithAssertions {
             writer.write(" ")
             writer.write("ON")
             writer.write(" ")
-            serializer.serialize(predicate1, writer, context)
+            serializer.serialize(predicate1, writer, context + JpqlRenderClause.On)
         }
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerAssociationJoinSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerAssociationJoinSerializerTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.path.Paths
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
 import com.linecorp.kotlinjdsl.render.TestRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -60,7 +61,7 @@ class JpqlInnerAssociationJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("INNER JOIN")
             writer.write(" ")
-            serializer.serialize(path1, writer, context)
+            serializer.serialize(path1, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("AS")
             writer.write(" ")
@@ -85,7 +86,7 @@ class JpqlInnerAssociationJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("INNER JOIN")
             writer.write(" ")
-            serializer.serialize(path1, writer, context)
+            serializer.serialize(path1, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("AS")
             writer.write(" ")
@@ -93,7 +94,7 @@ class JpqlInnerAssociationJoinSerializerTest : WithAssertions {
             writer.write(" ")
             writer.write("ON")
             writer.write(" ")
-            serializer.serialize(predicate1, writer, context)
+            serializer.serialize(predicate1, writer, context + JpqlRenderClause.On)
         }
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerFetchJoinSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerFetchJoinSerializerTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
 import com.linecorp.kotlinjdsl.render.TestRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.entity.author.Author
 import com.linecorp.kotlinjdsl.render.jpql.entity.book.BookAuthor
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -58,11 +59,11 @@ class JpqlInnerFetchJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("INNER JOIN FETCH")
             writer.write(" ")
-            serializer.serialize(part.entity, writer, context)
+            serializer.serialize(part.entity, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("ON")
             writer.write(" ")
-            serializer.serialize(part.on, writer, context)
+            serializer.serialize(part.on, writer, context + JpqlRenderClause.On)
         }
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerJoinSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlInnerJoinSerializerTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
 import com.linecorp.kotlinjdsl.render.TestRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.entity.author.Author
 import com.linecorp.kotlinjdsl.render.jpql.entity.book.BookAuthor
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -58,11 +59,11 @@ class JpqlInnerJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("INNER JOIN")
             writer.write(" ")
-            serializer.serialize(part.entity, writer, context)
+            serializer.serialize(part.entity, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("ON")
             writer.write(" ")
-            serializer.serialize(part.on, writer, context)
+            serializer.serialize(part.on, writer, context + JpqlRenderClause.On)
         }
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftAssociationFetchJoinSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftAssociationFetchJoinSerializerTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.path.Paths
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
 import com.linecorp.kotlinjdsl.render.TestRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -60,7 +61,7 @@ class JpqlLeftAssociationFetchJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("LEFT JOIN FETCH")
             writer.write(" ")
-            serializer.serialize(path1, writer, context)
+            serializer.serialize(path1, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("AS")
             writer.write(" ")
@@ -85,7 +86,7 @@ class JpqlLeftAssociationFetchJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("LEFT JOIN FETCH")
             writer.write(" ")
-            serializer.serialize(path1, writer, context)
+            serializer.serialize(path1, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("AS")
             writer.write(" ")
@@ -93,7 +94,7 @@ class JpqlLeftAssociationFetchJoinSerializerTest : WithAssertions {
             writer.write(" ")
             writer.write("ON")
             writer.write(" ")
-            serializer.serialize(predicate1, writer, context)
+            serializer.serialize(predicate1, writer, context + JpqlRenderClause.On)
         }
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftAssociationJoinSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftAssociationJoinSerializerTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.path.Paths
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
 import com.linecorp.kotlinjdsl.render.TestRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -60,7 +61,7 @@ class JpqlLeftAssociationJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("LEFT JOIN")
             writer.write(" ")
-            serializer.serialize(path1, writer, context)
+            serializer.serialize(path1, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("AS")
             writer.write(" ")
@@ -85,7 +86,7 @@ class JpqlLeftAssociationJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("LEFT JOIN")
             writer.write(" ")
-            serializer.serialize(path1, writer, context)
+            serializer.serialize(path1, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("AS")
             writer.write(" ")
@@ -93,7 +94,7 @@ class JpqlLeftAssociationJoinSerializerTest : WithAssertions {
             writer.write(" ")
             writer.write("ON")
             writer.write(" ")
-            serializer.serialize(predicate1, writer, context)
+            serializer.serialize(predicate1, writer, context + JpqlRenderClause.On)
         }
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftFetchJoinSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftFetchJoinSerializerTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
 import com.linecorp.kotlinjdsl.render.TestRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.entity.author.Author
 import com.linecorp.kotlinjdsl.render.jpql.entity.book.BookAuthor
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -58,11 +59,11 @@ class JpqlLeftFetchJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("LEFT JOIN FETCH")
             writer.write(" ")
-            serializer.serialize(entity1, writer, context)
+            serializer.serialize(entity1, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("ON")
             writer.write(" ")
-            serializer.serialize(predicate1, writer, context)
+            serializer.serialize(predicate1, writer, context + JpqlRenderClause.On)
         }
     }
 }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftJoinSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftJoinSerializerTest.kt
@@ -8,6 +8,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
 import com.linecorp.kotlinjdsl.render.TestRenderContext
 import com.linecorp.kotlinjdsl.render.jpql.entity.author.Author
 import com.linecorp.kotlinjdsl.render.jpql.entity.book.BookAuthor
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
@@ -58,11 +59,11 @@ class JpqlLeftJoinSerializerTest : WithAssertions {
         verifySequence {
             writer.write("LEFT JOIN")
             writer.write(" ")
-            serializer.serialize(entity1, writer, context)
+            serializer.serialize(entity1, writer, context + JpqlRenderClause.Join)
             writer.write(" ")
             writer.write("ON")
             writer.write(" ")
-            serializer.serialize(predicate1, writer, context)
+            serializer.serialize(predicate1, writer, context + JpqlRenderClause.On)
         }
     }
 }


### PR DESCRIPTION
# Motivation

- Bug when creating a Predicate inside the on() method, using entity() added 'AS [alias]' resulting in syntax error
- Republishing due to changes in the from branch #729 

# Modifications

- Add Join, On clause to JpqlRenderClause 
- Modified conditional statements to include Join, On clause in EntitySerialiser (so that 'AS alias' is not added when serialising entities in On clause)
- Add code to update JpqlRenderClause to Join, On in FetchJoin, Join, Association join serialisers
- Modify test code according to serialiser modification

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- 'AS [alias]' is not added when writing predicates for entity() in On clauses

# Closes

- #{issue number} (If this PR resolves an issue.)
