### PR TITLE
feat: handle mixed values and expressions in parameters

### DIFF
--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -1287,7 +1287,7 @@ open class Jpql : JpqlDsl {
      */
     @SinceJdsl("3.0.0")
     fun <T : Any> new(type: KClass<T>, vararg args: Any): Expression<T> {
-        return Expressions.new(type, args.map { Expressions.value(it) })
+        return Expressions.new(type, args.map { valueOrExpression(it) })
     }
 
     /**
@@ -1708,7 +1708,7 @@ open class Jpql : JpqlDsl {
     @LowPriorityInOverloadResolution
     @SinceJdsl("3.0.0")
     fun <T : Any> function(type: KClass<T>, name: String, vararg args: Any): Expression<T> {
-        return Expressions.function(type, name, args.map { Expressions.value(it) })
+        return Expressions.function(type, name, args.map { valueOrExpression(it) })
     }
 
     /**
@@ -1737,7 +1737,7 @@ open class Jpql : JpqlDsl {
     @LowPriorityInOverloadResolution
     @SinceJdsl("3.0.0")
     fun <T : Any> customExpression(type: KClass<T>, template: String, vararg args: Any): Expression<T> {
-        return Expressions.customExpression(type, template, args.map { Expressions.value(it) })
+        return Expressions.customExpression(type, template, args.map { valueOrExpression(it) })
     }
 
     /**
@@ -3036,7 +3036,7 @@ open class Jpql : JpqlDsl {
     @LowPriorityInOverloadResolution
     @SinceJdsl("3.0.0")
     fun function(type: KClass<Boolean>, name: String, vararg args: Any): Predicate {
-        return Predicates.function(name, args.map { Expressions.value(it) })
+        return Predicates.function(name, args.map { valueOrExpression(it) })
     }
 
     /**
@@ -3066,7 +3066,7 @@ open class Jpql : JpqlDsl {
     @LowPriorityInOverloadResolution
     @SinceJdsl("3.3.0")
     fun customPredicate(template: String, vararg args: Any): Predicate {
-        return Predicates.customPredicate(template, args.map { Expressions.value(it) })
+        return Predicates.customPredicate(template, args.map { valueOrExpression(it) })
     }
 
     /**
@@ -3217,5 +3217,13 @@ open class Jpql : JpqlDsl {
     @SinceJdsl("3.0.0")
     fun <T : Any> deleteFrom(entity: Entityable<T>): DeleteQueryWhereStep<T> {
         return DeleteQueryDsl(entity.toEntity())
+    }
+
+    private fun valueOrExpression(value: Any): Expression<*> {
+        return if (value is Expression<*>) {
+            value
+        } else {
+            Expressions.value(value)
+        }
     }
 }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/CustomExpressionDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/CustomExpressionDslTest.kt
@@ -58,4 +58,26 @@ class CustomExpressionDslTest : WithAssertions {
 
         assertThat(actual).isEqualTo(expected)
     }
+
+    @Test
+    fun `customExpression() with a string and a string expression`() {
+        // when
+        val expression = queryPart {
+            customExpression(Int::class, template1, string1, stringExpression2)
+        }.toExpression()
+
+        val actual: Expression<Int> = expression // for type check
+
+        // then
+        val expected = Expressions.customExpression(
+            Int::class,
+            template1,
+            listOf(
+                Expressions.value(string1),
+                stringExpression2,
+            ),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
 }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/FunctionDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/FunctionDslTest.kt
@@ -58,4 +58,26 @@ class FunctionDslTest : WithAssertions {
 
         assertThat(actual).isEqualTo(expected)
     }
+
+    @Test
+    fun `function() with a string and a string expression`() {
+        // when
+        val expression = queryPart {
+            function(Int::class, name1, string1, stringExpression2)
+        }.toExpression()
+
+        val actual: Expression<Int> = expression // for type check
+
+        // then
+        val expected = Expressions.function(
+            Int::class,
+            name1,
+            listOf(
+                Expressions.value(string1),
+                stringExpression2,
+            ),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
 }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/NewDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/NewDslTest.kt
@@ -56,4 +56,25 @@ class NewDslTest : WithAssertions {
 
         assertThat(actual).isEqualTo(expected)
     }
+
+    @Test
+    fun `new() with a string and a string expression`() {
+        // when
+        val expression = queryPart {
+            new(Row::class, string1, stringExpression2)
+        }.toExpression()
+
+        val actual: Expression<Row> = expression // for type check
+
+        // then
+        val expected = Expressions.new(
+            type = Row::class,
+            args = listOf(
+                Expressions.value(string1),
+                stringExpression2,
+            ),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
 }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/predicate/CustomPredicateDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/predicate/CustomPredicateDslTest.kt
@@ -57,4 +57,25 @@ class CustomPredicateDslTest : WithAssertions {
 
         assertThat(actual).isEqualTo(expected)
     }
+
+    @Test
+    fun `customPredicate() with a string and a string expression`() {
+        // when
+        val predicate = queryPart {
+            customPredicate(template1, string1, stringExpression2)
+        }
+
+        val actual: Predicate = predicate // for type check
+
+        // then
+        val expected = Predicates.customPredicate(
+            template1,
+            listOf(
+                Expressions.value(string1),
+                stringExpression2,
+            ),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
 }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/predicate/FunctionDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/predicate/FunctionDslTest.kt
@@ -57,4 +57,25 @@ class FunctionDslTest : WithAssertions {
 
         assertThat(actual).isEqualTo(expected)
     }
+
+    @Test
+    fun `function() with a string and a string expression`() {
+        // when
+        val predicate = queryPart {
+            function(Boolean::class, name1, string1, stringExpression2)
+        }
+
+        val actual: Predicate = predicate // for type check
+
+        // then
+        val expected = Predicates.function(
+            name1,
+            listOf(
+                Expressions.value(string1),
+                stringExpression2,
+            ),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
 }


### PR DESCRIPTION
# Motivation

- The `vararg args: Any` type parameter was designed expecting only values, but the user expects a mix of values and expressions.
- So the user uses a mix of values and expressions, which results in an error that is difficult for the user to understand. 

# Modifications

- For functions that can mix values and expressions, add logic to prevent expressions from being treated as values. 

# Result

- The function can perform as the user expects it to. 

