### PR TITLE
feat: support stream in spring data repository

### DIFF
--- a/docs/en/jpql-with-kotlin-jdsl/spring-supports.md
+++ b/docs/en/jpql-with-kotlin-jdsl/spring-supports.md
@@ -12,23 +12,33 @@ If you declare your `JpqlSerializer` or `JpqlIntrospector` as a bean, it will be
 If your `JpaRepository` extends `KotlinJdslJpqlExecutor`, you can use the extension provided by Kotlin JDSL.
 
 ```kotlin
-interface AuthorRepository : JpaRepository<Author, Long>, KotlinJdslJpqlExecutor
 interface BookRepository : JpaRepository<Book, Isbn>, KotlinJdslJpqlExecutor
 
-authorRepository.findAll {
+val result: List<Isbn?> = bookRepository.findAll {
     select(
-        path(Author::authorId),
+        path(Book::isbn),
     ).from(
-        entity(Author::class),
-        join(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
-    ).groupBy(
-        path(Author::authorId),
-    ).orderBy(
-        count(Author::authorId).desc(),
+        entity(Book::class),
     )
 }
 
-bookRepository.findPage(pageable) {
+val result: Page<Isbn?> = bookRepository.findPage(pageable) {
+    select(
+        path(Book::isbn),
+    ).from(
+        entity(Book::class),
+    )
+}
+
+val result: Slice<Isbn?> = bookRepository.findSlice(pageable) {
+    select(
+        path(Book::isbn),
+    ).from(
+        entity(Book::class),
+    )
+}
+
+val result: Stream<Isbn?> = bookRepository.findStream {
     select(
         path(Book::isbn),
     ).from(

--- a/docs/ko/jpql-with-kotlin-jdsl/spring-supports.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/spring-supports.md
@@ -12,23 +12,33 @@ Kotlin JDSL은 Spring Boot AutoConfigure를 지원합니다.
 만약 사용하고 있는 `JpaRepository`가 `KotlinJdslJpqlExecutor`를 상속하면, Kotlin JDSL이 제공하는 확장 기능을 사용할 수 있습니다.
 
 ```kotlin
-interface AuthorRepository : JpaRepository<Author, Long>, KotlinJdslJpqlExecutor
 interface BookRepository : JpaRepository<Book, Isbn>, KotlinJdslJpqlExecutor
 
-authorRepository.findAll {
+val result: List<Isbn?> = bookRepository.findAll {
     select(
-        path(Author::authorId),
+        path(Book::isbn),
     ).from(
-        entity(Author::class),
-        join(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
-    ).groupBy(
-        path(Author::authorId),
-    ).orderBy(
-        count(Author::authorId).desc(),
+        entity(Book::class),
     )
 }
 
-bookRepository.findPage(pageable) {
+val result: Page<Isbn?> = bookRepository.findPage(pageable) {
+    select(
+        path(Book::isbn),
+    ).from(
+        entity(Book::class),
+    )
+}
+
+val result: Slice<Isbn?> = bookRepository.findSlice(pageable) {
+    select(
+        path(Book::isbn),
+    ).from(
+        entity(Book::class),
+    )
+}
+
+val result: Stream<Isbn?> = bookRepository.findStream {
     select(
         path(Book::isbn),
     ).from(

--- a/example/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/SelectExample.kt
+++ b/example/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/SelectExample.kt
@@ -148,6 +148,24 @@ class SelectExample : WithAssertions {
     }
 
     @Test
+    fun `the stream of books`() {
+        // given
+        val pageable = PageRequest.of(1, 3, Sort.by(Sort.Direction.ASC, "isbn"))
+
+        // when
+        val actual = bookRepository.findStream(pageable) {
+            select(
+                path(Book::isbn),
+            ).from(
+                entity(Book::class),
+            )
+        }
+
+        // then
+        assertThat(actual.toList()).isEqualTo(listOf(Isbn("04"), Isbn("05"), Isbn("06")))
+    }
+
+    @Test
     fun `the book with the most authors`() {
         // when
         val actual = bookRepository.findAll {
@@ -313,6 +331,39 @@ class SelectExample : WithAssertions {
 
         // then
         assertThat(actual).isEqualTo(
+            listOf(
+                Row(1, 6),
+                Row(2, 15),
+                Row(3, 18),
+            ),
+        )
+    }
+
+    @Test
+    fun the_number_of_employees_per_department_stream() {
+        // given
+        data class Row(
+            val departmentId: Long,
+            val count: Long,
+        )
+
+        // when
+        val actual = employeeRepository.findStream {
+            selectNew<Row>(
+                path(EmployeeDepartment::departmentId),
+                count(Employee::employeeId),
+            ).from(
+                entity(Employee::class),
+                join(Employee::departments),
+            ).groupBy(
+                path(EmployeeDepartment::departmentId),
+            ).orderBy(
+                path(EmployeeDepartment::departmentId).asc(),
+            )
+        }
+
+        // then
+        assertThat(actual.toList()).isEqualTo(
             listOf(
                 Row(1, 6),
                 Row(2, 15),

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutor.kt
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.repository.NoRepositoryBean
+import java.util.stream.Stream
 
 @NoRepositoryBean
 @SinceJdsl("3.0.0")
@@ -133,6 +134,67 @@ interface KotlinJdslJpqlExecutor {
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): Slice<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any> findStream(
+        offset: Int? = null,
+        limit: Int? = null,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: JpqlDsl.Constructor<DSL>,
+        offset: Int? = null,
+        limit: Int? = null,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: DSL,
+        offset: Int? = null,
+        limit: Int? = null,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any> findStream(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
 
     /**
      * Execute the update query.

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -22,6 +22,7 @@ import org.springframework.data.jpa.repository.support.QueryHints
 import org.springframework.data.repository.NoRepositoryBean
 import org.springframework.data.support.PageableExecutionUtilsAdaptor
 import org.springframework.transaction.annotation.Transactional
+import java.util.stream.Stream
 import javax.persistence.EntityManager
 import javax.persistence.LockModeType
 import javax.persistence.Query
@@ -60,10 +61,7 @@ open class KotlinJdslJpqlExecutorImpl(
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
-        val jpaQuery = createJpaQuery(query, query.returnType).apply {
-            offset?.let { setFirstResult(it) }
-            limit?.let { setMaxResults(it) }
-        }
+        val jpaQuery = createJpaQuery(query, query.returnType, offset, limit)
 
         return jpaQuery.resultList
     }
@@ -90,7 +88,7 @@ open class KotlinJdslJpqlExecutorImpl(
     ): List<T?> {
         val query: SelectQuery<T> = jpql(dsl, init)
 
-        return createList(query, query.returnType, pageable)
+        return createSortedQuery(query, query.returnType, pageable).resultList
     }
 
     override fun <T : Any> findPage(
@@ -141,6 +139,60 @@ open class KotlinJdslJpqlExecutorImpl(
         val query: SelectQuery<T> = jpql(dsl, init)
 
         return createSlice(query, query.returnType, pageable)
+    }
+
+    override fun <T : Any> findStream(
+        offset: Int?,
+        limit: Int?,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?> {
+        return findStream(Jpql, offset = offset, limit = limit, init)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: JpqlDsl.Constructor<DSL>,
+        offset: Int?,
+        limit: Int?,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?> {
+        return findStream(dsl.newInstance(), offset = offset, limit = limit, init)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: DSL,
+        offset: Int?,
+        limit: Int?,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+        val jpaQuery = createJpaQuery(query, query.returnType, offset, limit)
+
+        return jpaQuery.resultStream
+    }
+
+    override fun <T : Any> findStream(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?> {
+        return findStream(Jpql, pageable, init)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?> {
+        return findStream(dsl.newInstance(), pageable, init)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+
+        return this.createSortedQuery(query, query.returnType, pageable).resultStream
     }
 
     @Transactional
@@ -198,9 +250,13 @@ open class KotlinJdslJpqlExecutorImpl(
     private fun <T : Any> createJpaQuery(
         query: JpqlQuery<*>,
         returnType: KClass<T>,
+        offset: Int?,
+        limit: Int?,
     ): TypedQuery<T> {
         return JpqlEntityManagerUtils.createQuery(entityManager, query, returnType, renderContext).apply {
             setMetadata(this, metadata)
+            offset?.let { setFirstResult(it) }
+            limit?.let { setMaxResults(it) }
         }
     }
 
@@ -258,11 +314,11 @@ open class KotlinJdslJpqlExecutorImpl(
         }
     }
 
-    private fun <T : Any> createList(
+    private fun <T : Any> createSortedQuery(
         query: JpqlQuery<*>,
         returnType: KClass<T>,
         pageable: Pageable,
-    ): List<T?> {
+    ): TypedQuery<T> {
         val enhancedQuery = createJpaEnhancedQuery(query, returnType, pageable.sort)
 
         val sortedQuery = enhancedQuery.sortedQuery
@@ -272,7 +328,7 @@ open class KotlinJdslJpqlExecutorImpl(
             sortedQuery.maxResults = pageable.pageSize
         }
 
-        return sortedQuery.resultList
+        return sortedQuery
     }
 
     private fun <T : Any> createPage(

--- a/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImplTest.kt
+++ b/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImplTest.kt
@@ -29,6 +29,7 @@ import org.springframework.data.jpa.repository.support.QueryHints
 import org.springframework.data.support.PageableExecutionUtilsAdaptor
 import java.util.function.BiConsumer
 import java.util.function.LongSupplier
+import java.util.stream.Stream
 import javax.persistence.EntityManager
 import javax.persistence.LockModeType
 import javax.persistence.Query
@@ -181,6 +182,7 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     private val pageable1 = PageRequest.of(1, 10, sort1)
 
     private val list1 = listOf("1", "2", "3")
+    private val stream1 = Stream.of("1", "2", "3")
     private val counts1 = listOf(1L, 1L, 1L)
 
     private val enhancedTypedQuery1: EnhancedTypedQuery<String> by lazy(LazyThreadSafetyMode.NONE) {
@@ -764,6 +766,228 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             stringTypedQuery3.firstResult = pageable1.offset.toInt()
             stringTypedQuery3.maxResults = pageable1.pageSize + 1
             stringTypedQuery3.resultList
+        }
+    }
+
+    @Test
+    fun findStream() {
+        // given
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
+        } returns stringTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(offset1, limit1, createSelectQuery1)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, String::class, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.setFirstResult(offset1)
+            stringTypedQuery1.setMaxResults(limit1)
+            stringTypedQuery1.resultStream
+        }
+    }
+
+    @Test
+    fun `findStream() with a dsl`() {
+        // given
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
+        } returns stringTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(MyJpql, offset1, limit1, createSelectQuery2)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery2, String::class, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.setFirstResult(offset1)
+            stringTypedQuery2.setMaxResults(limit1)
+            stringTypedQuery2.resultStream
+        }
+    }
+
+    @Test
+    fun `findStream() with a dsl object`() {
+        // given
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
+        } returns stringTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(MyJpqlObject, offset1, limit1, createSelectQuery3)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery3, String::class, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.setFirstResult(offset1)
+            stringTypedQuery3.setMaxResults(limit1)
+            stringTypedQuery3.resultStream
+        }
+    }
+
+    @Test
+    fun `findStream() with a pageable`() {
+        // given
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(pageable1, createSelectQuery1)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery1, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.firstResult = pageable1.offset.toInt()
+            stringTypedQuery1.maxResults = pageable1.pageSize
+            stringTypedQuery1.resultStream
+        }
+    }
+
+    @Test
+    fun `findStream() with a dsl and a pageable`() {
+        // given
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(MyJpql, pageable1, createSelectQuery2)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery2, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.firstResult = pageable1.offset.toInt()
+            stringTypedQuery2.maxResults = pageable1.pageSize
+            stringTypedQuery2.resultStream
+        }
+    }
+
+    @Test
+    fun `findStream() with a dsl object and a pageable`() {
+        // given
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(MyJpqlObject, pageable1, createSelectQuery3)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery3, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.firstResult = pageable1.offset.toInt()
+            stringTypedQuery3.maxResults = pageable1.pageSize
+            stringTypedQuery3.resultStream
         }
     }
 

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.repository.NoRepositoryBean
+import java.util.stream.Stream
 
 @NoRepositoryBean
 @SinceJdsl("3.0.0")
@@ -133,6 +134,67 @@ interface KotlinJdslJpqlExecutor {
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): Slice<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any> findStream(
+        offset: Int? = null,
+        limit: Int? = null,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: JpqlDsl.Constructor<DSL>,
+        offset: Int? = null,
+        limit: Int? = null,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: DSL,
+        offset: Int? = null,
+        limit: Int? = null,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any> findStream(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
+
+    /**
+     * Returns all results of the select query.
+     */
+    @SinceJdsl("3.5.4")
+    fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T?>
 
     /**
      * Execute the update query.

--- a/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImplTest.kt
+++ b/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImplTest.kt
@@ -33,6 +33,7 @@ import org.springframework.data.jpa.repository.support.QueryHints
 import org.springframework.data.support.PageableExecutionUtilsAdaptor
 import java.util.function.BiConsumer
 import java.util.function.LongSupplier
+import java.util.stream.Stream
 import kotlin.reflect.KClass
 
 @ExtendWith(MockKExtension::class)
@@ -181,6 +182,7 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     private val pageable1 = PageRequest.of(1, 10, sort1)
 
     private val list1 = listOf("1", "2", "3")
+    private val stream1 = Stream.of("1", "2", "3")
     private val counts1 = listOf(1L, 1L, 1L)
 
     private val enhancedTypedQuery1: EnhancedTypedQuery<String> by lazy(LazyThreadSafetyMode.NONE) {
@@ -764,6 +766,228 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             stringTypedQuery3.firstResult = pageable1.offset.toInt()
             stringTypedQuery3.maxResults = pageable1.pageSize + 1
             stringTypedQuery3.resultList
+        }
+    }
+
+    @Test
+    fun findStream() {
+        // given
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
+        } returns stringTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(offset1, limit1, createSelectQuery1)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery1, String::class, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.setFirstResult(offset1)
+            stringTypedQuery1.setMaxResults(limit1)
+            stringTypedQuery1.resultStream
+        }
+    }
+
+    @Test
+    fun `findStream() with a dsl`() {
+        // given
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
+        } returns stringTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(MyJpql, offset1, limit1, createSelectQuery2)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery2, String::class, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.setFirstResult(offset1)
+            stringTypedQuery2.setMaxResults(limit1)
+            stringTypedQuery2.resultStream
+        }
+    }
+
+    @Test
+    fun `findStream() with a dsl object`() {
+        // given
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createQuery(any(), any<SelectQuery<String>>(), any<KClass<*>>(), any())
+        } returns stringTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(MyJpqlObject, offset1, limit1, createSelectQuery3)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createQuery(entityManager, selectQuery3, String::class, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.setFirstResult(offset1)
+            stringTypedQuery3.setMaxResults(limit1)
+            stringTypedQuery3.resultStream
+        }
+    }
+
+    @Test
+    fun `findStream() with a pageable`() {
+        // given
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(pageable1, createSelectQuery1)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery1, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.firstResult = pageable1.offset.toInt()
+            stringTypedQuery1.maxResults = pageable1.pageSize
+            stringTypedQuery1.resultStream
+        }
+    }
+
+    @Test
+    fun `findStream() with a dsl and a pageable`() {
+        // given
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(MyJpql, pageable1, createSelectQuery2)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery2, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.firstResult = pageable1.offset.toInt()
+            stringTypedQuery2.maxResults = pageable1.pageSize
+            stringTypedQuery2.resultStream
+        }
+    }
+
+    @Test
+    fun `findStream() with a dsl object and a pageable`() {
+        // given
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultStream } returns stream1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+
+        // when
+        val actual = sut.findStream(MyJpqlObject, pageable1, createSelectQuery3)
+
+        // then
+        assertThat(actual).isEqualTo(stream1)
+
+        verifySequence {
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery3, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.firstResult = pageable1.offset.toInt()
+            stringTypedQuery3.maxResults = pageable1.pageSize
+            stringTypedQuery3.resultStream
         }
     }
 


### PR DESCRIPTION
# Motivation

- Spring Data supports a stream as a return type.

# Modifications

- Add the `findStream()` functions to make the stream available in the repository.

# Result

- Users will be able to use the stream when using the `findStream()` method of the KotlinJdslJpqlExecutor interface.
- Close https://github.com/line/kotlin-jdsl/issues/802

```kotlin
employeeRepository.findStream {
    selectNew<Row>(
        path(EmployeeDepartment::departmentId),
        count(Employee::employeeId),
    ).from(
        entity(Employee::class),
        join(Employee::departments),
    ).groupBy(
        path(EmployeeDepartment::departmentId),
    ).orderBy(
        path(EmployeeDepartment::departmentId).asc(),
    )
}
```

