### PR TITLE
fix: silently ignores exception when parameter setting to count query

### DIFF
--- a/support/eclipselink-javax/build.gradle.kts
+++ b/support/eclipselink-javax/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     compileOnly(libs.eclipselink2)
     compileOnly(libs.javax.persistence.api)
+    compileOnly(libs.slf4j)
     compileOnly(projects.jpqlDsl)
     compileOnly(projects.jpqlQueryModel)
     compileOnly(projects.jpqlRender)

--- a/support/eclipselink-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/javax/JpqlEntityManagerUtils.kt
+++ b/support/eclipselink-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/javax/JpqlEntityManagerUtils.kt
@@ -2,6 +2,7 @@ package com.linecorp.kotlinjdsl.support.eclipselink.javax
 
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
+import org.slf4j.LoggerFactory
 import javax.persistence.EntityManager
 import javax.persistence.Query
 import javax.persistence.TypedQuery
@@ -74,8 +75,20 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setParams(query: Query, params: Map<String, Any?>) {
+        val parameterNameSet = query.parameters.map { it.name }.toHashSet()
+
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            if (parameterNameSet.contains(name)) {
+                query.setParameter(name, value)
+            } else if (log.isDebugEnabled) {
+                log.debug(
+                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
+                    name,
+                    parameterNameSet.joinToString(),
+                )
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/eclipselink-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/javax/JpqlEntityManagerUtils.kt
+++ b/support/eclipselink-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/javax/JpqlEntityManagerUtils.kt
@@ -80,12 +80,14 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
-            } else if (log.isDebugEnabled) {
-                log.debug(
-                    "No parameter named '$name' in query " +
-                        "with named parameters [${parameterNameSet.joinToString()}], " +
-                        "parameter binding skipped",
-                )
+            } else {
+                if (log.isDebugEnabled) {
+                    log.debug(
+                        "No parameter named '$name' in query " +
+                            "with named parameters [${parameterNameSet.joinToString()}], " +
+                            "parameter binding skipped",
+                    )
+                }
             }
         }
     }

--- a/support/eclipselink-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/javax/JpqlEntityManagerUtils.kt
+++ b/support/eclipselink-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/javax/JpqlEntityManagerUtils.kt
@@ -82,9 +82,9 @@ internal object JpqlEntityManagerUtils {
                 query.setParameter(name, value)
             } else if (log.isDebugEnabled) {
                 log.debug(
-                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
-                    name,
-                    parameterNameSet.joinToString(),
+                    "No parameter named '$name' in query " +
+                        "with named parameters [${parameterNameSet.joinToString()}], " +
+                        "parameter binding skipped",
                 )
             }
         }

--- a/support/eclipselink-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/javax/JpqlEntityManagerUtilsTest.kt
+++ b/support/eclipselink-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/javax/JpqlEntityManagerUtilsTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import javax.persistence.EntityManager
+import javax.persistence.Parameter
 import javax.persistence.TypedQuery
 
 @ExtendWith(MockKExtension::class)
@@ -35,6 +36,12 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     @MockK
     private lateinit var stringTypedQuery1: TypedQuery<String>
 
+    @MockK
+    private lateinit var stringTypedQueryParam1: Parameter<String>
+
+    @MockK
+    private lateinit var stringTypedQueryParam2: Parameter<String>
+
     private val renderedQuery1 = "query"
     private val renderedParam1 = "queryParam1" to "queryParamValue1"
     private val renderedParam2 = "queryParam2" to "queryParamValue2"
@@ -51,6 +58,8 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         excludeRecords { JpqlRendererHolder.get() }
         excludeRecords { stringTypedQuery1.equals(any()) }
+        excludeRecords { stringTypedQueryParam1.hashCode() }
+        excludeRecords { stringTypedQueryParam2.hashCode() }
     }
 
     @Test
@@ -60,7 +69,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, String::class, context)
@@ -71,6 +83,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -83,7 +98,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -95,6 +113,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -107,7 +128,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, context)
@@ -118,6 +142,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -130,7 +157,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -142,6 +172,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }

--- a/support/eclipselink/build.gradle.kts
+++ b/support/eclipselink/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     compileOnly(libs.eclipselink3)
     compileOnly(libs.jakarta.persistence.api)
+    compileOnly(libs.slf4j)
     compileOnly(projects.jpqlDsl)
     compileOnly(projects.jpqlQueryModel)
     compileOnly(projects.jpqlRender)

--- a/support/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/JpqlEntityManagerUtils.kt
+++ b/support/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/JpqlEntityManagerUtils.kt
@@ -80,12 +80,14 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
-            } else if (log.isDebugEnabled) {
-                log.debug(
-                    "No parameter named '$name' in query " +
-                        "with named parameters [${parameterNameSet.joinToString()}], " +
-                        "parameter binding skipped",
-                )
+            } else {
+                if (log.isDebugEnabled) {
+                    log.debug(
+                        "No parameter named '$name' in query " +
+                            "with named parameters [${parameterNameSet.joinToString()}], " +
+                            "parameter binding skipped",
+                    )
+                }
             }
         }
     }

--- a/support/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/JpqlEntityManagerUtils.kt
+++ b/support/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/JpqlEntityManagerUtils.kt
@@ -82,9 +82,9 @@ internal object JpqlEntityManagerUtils {
                 query.setParameter(name, value)
             } else if (log.isDebugEnabled) {
                 log.debug(
-                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
-                    name,
-                    parameterNameSet.joinToString(),
+                    "No parameter named '$name' in query " +
+                        "with named parameters [${parameterNameSet.joinToString()}], " +
+                        "parameter binding skipped",
                 )
             }
         }

--- a/support/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/JpqlEntityManagerUtils.kt
+++ b/support/eclipselink/src/main/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/JpqlEntityManagerUtils.kt
@@ -5,6 +5,7 @@ import com.linecorp.kotlinjdsl.render.RenderContext
 import jakarta.persistence.EntityManager
 import jakarta.persistence.Query
 import jakarta.persistence.TypedQuery
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlEntityManagerUtils {
@@ -74,8 +75,20 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setParams(query: Query, params: Map<String, Any?>) {
+        val parameterNameSet = query.parameters.map { it.name }.toHashSet()
+
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            if (parameterNameSet.contains(name)) {
+                query.setParameter(name, value)
+            } else if (log.isDebugEnabled) {
+                log.debug(
+                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
+                    name,
+                    parameterNameSet.joinToString(),
+                )
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/JpqlEntityManagerUtilsTest.kt
+++ b/support/eclipselink/src/test/kotlin/com/linecorp/kotlinjdsl/support/eclipselink/JpqlEntityManagerUtilsTest.kt
@@ -12,6 +12,7 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockkObject
 import io.mockk.verifySequence
 import jakarta.persistence.EntityManager
+import jakarta.persistence.Parameter
 import jakarta.persistence.TypedQuery
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +36,12 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     @MockK
     private lateinit var stringTypedQuery1: TypedQuery<String>
 
+    @MockK
+    private lateinit var stringTypedQueryParam1: Parameter<String>
+
+    @MockK
+    private lateinit var stringTypedQueryParam2: Parameter<String>
+
     private val renderedQuery1 = "query"
     private val renderedParam1 = "queryParam1" to "queryParamValue1"
     private val renderedParam2 = "queryParam2" to "queryParamValue2"
@@ -51,6 +58,8 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         excludeRecords { JpqlRendererHolder.get() }
         excludeRecords { stringTypedQuery1.equals(any()) }
+        excludeRecords { stringTypedQueryParam1.hashCode() }
+        excludeRecords { stringTypedQueryParam2.hashCode() }
     }
 
     @Test
@@ -60,7 +69,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, String::class, context)
@@ -71,6 +83,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -83,7 +98,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -95,6 +113,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -107,7 +128,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, context)
@@ -118,6 +142,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -130,7 +157,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -142,6 +172,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }

--- a/support/hibernate-javax/build.gradle.kts
+++ b/support/hibernate-javax/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
     @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
     compileOnly(libs.hibernate5.core)
     compileOnly(libs.javax.persistence.api)
+    compileOnly(libs.slf4j)
     compileOnly(projects.jpqlDsl)
     compileOnly(projects.jpqlQueryModel)
     compileOnly(projects.jpqlRender)

--- a/support/hibernate-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
+++ b/support/hibernate-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
@@ -84,9 +84,9 @@ internal object JpqlEntityManagerUtils {
                 query.setParameter(name, value)
             } else if (log.isDebugEnabled) {
                 log.debug(
-                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
-                    name,
-                    parameterNameSet.joinToString(),
+                    "No parameter named '$name' in query " +
+                        "with named parameters [${parameterNameSet.joinToString()}], " +
+                        "parameter binding skipped",
                 )
             }
         }

--- a/support/hibernate-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
+++ b/support/hibernate-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
@@ -4,6 +4,7 @@ package com.linecorp.kotlinjdsl.support.hibernate
 
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
+import org.slf4j.LoggerFactory
 import javax.persistence.EntityManager
 import javax.persistence.Query
 import javax.persistence.TypedQuery
@@ -76,8 +77,20 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setParams(query: Query, params: Map<String, Any?>) {
+        val parameterNameSet = query.parameters.map { it.name }.toHashSet()
+
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            if (parameterNameSet.contains(name)) {
+                query.setParameter(name, value)
+            } else if (log.isDebugEnabled) {
+                log.debug(
+                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
+                    name,
+                    parameterNameSet.joinToString(),
+                )
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/hibernate-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
+++ b/support/hibernate-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
@@ -82,12 +82,14 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
-            } else if (log.isDebugEnabled) {
-                log.debug(
-                    "No parameter named '$name' in query " +
-                        "with named parameters [${parameterNameSet.joinToString()}], " +
-                        "parameter binding skipped",
-                )
+            } else {
+                if (log.isDebugEnabled) {
+                    log.debug(
+                        "No parameter named '$name' in query " +
+                            "with named parameters [${parameterNameSet.joinToString()}], " +
+                            "parameter binding skipped",
+                    )
+                }
             }
         }
     }

--- a/support/hibernate-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtilsTest.kt
+++ b/support/hibernate-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtilsTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import javax.persistence.EntityManager
+import javax.persistence.Parameter
 import javax.persistence.TypedQuery
 
 @ExtendWith(MockKExtension::class)
@@ -35,6 +36,12 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     @MockK
     private lateinit var stringTypedQuery1: TypedQuery<String>
 
+    @MockK
+    private lateinit var stringTypedQueryParam1: Parameter<String>
+
+    @MockK
+    private lateinit var stringTypedQueryParam2: Parameter<String>
+
     private val renderedQuery1 = "query"
     private val renderedParam1 = "queryParam1" to "queryParamValue1"
     private val renderedParam2 = "queryParam2" to "queryParamValue2"
@@ -51,6 +58,8 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         excludeRecords { JpqlRendererHolder.get() }
         excludeRecords { stringTypedQuery1.equals(any()) }
+        excludeRecords { stringTypedQueryParam1.hashCode() }
+        excludeRecords { stringTypedQueryParam2.hashCode() }
     }
 
     @Test
@@ -60,7 +69,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, String::class, context)
@@ -71,6 +83,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -83,7 +98,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -95,6 +113,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -107,7 +128,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, context)
@@ -118,6 +142,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -130,7 +157,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -142,6 +172,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }

--- a/support/hibernate-reactive-javax/build.gradle.kts
+++ b/support/hibernate-reactive-javax/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     compileOnly(libs.hibernate.reactive1.core)
     compileOnly(libs.javax.persistence.api)
+    compileOnly(libs.slf4j)
     compileOnly(projects.jpqlDsl)
     compileOnly(projects.jpqlQueryModel)
     compileOnly(projects.jpqlRender)

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinySessionUtils.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinySessionUtils.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.support.hibernate.reactive
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import org.hibernate.reactive.mutiny.Mutiny
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlMutinySessionUtils {
@@ -73,7 +74,15 @@ internal object JpqlMutinySessionUtils {
 
     private fun <T> setParams(query: Mutiny.Query<T>, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlMutinySessionUtils::class.java)

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinyStatelessSessionUtils.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinyStatelessSessionUtils.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.support.hibernate.reactive
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import org.hibernate.reactive.mutiny.Mutiny
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlMutinyStatelessSessionUtils {
@@ -73,7 +74,15 @@ internal object JpqlMutinyStatelessSessionUtils {
 
     private fun <T> setParams(query: Mutiny.Query<T>, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlMutinyStatelessSessionUtils::class.java)

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageSessionUtils.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageSessionUtils.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.support.hibernate.reactive
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import org.hibernate.reactive.stage.Stage
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlStageSessionUtils {
@@ -73,7 +74,15 @@ internal object JpqlStageSessionUtils {
 
     private fun <T> setParams(query: Stage.Query<T>, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlStageSessionUtils::class.java)

--- a/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageStatelessSessionUtils.kt
+++ b/support/hibernate-reactive-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageStatelessSessionUtils.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.support.hibernate.reactive
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import org.hibernate.reactive.stage.Stage
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlStageStatelessSessionUtils {
@@ -73,7 +74,15 @@ internal object JpqlStageStatelessSessionUtils {
 
     private fun <T> setParams(query: Stage.Query<T>, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlStageStatelessSessionUtils::class.java)

--- a/support/hibernate-reactive/build.gradle.kts
+++ b/support/hibernate-reactive/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     compileOnly(libs.hibernate.reactive2.core)
     compileOnly(libs.jakarta.persistence.api)
+    compileOnly(libs.slf4j)
     compileOnly(projects.jpqlDsl)
     compileOnly(projects.jpqlQueryModel)
     compileOnly(projects.jpqlRender)

--- a/support/hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinySessionUtils.kt
+++ b/support/hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinySessionUtils.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.support.hibernate.reactive
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import org.hibernate.reactive.mutiny.Mutiny
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlMutinySessionUtils {
@@ -73,13 +74,27 @@ internal object JpqlMutinySessionUtils {
 
     private fun <T> setParams(query: Mutiny.SelectionQuery<T>, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 
     private fun setParams(query: Mutiny.MutationQuery, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlMutinySessionUtils::class.java)

--- a/support/hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinyStatelessSessionUtils.kt
+++ b/support/hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlMutinyStatelessSessionUtils.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.support.hibernate.reactive
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import org.hibernate.reactive.mutiny.Mutiny
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlMutinyStatelessSessionUtils {
@@ -73,13 +74,27 @@ internal object JpqlMutinyStatelessSessionUtils {
 
     private fun <T> setParams(query: Mutiny.SelectionQuery<T>, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 
     private fun <T> setParams(query: Mutiny.Query<T>, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlMutinyStatelessSessionUtils::class.java)

--- a/support/hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageSessionUtils.kt
+++ b/support/hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageSessionUtils.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.support.hibernate.reactive
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import org.hibernate.reactive.stage.Stage
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlStageSessionUtils {
@@ -73,13 +74,27 @@ internal object JpqlStageSessionUtils {
 
     private fun <T> setParams(query: Stage.SelectionQuery<T>, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 
     private fun setParams(query: Stage.MutationQuery, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlStageSessionUtils::class.java)

--- a/support/hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageStatelessSessionUtils.kt
+++ b/support/hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/reactive/JpqlStageStatelessSessionUtils.kt
@@ -3,6 +3,7 @@ package com.linecorp.kotlinjdsl.support.hibernate.reactive
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import org.hibernate.reactive.stage.Stage
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlStageStatelessSessionUtils {
@@ -73,13 +74,27 @@ internal object JpqlStageStatelessSessionUtils {
 
     private fun <T> setParams(query: Stage.SelectionQuery<T>, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 
     private fun <T> setParams(query: Stage.Query<T>, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlStageStatelessSessionUtils::class.java)

--- a/support/hibernate/build.gradle.kts
+++ b/support/hibernate/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     compileOnly(libs.hibernate6.core)
     compileOnly(libs.jakarta.persistence.api)
+    compileOnly(libs.slf4j)
     compileOnly(projects.jpqlDsl)
     compileOnly(projects.jpqlQueryModel)
     compileOnly(projects.jpqlRender)

--- a/support/hibernate/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
+++ b/support/hibernate/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
@@ -84,9 +84,9 @@ internal object JpqlEntityManagerUtils {
                 query.setParameter(name, value)
             } else if (log.isDebugEnabled) {
                 log.debug(
-                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
-                    name,
-                    parameterNameSet.joinToString(),
+                    "No parameter named '$name' in query " +
+                        "with named parameters [${parameterNameSet.joinToString()}], " +
+                        "parameter binding skipped",
                 )
             }
         }

--- a/support/hibernate/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
+++ b/support/hibernate/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
@@ -7,6 +7,7 @@ import com.linecorp.kotlinjdsl.render.RenderContext
 import jakarta.persistence.EntityManager
 import jakarta.persistence.Query
 import jakarta.persistence.TypedQuery
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlEntityManagerUtils {
@@ -76,8 +77,20 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setParams(query: Query, params: Map<String, Any?>) {
+        val parameterNameSet = query.parameters.map { it.name }.toHashSet()
+
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            if (parameterNameSet.contains(name)) {
+                query.setParameter(name, value)
+            } else if (log.isDebugEnabled) {
+                log.debug(
+                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
+                    name,
+                    parameterNameSet.joinToString(),
+                )
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/hibernate/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
+++ b/support/hibernate/src/main/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtils.kt
@@ -82,12 +82,14 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
-            } else if (log.isDebugEnabled) {
-                log.debug(
-                    "No parameter named '$name' in query " +
-                        "with named parameters [${parameterNameSet.joinToString()}], " +
-                        "parameter binding skipped",
-                )
+            } else {
+                if (log.isDebugEnabled) {
+                    log.debug(
+                        "No parameter named '$name' in query " +
+                            "with named parameters [${parameterNameSet.joinToString()}], " +
+                            "parameter binding skipped",
+                    )
+                }
             }
         }
     }

--- a/support/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtilsTest.kt
+++ b/support/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/support/hibernate/JpqlEntityManagerUtilsTest.kt
@@ -12,6 +12,7 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockkObject
 import io.mockk.verifySequence
 import jakarta.persistence.EntityManager
+import jakarta.persistence.Parameter
 import jakarta.persistence.TypedQuery
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +36,12 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     @MockK
     private lateinit var stringTypedQuery1: TypedQuery<String>
 
+    @MockK
+    private lateinit var stringTypedQueryParam1: Parameter<String>
+
+    @MockK
+    private lateinit var stringTypedQueryParam2: Parameter<String>
+
     private val renderedQuery1 = "query"
     private val renderedParam1 = "queryParam1" to "queryParamValue1"
     private val renderedParam2 = "queryParam2" to "queryParamValue2"
@@ -51,6 +58,8 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         excludeRecords { JpqlRendererHolder.get() }
         excludeRecords { stringTypedQuery1.equals(any()) }
+        excludeRecords { stringTypedQueryParam1.hashCode() }
+        excludeRecords { stringTypedQueryParam2.hashCode() }
     }
 
     @Test
@@ -60,7 +69,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, String::class, context)
@@ -71,6 +83,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -83,7 +98,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -95,6 +113,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -107,7 +128,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, context)
@@ -118,6 +142,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -130,7 +157,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -142,6 +172,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }

--- a/support/spring-batch-javax/build.gradle.kts
+++ b/support/spring-batch-javax/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
     @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
     compileOnly(libs.spring.batch4.infrastructure)
     compileOnly(libs.javax.persistence.api)
+    compileOnly(libs.slf4j)
     compileOnly(projects.jpqlDsl)
     compileOnly(projects.jpqlQueryModel)
     compileOnly(projects.jpqlRender)

--- a/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/JpqlEntityManagerUtils.kt
@@ -39,12 +39,14 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
-            } else if (log.isDebugEnabled) {
-                log.debug(
-                    "No parameter named '$name' in query " +
-                        "with named parameters [${parameterNameSet.joinToString()}], " +
-                        "parameter binding skipped",
-                )
+            } else {
+                if (log.isDebugEnabled) {
+                    log.debug(
+                        "No parameter named '$name' in query " +
+                            "with named parameters [${parameterNameSet.joinToString()}], " +
+                            "parameter binding skipped",
+                    )
+                }
             }
         }
     }

--- a/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/JpqlEntityManagerUtils.kt
@@ -34,16 +34,16 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setParams(query: Query, params: JpqlRenderedParams) {
-        val parameterList = query.parameters.map { it.name }.toHashSet()
+        val parameterNameSet = query.parameters.map { it.name }.toHashSet()
 
         params.forEach { (name, value) ->
-            if (parameterList.contains(name)) {
+            if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
             } else if (log.isDebugEnabled) {
                 log.debug(
-                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
-                    name,
-                    parameterList.joinToString(),
+                    "No parameter named '$name' in query " +
+                        "with named parameters [${parameterNameSet.joinToString()}], " +
+                        "parameter binding skipped",
                 )
             }
         }

--- a/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-batch-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/javax/JpqlEntityManagerUtils.kt
@@ -4,6 +4,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRendered
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
+import org.slf4j.LoggerFactory
 import javax.persistence.EntityManager
 import javax.persistence.Query
 import javax.persistence.TypedQuery
@@ -33,8 +34,20 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setParams(query: Query, params: JpqlRenderedParams) {
+        val parameterList = query.parameters.map { it.name }.toHashSet()
+
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            if (parameterList.contains(name)) {
+                query.setParameter(name, value)
+            } else if (log.isDebugEnabled) {
+                log.debug(
+                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
+                    name,
+                    parameterList.joinToString(),
+                )
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/spring-batch/build.gradle.kts
+++ b/support/spring-batch/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
     compileOnly(libs.spring.boot3.starter)
     compileOnly(libs.spring.batch5.infrastructure)
     compileOnly(libs.jakarta.persistence.api)
+    compileOnly(libs.slf4j)
     compileOnly(projects.jpqlDsl)
     compileOnly(projects.jpqlQueryModel)
     compileOnly(projects.jpqlRender)

--- a/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtils.kt
+++ b/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtils.kt
@@ -7,6 +7,7 @@ import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderedParams
 import jakarta.persistence.EntityManager
 import jakarta.persistence.Query
 import jakarta.persistence.TypedQuery
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 internal object JpqlEntityManagerUtils {
@@ -33,8 +34,20 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setParams(query: Query, params: JpqlRenderedParams) {
+        val parameterNameSet = query.parameters.map { it.name }.toHashSet()
+
         params.forEach { (name, value) ->
-            query.setParameter(name, value)
+            if (parameterNameSet.contains(name)) {
+                query.setParameter(name, value)
+            } else if (log.isDebugEnabled) {
+                log.debug(
+                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
+                    name,
+                    parameterNameSet.joinToString(),
+                )
+            }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtils.kt
+++ b/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtils.kt
@@ -39,12 +39,14 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
-            } else if (log.isDebugEnabled) {
-                log.debug(
-                    "No parameter named '$name' in query " +
-                        "with named parameters [${parameterNameSet.joinToString()}], " +
-                        "parameter binding skipped",
-                )
+            } else {
+                if (log.isDebugEnabled) {
+                    log.debug(
+                        "No parameter named '$name' in query " +
+                            "with named parameters [${parameterNameSet.joinToString()}], " +
+                            "parameter binding skipped",
+                    )
+                }
             }
         }
     }

--- a/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtils.kt
+++ b/support/spring-batch/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtils.kt
@@ -41,9 +41,9 @@ internal object JpqlEntityManagerUtils {
                 query.setParameter(name, value)
             } else if (log.isDebugEnabled) {
                 log.debug(
-                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
-                    name,
-                    parameterNameSet.joinToString(),
+                    "No parameter named '$name' in query " +
+                        "with named parameters [${parameterNameSet.joinToString()}], " +
+                        "parameter binding skipped",
                 )
             }
         }

--- a/support/spring-batch/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-batch/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/batch/JpqlEntityManagerUtilsTest.kt
@@ -12,6 +12,7 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockkObject
 import io.mockk.verifySequence
 import jakarta.persistence.EntityManager
+import jakarta.persistence.Parameter
 import jakarta.persistence.TypedQuery
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +36,12 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     @MockK
     private lateinit var stringTypedQuery1: TypedQuery<String>
 
+    @MockK
+    private lateinit var stringTypedQueryParam1: Parameter<String>
+
+    @MockK
+    private lateinit var stringTypedQueryParam2: Parameter<String>
+
     private val renderedQuery1 = "query"
     private val renderedParam1 = "queryParam1" to "queryParamValue1"
     private val renderedParam2 = "queryParam2" to "queryParamValue2"
@@ -51,6 +58,8 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         excludeRecords { JpqlRendererHolder.get() }
         excludeRecords { stringTypedQuery1.equals(any()) }
+        excludeRecords { stringTypedQueryParam1.hashCode() }
+        excludeRecords { stringTypedQueryParam2.hashCode() }
     }
 
     @Test
@@ -60,7 +69,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -72,6 +84,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(selectQuery1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -4,6 +4,7 @@ package com.linecorp.kotlinjdsl.support.spring.data.jpa.javax
 
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.query.QueryEnhancerFactoryAdaptor
 import javax.persistence.EntityManager
@@ -102,7 +103,15 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterList.contains(name)) {
                 query.setParameter(name, value)
+            } else {
+                log.debug(
+                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
+                    name,
+                    parameterList.joinToString { it },
+                )
             }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -71,17 +71,7 @@ internal object JpqlEntityManagerUtils {
             createQuery(entityManager, queryEnhancer.applySorting(sort), rendered.params, returnType.java),
         ) {
             // Lazy
-            createCountQuery(entityManager, queryEnhancer.createCountQueryFor(), rendered.params)
-        }
-    }
-
-    private fun createCountQuery(
-        entityManager: EntityManager,
-        query: String,
-        queryParams: Map<String, Any?>,
-    ): TypedQuery<Long> {
-        return entityManager.createQuery(query, Long::class.javaObjectType).apply {
-            setCountQueryParams(this, queryParams)
+            createQuery(entityManager, queryEnhancer.createCountQueryFor(), rendered.params, Long::class.javaObjectType)
         }
     }
 
@@ -106,21 +96,13 @@ internal object JpqlEntityManagerUtils {
         }
     }
 
-    private fun setCountQueryParams(query: Query, params: Map<String, Any?>) {
-        val parameterList = query.parameters.map {
-            it.name
-        }.toHashSet()
+    private fun setParams(query: Query, params: Map<String, Any?>) {
+        val parameterList = query.parameters.map { it.name }.toHashSet()
 
         params.forEach { (name, value) ->
             if (parameterList.contains(name)) {
                 query.setParameter(name, value)
             }
-        }
-    }
-
-    private fun setParams(query: Query, params: Map<String, Any?>) {
-        params.forEach { (name, value) ->
-            query.setParameter(name, value)
         }
     }
 }

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -107,7 +107,7 @@ internal object JpqlEntityManagerUtils {
                 log.debug(
                     "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
                     name,
-                    parameterList.joinToString { it },
+                    parameterList.joinToString(),
                 )
             }
         }

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -103,7 +103,7 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterList.contains(name)) {
                 query.setParameter(name, value)
-            } else {
+            } else if (log.isDebugEnabled) {
                 log.debug(
                     "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
                     name,

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -103,12 +103,14 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
-            } else if (log.isDebugEnabled) {
-                log.debug(
-                    "No parameter named '$name' in query " +
-                        "with named parameters [${parameterNameSet.joinToString()}], " +
-                        "parameter binding skipped",
-                )
+            } else {
+                if (log.isDebugEnabled) {
+                    log.debug(
+                        "No parameter named '$name' in query " +
+                            "with named parameters [${parameterNameSet.joinToString()}], " +
+                            "parameter binding skipped",
+                    )
+                }
             }
         }
     }

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -107,7 +107,9 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setCountQueryParams(query: Query, params: Map<String, Any?>) {
-        val parameterList = query.parameters.associateBy { it.name }
+        val parameterList = query.parameters.map {
+            it.name
+        }.toHashSet()
 
         params.forEach { (name, value) ->
             if (parameterList.contains(name)) {

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -4,7 +4,6 @@ package com.linecorp.kotlinjdsl.support.spring.data.jpa.javax
 
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
-import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.query.QueryEnhancerFactoryAdaptor
 import javax.persistence.EntityManager
@@ -108,13 +107,11 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setCountQueryParams(query: Query, params: Map<String, Any?>) {
+        val parameterList = query.parameters.associateBy { it.name }
+
         params.forEach { (name, value) ->
-            try {
+            if (parameterList.contains(name)) {
                 query.setParameter(name, value)
-            } catch (e: RuntimeException) {
-                if (log.isDebugEnabled) {
-                    log.debug("Silently ignoring", e)
-                }
             }
         }
     }
@@ -125,5 +122,3 @@ internal object JpqlEntityManagerUtils {
         }
     }
 }
-
-private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -4,6 +4,7 @@ package com.linecorp.kotlinjdsl.support.spring.data.jpa.javax
 
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQuery
 import com.linecorp.kotlinjdsl.render.RenderContext
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.query.QueryEnhancerFactoryAdaptor
 import javax.persistence.EntityManager
@@ -71,7 +72,17 @@ internal object JpqlEntityManagerUtils {
             createQuery(entityManager, queryEnhancer.applySorting(sort), rendered.params, returnType.java),
         ) {
             // Lazy
-            createQuery(entityManager, queryEnhancer.createCountQueryFor(), rendered.params, Long::class.javaObjectType)
+            createCountQuery(entityManager, queryEnhancer.createCountQueryFor(), rendered.params)
+        }
+    }
+
+    private fun createCountQuery(
+        entityManager: EntityManager,
+        query: String,
+        queryParams: Map<String, Any?>,
+    ): TypedQuery<Long> {
+        return entityManager.createQuery(query, Long::class.javaObjectType).apply {
+            setCountQueryParams(this, queryParams)
         }
     }
 
@@ -96,9 +107,23 @@ internal object JpqlEntityManagerUtils {
         }
     }
 
+    private fun setCountQueryParams(query: Query, params: Map<String, Any?>) {
+        params.forEach { (name, value) ->
+            try {
+                query.setParameter(name, value)
+            } catch (e: RuntimeException) {
+                if (log.isDebugEnabled) {
+                    log.debug("Silently ignoring", e)
+                }
+            }
+        }
+    }
+
     private fun setParams(query: Query, params: Map<String, Any?>) {
         params.forEach { (name, value) ->
             query.setParameter(name, value)
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -98,16 +98,16 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setParams(query: Query, params: Map<String, Any?>) {
-        val parameterList = query.parameters.map { it.name }.toHashSet()
+        val parameterNameSet = query.parameters.map { it.name }.toHashSet()
 
         params.forEach { (name, value) ->
-            if (parameterList.contains(name)) {
+            if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
             } else if (log.isDebugEnabled) {
                 log.debug(
-                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
-                    name,
-                    parameterList.joinToString(),
+                    "No parameter named '$name' in query " +
+                        "with named parameters [${parameterNameSet.joinToString()}], " +
+                        "parameter binding skipped",
                 )
             }
         }

--- a/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtilsTest.kt
@@ -43,6 +43,12 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     private lateinit var stringTypedQuery1: TypedQuery<String>
 
     @MockK
+    private lateinit var stringTypedQueryParam1: Parameter<String>
+
+    @MockK
+    private lateinit var stringTypedQueryParam2: Parameter<String>
+
+    @MockK
     private lateinit var longTypedQuery1: TypedQuery<Long>
 
     @MockK
@@ -76,6 +82,8 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         excludeRecords { longTypedQuery1.equals(any()) }
         excludeRecords { longTypedQueryParam1.hashCode() }
         excludeRecords { longTypedQueryParam2.hashCode() }
+        excludeRecords { stringTypedQueryParam1.hashCode() }
+        excludeRecords { stringTypedQueryParam2.hashCode() }
     }
 
     @Test
@@ -85,7 +93,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, String::class, context)
@@ -96,6 +107,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -108,7 +122,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -120,6 +137,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -132,7 +152,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, context)
@@ -143,6 +166,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -155,7 +181,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -167,6 +196,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -184,7 +216,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         every {
             entityManager.createQuery(any<String>(), any<Class<*>>())
         } returns stringTypedQuery1 andThen longTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
         every { longTypedQuery1.parameters } returns setOf(longTypedQueryParam1, longTypedQueryParam2)
         every { longTypedQuery1.setParameter(any<String>(), any()) } returns longTypedQuery1
         every { longTypedQueryParam1.name } returns renderedParam1.first
@@ -205,6 +240,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
             queryEnhancer.applySorting(sort1)
             entityManager.createQuery(sortedQuery1, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
 

--- a/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtilsTest.kt
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.query.QueryEnhancer
 import org.springframework.data.jpa.repository.query.QueryEnhancerFactoryAdaptor
 import javax.persistence.EntityManager
+import javax.persistence.Parameter
 import javax.persistence.TypedQuery
 
 @ExtendWith(MockKExtension::class)
@@ -44,6 +45,12 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     @MockK
     private lateinit var longTypedQuery1: TypedQuery<Long>
 
+    @MockK
+    private lateinit var longTypedQueryParam1: Parameter<String>
+
+    @MockK
+    private lateinit var longTypedQueryParam2: Parameter<String>
+
     private val sort1 = Sort.by("property1")
 
     private val renderedQuery1 = "query"
@@ -67,6 +74,8 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         excludeRecords { JpqlRendererHolder.get() }
         excludeRecords { stringTypedQuery1.equals(any()) }
         excludeRecords { longTypedQuery1.equals(any()) }
+        excludeRecords { longTypedQueryParam1.hashCode() }
+        excludeRecords { longTypedQueryParam2.hashCode() }
     }
 
     @Test
@@ -176,7 +185,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
             entityManager.createQuery(any<String>(), any<Class<*>>())
         } returns stringTypedQuery1 andThen longTypedQuery1
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { longTypedQuery1.parameters } returns setOf(longTypedQueryParam1, longTypedQueryParam2)
         every { longTypedQuery1.setParameter(any<String>(), any()) } returns longTypedQuery1
+        every { longTypedQueryParam1.name } returns renderedParam1.first
+        every { longTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -198,6 +210,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
             queryEnhancer.createCountQueryFor()
             entityManager.createQuery(countQuery1, Long::class.javaObjectType)
+            longTypedQuery1.parameters
+            longTypedQueryParam1.name
+            longTypedQueryParam2.name
             longTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             longTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -107,7 +107,7 @@ internal object JpqlEntityManagerUtils {
                 log.debug(
                     "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
                     name,
-                    parameterList.joinToString { it },
+                    parameterList.joinToString(),
                 )
             }
         }

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -7,7 +7,6 @@ import com.linecorp.kotlinjdsl.render.RenderContext
 import jakarta.persistence.EntityManager
 import jakarta.persistence.Query
 import jakarta.persistence.TypedQuery
-import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.query.QueryEnhancerFactoryAdaptor
 import kotlin.reflect.KClass
@@ -108,13 +107,11 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setCountQueryParams(query: Query, params: Map<String, Any?>) {
+        val parameterList = query.parameters.associateBy { it.name }
+
         params.forEach { (name, value) ->
-            try {
+            if (parameterList.contains(name)) {
                 query.setParameter(name, value)
-            } catch (e: RuntimeException) {
-                if (log.isDebugEnabled) {
-                    log.debug("Silently ignoring", e)
-                }
             }
         }
     }
@@ -125,5 +122,3 @@ internal object JpqlEntityManagerUtils {
         }
     }
 }
-
-private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -103,7 +103,7 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterList.contains(name)) {
                 query.setParameter(name, value)
-            } else {
+            } else if (log.isDebugEnabled) {
                 log.debug(
                     "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
                     name,

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -103,12 +103,14 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
-            } else if (log.isDebugEnabled) {
-                log.debug(
-                    "No parameter named '$name' in query " +
-                        "with named parameters [${parameterNameSet.joinToString()}], " +
-                        "parameter binding skipped",
-                )
+            } else {
+                if (log.isDebugEnabled) {
+                    log.debug(
+                        "No parameter named '$name' in query " +
+                            "with named parameters [${parameterNameSet.joinToString()}], " +
+                            "parameter binding skipped",
+                    )
+                }
             }
         }
     }

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -7,6 +7,7 @@ import com.linecorp.kotlinjdsl.render.RenderContext
 import jakarta.persistence.EntityManager
 import jakarta.persistence.Query
 import jakarta.persistence.TypedQuery
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.query.QueryEnhancerFactoryAdaptor
 import kotlin.reflect.KClass
@@ -102,7 +103,15 @@ internal object JpqlEntityManagerUtils {
         params.forEach { (name, value) ->
             if (parameterList.contains(name)) {
                 query.setParameter(name, value)
+            } else {
+                log.debug(
+                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
+                    name,
+                    parameterList.joinToString { it },
+                )
             }
         }
     }
 }
+
+private val log = LoggerFactory.getLogger(JpqlEntityManagerUtils::class.java)

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -71,17 +71,7 @@ internal object JpqlEntityManagerUtils {
             createQuery(entityManager, queryEnhancer.applySorting(sort), rendered.params, returnType.java),
         ) {
             // Lazy
-            createCountQuery(entityManager, queryEnhancer.createCountQueryFor(), rendered.params)
-        }
-    }
-
-    private fun createCountQuery(
-        entityManager: EntityManager,
-        query: String,
-        queryParams: Map<String, Any?>,
-    ): TypedQuery<Long> {
-        return entityManager.createQuery(query, Long::class.javaObjectType).apply {
-            setCountQueryParams(this, queryParams)
+            createQuery(entityManager, queryEnhancer.createCountQueryFor(), rendered.params, Long::class.javaObjectType)
         }
     }
 
@@ -106,19 +96,13 @@ internal object JpqlEntityManagerUtils {
         }
     }
 
-    private fun setCountQueryParams(query: Query, params: Map<String, Any?>) {
+    private fun setParams(query: Query, params: Map<String, Any?>) {
         val parameterList = query.parameters.map { it.name }.toHashSet()
 
         params.forEach { (name, value) ->
             if (parameterList.contains(name)) {
                 query.setParameter(name, value)
             }
-        }
-    }
-
-    private fun setParams(query: Query, params: Map<String, Any?>) {
-        params.forEach { (name, value) ->
-            query.setParameter(name, value)
         }
     }
 }

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -107,7 +107,7 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setCountQueryParams(query: Query, params: Map<String, Any?>) {
-        val parameterList = query.parameters.associateBy { it.name }
+        val parameterList = query.parameters.map { it.name }.toHashSet()
 
         params.forEach { (name, value) ->
             if (parameterList.contains(name)) {

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -98,16 +98,16 @@ internal object JpqlEntityManagerUtils {
     }
 
     private fun setParams(query: Query, params: Map<String, Any?>) {
-        val parameterList = query.parameters.map { it.name }.toHashSet()
+        val parameterNameSet = query.parameters.map { it.name }.toHashSet()
 
         params.forEach { (name, value) ->
-            if (parameterList.contains(name)) {
+            if (parameterNameSet.contains(name)) {
                 query.setParameter(name, value)
             } else if (log.isDebugEnabled) {
                 log.debug(
-                    "No parameter named '{}' in query with named parameters [{}], parameter binding skipped",
-                    name,
-                    parameterList.joinToString(),
+                    "No parameter named '$name' in query " +
+                        "with named parameters [${parameterNameSet.joinToString()}], " +
+                        "parameter binding skipped",
                 )
             }
         }

--- a/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtilsTest.kt
@@ -43,6 +43,12 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     private lateinit var stringTypedQuery1: TypedQuery<String>
 
     @MockK
+    private lateinit var stringTypedQueryParam1: Parameter<String>
+
+    @MockK
+    private lateinit var stringTypedQueryParam2: Parameter<String>
+
+    @MockK
     private lateinit var longTypedQuery1: TypedQuery<Long>
 
     @MockK
@@ -76,6 +82,8 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         excludeRecords { longTypedQuery1.equals(any()) }
         excludeRecords { longTypedQueryParam1.hashCode() }
         excludeRecords { longTypedQueryParam2.hashCode() }
+        excludeRecords { stringTypedQueryParam1.hashCode() }
+        excludeRecords { stringTypedQueryParam2.hashCode() }
     }
 
     @Test
@@ -85,7 +93,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, String::class, context)
@@ -96,6 +107,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -108,7 +122,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>(), any<Class<String>>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -120,6 +137,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -132,7 +152,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils.createQuery(entityManager, query1, context)
@@ -143,6 +166,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -155,7 +181,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         every { renderer.render(any(), any(), any()) } returns rendered1
         every { entityManager.createQuery(any<String>()) } returns stringTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
 
         // when
         val actual = JpqlEntityManagerUtils
@@ -167,6 +196,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         verifySequence {
             renderer.render(query1, mapOf(queryParam1, queryParam2), context)
             entityManager.createQuery(rendered1.query)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
         }
@@ -184,7 +216,10 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
         every {
             entityManager.createQuery(any<String>(), any<Class<*>>())
         } returns stringTypedQuery1 andThen longTypedQuery1
+        every { stringTypedQuery1.parameters } returns setOf(stringTypedQueryParam1, stringTypedQueryParam2)
         every { stringTypedQuery1.setParameter(any<String>(), any()) } returns stringTypedQuery1
+        every { stringTypedQueryParam1.name } returns renderedParam1.first
+        every { stringTypedQueryParam2.name } returns renderedParam2.first
         every { longTypedQuery1.parameters } returns setOf(longTypedQueryParam1, longTypedQueryParam2)
         every { longTypedQuery1.setParameter(any<String>(), any()) } returns longTypedQuery1
         every { longTypedQueryParam1.name } returns renderedParam1.first
@@ -205,6 +240,9 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
             queryEnhancer.applySorting(sort1)
             entityManager.createQuery(sortedQuery1, String::class.java)
+            stringTypedQuery1.parameters
+            stringTypedQueryParam1.name
+            stringTypedQueryParam2.name
             stringTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
             stringTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
 

--- a/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtilsTest.kt
@@ -79,11 +79,11 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
 
         excludeRecords { JpqlRendererHolder.get() }
         excludeRecords { stringTypedQuery1.equals(any()) }
+        excludeRecords { stringTypedQueryParam1.hashCode() }
+        excludeRecords { stringTypedQueryParam2.hashCode() }
         excludeRecords { longTypedQuery1.equals(any()) }
         excludeRecords { longTypedQueryParam1.hashCode() }
         excludeRecords { longTypedQueryParam2.hashCode() }
-        excludeRecords { stringTypedQueryParam1.hashCode() }
-        excludeRecords { stringTypedQueryParam2.hashCode() }
     }
 
     @Test


### PR DESCRIPTION
# Motivation

- Spring Data JPA를 Pageable과 사용하면서 에러로 동작하지 않는 상황을 발견하였는데, 해당 상황을 해결하는 풀리퀘를 하려고 합니다.

# Modifications

- [Spring Data JPA 코드](https://github.com/spring-projects/spring-data-jpa/blob/f0453520498f8dea411d3a317b41ef1b3c26848c/spring-data-jpa/src/main/java/org/springframework/data/jpa/repository/query/AbstractStringBasedJpaQuery.java#L146)를 참고하였습니다.
- Count Query를 생성하는 경우 파라미터 바인딩하는 로직을 수정하였습니다.
  - RuntimeException을 만나는 경우 log를 찍는 함수를 만들어 그 함수로 파라미터 바인딩하도록 변경하였습니다.

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- 파라미터 바인딩이 실패하더라도 Count Query가 문제 없이 실행되고, debug모드로 실행한 경우 로그를 출력합니다.

# Closes

- #780 
