### PR TITLE
feat: Support select() with KClass<T> arguments

### DIFF
--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -3109,6 +3109,21 @@ open class Jpql : JpqlDsl {
      * Creates a select clause in a select query.
      */
     @SinceJdsl("3.0.0")
+    fun <T : Any> select(
+        type: KClass<T>,
+        expr: Expressionable<T>,
+    ): SelectQueryFromStep<T> {
+        return SelectQueryFromStepDsl(
+            type,
+            distinct = false,
+            listOf(expr.toExpression()),
+        )
+    }
+
+    /**
+     * Creates a select clause in a select query.
+     */
+    @SinceJdsl("3.0.0")
     inline fun <reified T : Any> select(
         expr: Expressionable<T>,
     ): SelectQueryFromStep<T> {
@@ -3116,6 +3131,22 @@ open class Jpql : JpqlDsl {
             T::class,
             distinct = false,
             listOf(expr.toExpression()),
+        )
+    }
+
+    /**
+     * Creates a select clause in a select query.
+     */
+    @SinceJdsl("3.0.0")
+    fun <T : Any> select(
+        type: KClass<T>,
+        expr: Expressionable<*>,
+        vararg exprs: Expressionable<*>,
+    ): SelectQueryFromStep<T> {
+        return SelectQueryFromStepDsl(
+            type,
+            distinct = false,
+            listOf(expr.toExpression()) + exprs.map { it.toExpression() },
         )
     }
 
@@ -3138,6 +3169,21 @@ open class Jpql : JpqlDsl {
      * Creates a select clause in a select query.
      */
     @SinceJdsl("3.0.0")
+    fun <T : Any> selectDistinct(
+        type: KClass<T>,
+        expr: Expressionable<T>,
+    ): SelectQueryFromStep<T> {
+        return SelectQueryFromStepDsl(
+            type,
+            distinct = true,
+            listOf(expr.toExpression()),
+        )
+    }
+
+    /**
+     * Creates a select clause in a select query.
+     */
+    @SinceJdsl("3.0.0")
     inline fun <reified T : Any> selectDistinct(
         expr: Expressionable<T>,
     ): SelectQueryFromStep<T> {
@@ -3145,6 +3191,22 @@ open class Jpql : JpqlDsl {
             T::class,
             distinct = true,
             listOf(expr.toExpression()),
+        )
+    }
+
+    /**
+     * Creates a select clause in a select query.
+     */
+    @SinceJdsl("3.0.0")
+    fun <T : Any> selectDistinct(
+        type: KClass<T>,
+        expr: Expressionable<*>,
+        vararg exprs: Expressionable<*>,
+    ): SelectQueryFromStep<T> {
+        return SelectQueryFromStepDsl(
+            type,
+            distinct = true,
+            listOf(expr.toExpression()) + exprs.map { it.toExpression() },
         )
     }
 
@@ -3167,6 +3229,27 @@ open class Jpql : JpqlDsl {
      * Creates a select clause with the DTO projection in a select query.
      */
     @SinceJdsl("3.0.0")
+    fun <T : Any> selectNew(
+        type: KClass<T>,
+        expr: Expressionable<*>,
+        vararg exprs: Expressionable<*>,
+    ): SelectQueryFromStep<T> {
+        return SelectQueryFromStepDsl(
+            returnType = type,
+            distinct = false,
+            select = listOf(
+                Expressions.new(
+                    type,
+                    listOf(expr.toExpression()) + exprs.map { it.toExpression() },
+                ),
+            ),
+        )
+    }
+
+    /**
+     * Creates a select clause with the DTO projection in a select query.
+     */
+    @SinceJdsl("3.0.0")
     inline fun <reified T : Any> selectNew(
         expr: Expressionable<*>,
         vararg exprs: Expressionable<*>,
@@ -3177,6 +3260,27 @@ open class Jpql : JpqlDsl {
             select = listOf(
                 Expressions.new(
                     T::class,
+                    listOf(expr.toExpression()) + exprs.map { it.toExpression() },
+                ),
+            ),
+        )
+    }
+
+    /**
+     * Creates a select clause with the DTO projection in a select query.
+     */
+    @SinceJdsl("3.0.0")
+    fun <T : Any> selectDistinctNew(
+        type: KClass<T>,
+        expr: Expressionable<*>,
+        vararg exprs: Expressionable<*>,
+    ): SelectQueryFromStep<T> {
+        return SelectQueryFromStepDsl(
+            returnType = type,
+            distinct = true,
+            select = listOf(
+                Expressions.new(
+                    type,
                     listOf(expr.toExpression()) + exprs.map { it.toExpression() },
                 ),
             ),

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -3108,7 +3108,7 @@ open class Jpql : JpqlDsl {
     /**
      * Creates a select clause in a select query.
      */
-    @SinceJdsl("3.0.0")
+    @SinceJdsl("3.5.5")
     fun <T : Any> select(
         type: KClass<T>,
         expr: Expressionable<T>,
@@ -3137,7 +3137,7 @@ open class Jpql : JpqlDsl {
     /**
      * Creates a select clause in a select query.
      */
-    @SinceJdsl("3.0.0")
+    @SinceJdsl("3.5.5")
     fun <T : Any> select(
         type: KClass<T>,
         expr: Expressionable<*>,
@@ -3168,7 +3168,7 @@ open class Jpql : JpqlDsl {
     /**
      * Creates a select clause in a select query.
      */
-    @SinceJdsl("3.0.0")
+    @SinceJdsl("3.5.5")
     fun <T : Any> selectDistinct(
         type: KClass<T>,
         expr: Expressionable<T>,
@@ -3197,7 +3197,7 @@ open class Jpql : JpqlDsl {
     /**
      * Creates a select clause in a select query.
      */
-    @SinceJdsl("3.0.0")
+    @SinceJdsl("3.5.5")
     fun <T : Any> selectDistinct(
         type: KClass<T>,
         expr: Expressionable<*>,
@@ -3228,7 +3228,7 @@ open class Jpql : JpqlDsl {
     /**
      * Creates a select clause with the DTO projection in a select query.
      */
-    @SinceJdsl("3.0.0")
+    @SinceJdsl("3.5.5")
     fun <T : Any> selectNew(
         type: KClass<T>,
         expr: Expressionable<*>,
@@ -3269,7 +3269,7 @@ open class Jpql : JpqlDsl {
     /**
      * Creates a select clause with the DTO projection in a select query.
      */
-    @SinceJdsl("3.0.0")
+    @SinceJdsl("3.5.5")
     fun <T : Any> selectDistinctNew(
         type: KClass<T>,
         expr: Expressionable<*>,

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/SelectDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/SelectDslTest.kt
@@ -70,6 +70,31 @@ class SelectDslTest : WithAssertions {
     }
 
     @Test
+    fun `select() with a KClass`() {
+        // when
+        val select = queryPart {
+            select(
+                BigDecimal::class,
+                expression1,
+            ).from(
+                entity1,
+            )
+        }.toQuery()
+
+        val actual: SelectQuery<BigDecimal> = select // for type check
+
+        // then
+        val expected = SelectQueries.selectQuery(
+            returnType = BigDecimal::class,
+            distinct = false,
+            select = listOf(expression1),
+            from = listOf(entity1),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
     fun `selectDistinct() with an expression`() {
         // when
         val select = queryPart {
@@ -119,6 +144,31 @@ class SelectDslTest : WithAssertions {
     }
 
     @Test
+    fun `selectDistinct() with a KClass`() {
+        // when
+        val select = queryPart {
+            selectDistinct(
+                BigDecimal::class,
+                expression1,
+            ).from(
+                entity1,
+            )
+        }.toQuery()
+
+        val actual: SelectQuery<BigDecimal> = select // for type check
+
+        // then
+        val expected = SelectQueries.selectQuery(
+            returnType = BigDecimal::class,
+            distinct = true,
+            select = listOf(expression1),
+            from = listOf(entity1),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
     fun `selectNew() with a generic type and expressions`() {
         // when
         val select = queryPart {
@@ -149,10 +199,72 @@ class SelectDslTest : WithAssertions {
     }
 
     @Test
+    fun `selectNew() with a KClass`() {
+        // when
+        val select = queryPart {
+            selectNew(
+                Dto::class,
+                expression1,
+                expression2,
+            ).from(
+                entity1,
+            )
+        }.toQuery()
+
+        val actual: SelectQuery<Dto> = select // for type check
+
+        // then
+        val expected = SelectQueries.selectQuery(
+            returnType = Dto::class,
+            distinct = false,
+            select = listOf(
+                Expressions.new(
+                    type = Dto::class,
+                    args = listOf(expression1, expression2),
+                ),
+            ),
+            from = listOf(entity1),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
     fun `selectDistinctNew() with a generic type and expressions`() {
         // when
         val select = queryPart {
             selectDistinctNew<Dto>(
+                expression1,
+                expression2,
+            ).from(
+                entity1,
+            )
+        }.toQuery()
+
+        val actual: SelectQuery<Dto> = select // for type check
+
+        // then
+        val expected = SelectQueries.selectQuery(
+            returnType = Dto::class,
+            distinct = true,
+            select = listOf(
+                Expressions.new(
+                    type = Dto::class,
+                    args = listOf(expression1, expression2),
+                ),
+            ),
+            from = listOf(entity1),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `selectDistinctNew() with a KClass`() {
+        // when
+        val select = queryPart {
+            selectDistinctNew(
+                Dto::class,
                 expression1,
                 expression2,
             ).from(

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/SelectDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/SelectDslTest.kt
@@ -21,6 +21,31 @@ class SelectDslTest : WithAssertions {
     private class View
 
     @Test
+    fun `select() with a KClass and an expression`() {
+        // when
+        val select = queryPart {
+            select(
+                BigDecimal::class,
+                expression1,
+            ).from(
+                entity1,
+            )
+        }.toQuery()
+
+        val actual: SelectQuery<BigDecimal> = select // for type check
+
+        // then
+        val expected = SelectQueries.selectQuery(
+            returnType = BigDecimal::class,
+            distinct = false,
+            select = listOf(expression1),
+            from = listOf(entity1),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
     fun `select() with an expression`() {
         // when
         val select = queryPart {
@@ -38,6 +63,32 @@ class SelectDslTest : WithAssertions {
             returnType = BigDecimal::class,
             distinct = false,
             select = listOf(expression1),
+            from = listOf(entity1),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `select() with a KClass and expressions`() {
+        // when
+        val select = queryPart {
+            select(
+                View::class,
+                expression1,
+                expression2,
+            ).from(
+                entity1,
+            )
+        }.toQuery()
+
+        val actual: SelectQuery<View> = select // for type check
+
+        // then
+        val expected = SelectQueries.selectQuery(
+            returnType = View::class,
+            distinct = false,
+            select = listOf(expression1, expression2),
             from = listOf(entity1),
         )
 
@@ -70,10 +121,10 @@ class SelectDslTest : WithAssertions {
     }
 
     @Test
-    fun `select() with a KClass`() {
+    fun `selectDistinct() with a KClass and an expression`() {
         // when
         val select = queryPart {
-            select(
+            selectDistinct(
                 BigDecimal::class,
                 expression1,
             ).from(
@@ -86,7 +137,7 @@ class SelectDslTest : WithAssertions {
         // then
         val expected = SelectQueries.selectQuery(
             returnType = BigDecimal::class,
-            distinct = false,
+            distinct = true,
             select = listOf(expression1),
             from = listOf(entity1),
         )
@@ -119,6 +170,32 @@ class SelectDslTest : WithAssertions {
     }
 
     @Test
+    fun `selectDistinct() with a KClass and expressions`() {
+        // when
+        val select = queryPart {
+            selectDistinct(
+                View::class,
+                expression1,
+                expression2,
+            ).from(
+                entity1,
+            )
+        }.toQuery()
+
+        val actual: SelectQuery<View> = select // for type check
+
+        // then
+        val expected = SelectQueries.selectQuery(
+            returnType = View::class,
+            distinct = true,
+            select = listOf(expression1, expression2),
+            from = listOf(entity1),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
     fun `selectDistinct() with a generic type and expressions`() {
         // when
         val select = queryPart {
@@ -144,24 +221,30 @@ class SelectDslTest : WithAssertions {
     }
 
     @Test
-    fun `selectDistinct() with a KClass`() {
+    fun `selectNew() with a KClass and expressions`() {
         // when
         val select = queryPart {
-            selectDistinct(
-                BigDecimal::class,
+            selectNew(
+                Dto::class,
                 expression1,
+                expression2,
             ).from(
                 entity1,
             )
         }.toQuery()
 
-        val actual: SelectQuery<BigDecimal> = select // for type check
+        val actual: SelectQuery<Dto> = select // for type check
 
         // then
         val expected = SelectQueries.selectQuery(
-            returnType = BigDecimal::class,
-            distinct = true,
-            select = listOf(expression1),
+            returnType = Dto::class,
+            distinct = false,
+            select = listOf(
+                Expressions.new(
+                    type = Dto::class,
+                    args = listOf(expression1, expression2),
+                ),
+            ),
             from = listOf(entity1),
         )
 
@@ -199,41 +282,11 @@ class SelectDslTest : WithAssertions {
     }
 
     @Test
-    fun `selectNew() with a KClass`() {
+    fun `selectDistinctNew() with a KClass and expressions`() {
         // when
         val select = queryPart {
-            selectNew(
+            selectDistinctNew(
                 Dto::class,
-                expression1,
-                expression2,
-            ).from(
-                entity1,
-            )
-        }.toQuery()
-
-        val actual: SelectQuery<Dto> = select // for type check
-
-        // then
-        val expected = SelectQueries.selectQuery(
-            returnType = Dto::class,
-            distinct = false,
-            select = listOf(
-                Expressions.new(
-                    type = Dto::class,
-                    args = listOf(expression1, expression2),
-                ),
-            ),
-            from = listOf(entity1),
-        )
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @Test
-    fun `selectDistinctNew() with a generic type and expressions`() {
-        // when
-        val select = queryPart {
-            selectDistinctNew<Dto>(
                 expression1,
                 expression2,
             ).from(
@@ -260,11 +313,10 @@ class SelectDslTest : WithAssertions {
     }
 
     @Test
-    fun `selectDistinctNew() with a KClass`() {
+    fun `selectDistinctNew() with a generic type and expressions`() {
         // when
         val select = queryPart {
-            selectDistinctNew(
-                Dto::class,
+            selectDistinctNew<Dto>(
                 expression1,
                 expression2,
             ).from(


### PR DESCRIPTION
# Motivation

- Original `select(..)` functions used `reified` types for class parameters, making it hard to use them for generic classes even in the presence of class variables (`T::class`)

# Modifications

- Added class variable versions for every function in `select(..)` family.
  - Tried to match style with existing class type functions
- Added some tests covering new functions

# Result

- One can write following code without an error:
```kotlin
abstract class JdslRepository<ENTITY : Any> { 
   abstract fun findAll(): SelectQuery<ENTITY>
}

class TRepository<T: Any>(private val entityClass: KClass<T>) : JdslRepository<T> {
  override fun findAll(): SelectQuery<T> {
      return jpql {
          select(entityClass, entity(entityClass)) // <- free of the error came from type erasure
              .from(entity(entityClass))
      }
  }
}
```

# Closes

- #825 
