### PR TITLE
feat: support limit in spring data repository

### DIFF
--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutor.kt
@@ -20,6 +20,8 @@ interface KotlinJdslJpqlExecutor {
      */
     @SinceJdsl("3.0.0")
     fun <T : Any> findAll(
+        offset: Int? = null,
+        limit: Int? = null,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?>
 
@@ -29,6 +31,8 @@ interface KotlinJdslJpqlExecutor {
     @SinceJdsl("3.0.0")
     fun <T : Any, DSL : JpqlDsl> findAll(
         dsl: JpqlDsl.Constructor<DSL>,
+        offset: Int? = null,
+        limit: Int? = null,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?>
 
@@ -38,6 +42,8 @@ interface KotlinJdslJpqlExecutor {
     @SinceJdsl("3.4.0")
     fun <T : Any, DSL : JpqlDsl> findAll(
         dsl: DSL,
+        offset: Int? = null,
+        limit: Int? = null,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?>
 

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -41,7 +41,7 @@ open class KotlinJdslJpqlExecutorImpl(
         limit: Int?,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
-        return findAll(Jpql, offset, limit, init)
+        return findAll(Jpql, offset = offset, limit = limit, init)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findAll(
@@ -50,7 +50,7 @@ open class KotlinJdslJpqlExecutorImpl(
         limit: Int?,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
-        return findAll(dsl.newInstance(), offset, limit, init)
+        return findAll(dsl.newInstance(), offset = offset, limit = limit, init)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findAll(

--- a/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImplTest.kt
+++ b/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImplTest.kt
@@ -133,6 +133,10 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     @MockK
     private lateinit var page1: Page<String>
 
+    private val offset1 = 10
+
+    private val limit1 = 20
+
     private val lockModeType1 = LockModeType.READ
 
     private val queryHint1 = "queryHintName1" to "queryHintValue1"
@@ -268,12 +272,14 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         } returns stringTypedQuery1
         every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
         every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
         every { stringTypedQuery1.resultList } returns list1
         every { metadata.lockModeType } returns lockModeType1
         every { metadata.queryHints } returns queryHints1
 
         // when
-        val actual = sut.findAll(createSelectQuery1)
+        val actual = sut.findAll(offset1, limit1, createSelectQuery1)
 
         // then
         assertThat(actual).isEqualTo(list1)
@@ -287,6 +293,8 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
             stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
             stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.setFirstResult(offset1)
+            stringTypedQuery1.setMaxResults(limit1)
             stringTypedQuery1.resultList
         }
     }
@@ -300,12 +308,14 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         } returns stringTypedQuery2
         every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
         every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
         every { stringTypedQuery2.resultList } returns list1
         every { metadata.lockModeType } returns lockModeType1
         every { metadata.queryHints } returns queryHints1
 
         // when
-        val actual = sut.findAll(MyJpql, createSelectQuery2)
+        val actual = sut.findAll(MyJpql, offset1, limit1, createSelectQuery2)
 
         // then
         assertThat(actual).isEqualTo(list1)
@@ -319,6 +329,8 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
             stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
             stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.setFirstResult(offset1)
+            stringTypedQuery2.setMaxResults(limit1)
             stringTypedQuery2.resultList
         }
     }
@@ -332,12 +344,14 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         } returns stringTypedQuery3
         every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
         every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
         every { stringTypedQuery3.resultList } returns list1
         every { metadata.lockModeType } returns lockModeType1
         every { metadata.queryHints } returns queryHints1
 
         // when
-        val actual = sut.findAll(MyJpqlObject, createSelectQuery3)
+        val actual = sut.findAll(MyJpqlObject, offset1, limit1, createSelectQuery3)
 
         // then
         assertThat(actual).isEqualTo(list1)
@@ -351,6 +365,8 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
             stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
             stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.setFirstResult(offset1)
+            stringTypedQuery3.setMaxResults(limit1)
             stringTypedQuery3.resultList
         }
     }

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
@@ -20,6 +20,8 @@ interface KotlinJdslJpqlExecutor {
      */
     @SinceJdsl("3.0.0")
     fun <T : Any> findAll(
+        offset: Int? = null,
+        limit: Int? = null,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?>
 
@@ -29,6 +31,8 @@ interface KotlinJdslJpqlExecutor {
     @SinceJdsl("3.0.0")
     fun <T : Any, DSL : JpqlDsl> findAll(
         dsl: JpqlDsl.Constructor<DSL>,
+        offset: Int? = null,
+        limit: Int? = null,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?>
 
@@ -38,6 +42,8 @@ interface KotlinJdslJpqlExecutor {
     @SinceJdsl("3.4.0")
     fun <T : Any, DSL : JpqlDsl> findAll(
         dsl: DSL,
+        offset: Int? = null,
+        limit: Int? = null,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?>
 

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -39,27 +39,33 @@ open class KotlinJdslJpqlExecutorImpl(
     private val metadata: CrudMethodMetadata?,
 ) : KotlinJdslJpqlExecutor {
     override fun <T : Any> findAll(
+        offset: Int?,
+        limit: Int?,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
-        return findAll(Jpql, init)
+        return findAll(Jpql, offset, limit, init)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findAll(
         dsl: JpqlDsl.Constructor<DSL>,
+        offset: Int?,
+        limit: Int?,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
-        val query: SelectQuery<T> = jpql(dsl, init)
-        val jpaQuery = createJpaQuery(query, query.returnType)
-
-        return jpaQuery.resultList
+        return findAll(dsl.newInstance(), offset, limit, init)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findAll(
         dsl: DSL,
+        offset: Int?,
+        limit: Int?,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
-        val jpaQuery = createJpaQuery(query, query.returnType)
+        val jpaQuery = createJpaQuery(query, query.returnType).apply {
+            offset?.let { setFirstResult(it) }
+            limit?.let { setMaxResults(it) }
+        }
 
         return jpaQuery.resultList
     }
@@ -76,9 +82,7 @@ open class KotlinJdslJpqlExecutorImpl(
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
-        val query: SelectQuery<T> = jpql(dsl, init)
-
-        return createList(query, query.returnType, pageable)
+        return findAll(dsl.newInstance(), pageable, init)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findAll(
@@ -103,9 +107,7 @@ open class KotlinJdslJpqlExecutorImpl(
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): Page<T?> {
-        val query: SelectQuery<T> = jpql(dsl, init)
-
-        return createPage(query, query.returnType, pageable)
+        return findPage(dsl.newInstance(), pageable, init)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findPage(
@@ -130,9 +132,7 @@ open class KotlinJdslJpqlExecutorImpl(
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): Slice<T?> {
-        val query: SelectQuery<T> = jpql(dsl, init)
-
-        return createSlice(query, query.returnType, pageable)
+        return findSlice(dsl.newInstance(), pageable, init)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findSlice(
@@ -157,10 +157,7 @@ open class KotlinJdslJpqlExecutorImpl(
         dsl: JpqlDsl.Constructor<DSL>,
         init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
     ): Int {
-        val query: UpdateQuery<T> = jpql(dsl, init)
-        val jpaQuery = createJpaQuery(query)
-
-        return jpaQuery.executeUpdate()
+        return update(dsl.newInstance(), init)
     }
 
     @Transactional
@@ -186,10 +183,7 @@ open class KotlinJdslJpqlExecutorImpl(
         dsl: JpqlDsl.Constructor<DSL>,
         init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
     ): Int {
-        val query: DeleteQuery<T> = jpql(dsl, init)
-        val jpaQuery = createJpaQuery(query)
-
-        return jpaQuery.executeUpdate()
+        return delete(dsl.newInstance(), init)
     }
 
     @Transactional

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -43,7 +43,7 @@ open class KotlinJdslJpqlExecutorImpl(
         limit: Int?,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
-        return findAll(Jpql, offset, limit, init)
+        return findAll(Jpql, offset = offset, limit = limit, init)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findAll(
@@ -52,7 +52,7 @@ open class KotlinJdslJpqlExecutorImpl(
         limit: Int?,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
-        return findAll(dsl.newInstance(), offset, limit, init)
+        return findAll(dsl.newInstance(), offset = offset, limit = limit, init)
     }
 
     override fun <T : Any, DSL : JpqlDsl> findAll(

--- a/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImplTest.kt
+++ b/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImplTest.kt
@@ -133,6 +133,10 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     @MockK
     private lateinit var page1: Page<String>
 
+    private val offset1 = 10
+
+    private val limit1 = 20
+
     private val lockModeType1 = LockModeType.READ
 
     private val queryHint1 = "queryHintName1" to "queryHintValue1"
@@ -268,12 +272,14 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         } returns stringTypedQuery1
         every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
         every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
         every { stringTypedQuery1.resultList } returns list1
         every { metadata.lockModeType } returns lockModeType1
         every { metadata.queryHints } returns queryHints1
 
         // when
-        val actual = sut.findAll(createSelectQuery1)
+        val actual = sut.findAll(offset1, limit1, createSelectQuery1)
 
         // then
         assertThat(actual).isEqualTo(list1)
@@ -287,6 +293,8 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
             stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
             stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.setFirstResult(offset1)
+            stringTypedQuery1.setMaxResults(limit1)
             stringTypedQuery1.resultList
         }
     }
@@ -300,12 +308,14 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         } returns stringTypedQuery2
         every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
         every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
         every { stringTypedQuery2.resultList } returns list1
         every { metadata.lockModeType } returns lockModeType1
         every { metadata.queryHints } returns queryHints1
 
         // when
-        val actual = sut.findAll(MyJpql, createSelectQuery2)
+        val actual = sut.findAll(MyJpql, offset1, limit1, createSelectQuery2)
 
         // then
         assertThat(actual).isEqualTo(list1)
@@ -319,6 +329,8 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
             stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
             stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.setFirstResult(offset1)
+            stringTypedQuery2.setMaxResults(limit1)
             stringTypedQuery2.resultList
         }
     }
@@ -332,12 +344,14 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         } returns stringTypedQuery3
         every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
         every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
         every { stringTypedQuery3.resultList } returns list1
         every { metadata.lockModeType } returns lockModeType1
         every { metadata.queryHints } returns queryHints1
 
         // when
-        val actual = sut.findAll(MyJpqlObject, createSelectQuery3)
+        val actual = sut.findAll(MyJpqlObject, offset1, limit1, createSelectQuery3)
 
         // then
         assertThat(actual).isEqualTo(list1)
@@ -351,6 +365,8 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
             stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
             stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.setFirstResult(offset1)
+            stringTypedQuery3.setMaxResults(limit1)
             stringTypedQuery3.resultList
         }
     }


### PR DESCRIPTION
# Motivation

- Spring Data supports a Limit class as a parameter in Repository since version 3.2.
- However, the Kotlin JDSL takes Spring Boot 2.7.9 and 3.0.3 as the minimum compatible version, which makes it difficult to support the Limit class.

# Modifications

- Add the parameters `offset: Int`, `limit: Int` to make Limit available in the Repository even for the minimum compatible Spring Boot version supported by the Kotlin JDSL.

# Result

- Users will be able to use offset and limit when using the findAll method of the KotlinJdslJpqlExecutor interface.

```kotlin
bookRepository.findAll(limit = 1) {
    select(
        path(Book::isbn),
    ).from(
        entity(Book::class),
        join(entity(BookPublisher::class)).on(path(BookPublisher::book).eq(entity(Book::class))),
    ).where(
        path(BookPublisher::publisherId).eq(3),
    )
}

bookRepository.findAll(offset = 1, limit = 1) {
    select(
        path(Book::isbn),
    ).from(
        entity(Book::class),
        join(entity(BookPublisher::class)).on(path(BookPublisher::book).eq(entity(Book::class))),
    ).where(
        path(BookPublisher::publisherId).eq(3),
    )
}
```

