### PR TITLE
feat: Implement UNION and UNION ALL with dedicated query models and serializers (follow-up to #880)

### DIFF
--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -19,7 +19,10 @@ import com.linecorp.kotlinjdsl.dsl.jpql.join.impl.AssociationJoinDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.join.impl.FetchJoinDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.join.impl.JoinDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.select.SelectQueryFromStep
+import com.linecorp.kotlinjdsl.dsl.jpql.select.SelectQueryOrderByStep
 import com.linecorp.kotlinjdsl.dsl.jpql.select.impl.SelectQueryFromStepDsl
+import com.linecorp.kotlinjdsl.dsl.jpql.select.impl.SetOperatorQueryDsl
+import com.linecorp.kotlinjdsl.dsl.jpql.select.impl.SetOperatorType
 import com.linecorp.kotlinjdsl.dsl.jpql.sort.SortNullsStep
 import com.linecorp.kotlinjdsl.dsl.jpql.sort.impl.SortDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.update.UpdateQuerySetFirstStep
@@ -3321,6 +3324,62 @@ open class Jpql : JpqlDsl {
     @SinceJdsl("3.0.0")
     fun <T : Any> deleteFrom(entity: Entityable<T>): DeleteQueryWhereStep<T> {
         return DeleteQueryDsl(entity.toEntity())
+    }
+
+    /**
+     * Creates a UNION query with two select queries.
+     */
+    @SinceJdsl("3.6.0")
+    @JvmName("union")
+    inline fun <reified T : Any> union(
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return SetOperatorQueryDsl(
+            returnType = T::class,
+            leftQuery = left,
+            setOperator = SetOperatorType.UNION,
+            rightQuery = right,
+        )
+    }
+
+    /**
+     * Creates a UNION ALL query with two select queries.
+     */
+    @JvmName("unionAll")
+    @SinceJdsl("3.6.0")
+    inline fun <reified T : Any> unionAll(
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return SetOperatorQueryDsl(
+            returnType = T::class,
+            leftQuery = left,
+            setOperator = SetOperatorType.UNION_ALL,
+            rightQuery = right,
+        )
+    }
+
+    /**
+     * Creates a UNION query that represents the union of this query and the [right] query.
+     */
+    @JvmName("unionExtension")
+    @SinceJdsl("3.6.0")
+    inline fun <reified T : Any> JpqlQueryable<SelectQuery<T>>.union(
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return union(this, right)
+    }
+
+    /**
+     * Creates a UNION ALL that represents the union all of this query and the [right] query.
+     */
+    @JvmName("unionAllExtension")
+    @SinceJdsl("3.6.0")
+    inline fun <reified T : Any> JpqlQueryable<SelectQuery<T>>.unionAll(
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return unionAll(this, right)
     }
 
     private fun valueOrExpression(value: Any): Expression<*> {

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -21,8 +21,8 @@ import com.linecorp.kotlinjdsl.dsl.jpql.join.impl.JoinDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.select.SelectQueryFromStep
 import com.linecorp.kotlinjdsl.dsl.jpql.select.SelectQueryOrderByStep
 import com.linecorp.kotlinjdsl.dsl.jpql.select.impl.SelectQueryFromStepDsl
+import com.linecorp.kotlinjdsl.dsl.jpql.select.impl.SetOperator
 import com.linecorp.kotlinjdsl.dsl.jpql.select.impl.SetOperatorQueryDsl
-import com.linecorp.kotlinjdsl.dsl.jpql.select.impl.SetOperatorType
 import com.linecorp.kotlinjdsl.dsl.jpql.sort.SortNullsStep
 import com.linecorp.kotlinjdsl.dsl.jpql.sort.impl.SortDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.update.UpdateQuerySetFirstStep
@@ -3338,7 +3338,7 @@ open class Jpql : JpqlDsl {
         return SetOperatorQueryDsl(
             returnType = T::class,
             leftQuery = left,
-            setOperator = SetOperatorType.UNION,
+            setOperator = SetOperator.UNION,
             rightQuery = right,
         )
     }
@@ -3355,7 +3355,7 @@ open class Jpql : JpqlDsl {
         return SetOperatorQueryDsl(
             returnType = T::class,
             leftQuery = left,
-            setOperator = SetOperatorType.UNION_ALL,
+            setOperator = SetOperator.UNION_ALL,
             rightQuery = right,
         )
     }

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperator.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperator.kt
@@ -1,11 +1,10 @@
 package com.linecorp.kotlinjdsl.dsl.jpql.select.impl
 
-import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.SinceJdsl
 
 @SinceJdsl("3.6.0")
-@Internal
-enum class SetOperator {
+@PublishedApi
+internal enum class SetOperator {
     UNION,
     UNION_ALL,
 }

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperator.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperator.kt
@@ -5,7 +5,7 @@ import com.linecorp.kotlinjdsl.SinceJdsl
 
 @SinceJdsl("3.6.0")
 @Internal
-enum class SetOperatorType {
+enum class SetOperator {
     UNION,
     UNION_ALL,
 }

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorQueryDsl.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorQueryDsl.kt
@@ -1,0 +1,30 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.select.impl
+
+import com.linecorp.kotlinjdsl.dsl.jpql.select.SelectQueryOrderByStep
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sortable
+import kotlin.reflect.KClass
+
+@PublishedApi
+internal class SetOperatorQueryDsl<T : Any>(
+    private val builder: SetOperatorSelectQueryBuilder<T>,
+) : SelectQueryOrderByStep<T>, JpqlQueryable<SelectQuery<T>> {
+    constructor(
+        returnType: KClass<T>,
+        leftQuery: JpqlQueryable<SelectQuery<T>>,
+        rightQuery: JpqlQueryable<SelectQuery<T>>,
+        setOperator: SetOperatorType,
+    ) : this(
+        SetOperatorSelectQueryBuilder<T>(returnType, leftQuery, rightQuery, setOperator),
+    )
+
+    override fun orderBy(vararg sorts: Sortable?): JpqlQueryable<SelectQuery<T>> {
+        builder.orderBy(sorts.mapNotNull { it?.toSort() })
+        return this
+    }
+
+    override fun toQuery(): SelectQuery<T> {
+        return builder.build()
+    }
+}

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorQueryDsl.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorQueryDsl.kt
@@ -14,7 +14,7 @@ internal class SetOperatorQueryDsl<T : Any>(
         returnType: KClass<T>,
         leftQuery: JpqlQueryable<SelectQuery<T>>,
         rightQuery: JpqlQueryable<SelectQuery<T>>,
-        setOperator: SetOperatorType,
+        setOperator: SetOperator,
     ) : this(
         SetOperatorSelectQueryBuilder<T>(returnType, leftQuery, rightQuery, setOperator),
     )

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorSelectQueryBuilder.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorSelectQueryBuilder.kt
@@ -1,0 +1,38 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.select.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import kotlin.reflect.KClass
+
+internal data class SetOperatorSelectQueryBuilder<T : Any>(
+    private val returnType: KClass<T>,
+    private val leftQuery: JpqlQueryable<SelectQuery<T>>,
+    private val rightQuery: JpqlQueryable<SelectQuery<T>>,
+    private var operationType: SetOperatorType,
+    private var orderBy: MutableList<Sort>? = null,
+) {
+    fun orderBy(sorts: Iterable<Sort>): SetOperatorSelectQueryBuilder<T> {
+        this.orderBy = (this.orderBy ?: mutableListOf()).also { it.addAll(sorts) }
+
+        return this
+    }
+
+    fun build(): SelectQuery<T> {
+        return when (operationType) {
+            SetOperatorType.UNION -> SelectQueries.selectUnionQuery(
+                returnType = returnType,
+                left = leftQuery,
+                right = rightQuery,
+                orderBy = orderBy,
+            )
+            SetOperatorType.UNION_ALL -> SelectQueries.selectUnionAllQuery(
+                returnType = returnType,
+                left = leftQuery,
+                right = rightQuery,
+                orderBy = orderBy,
+            )
+        }
+    }
+}

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorSelectQueryBuilder.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorSelectQueryBuilder.kt
@@ -10,7 +10,7 @@ internal data class SetOperatorSelectQueryBuilder<T : Any>(
     private val returnType: KClass<T>,
     private val leftQuery: JpqlQueryable<SelectQuery<T>>,
     private val rightQuery: JpqlQueryable<SelectQuery<T>>,
-    private var operationType: SetOperatorType,
+    private var setOperator: SetOperator,
     private var orderBy: MutableList<Sort>? = null,
 ) {
     fun orderBy(sorts: Iterable<Sort>): SetOperatorSelectQueryBuilder<T> {
@@ -20,14 +20,14 @@ internal data class SetOperatorSelectQueryBuilder<T : Any>(
     }
 
     fun build(): SelectQuery<T> {
-        return when (operationType) {
-            SetOperatorType.UNION -> SelectQueries.selectUnionQuery(
+        return when (setOperator) {
+            SetOperator.UNION -> SelectQueries.selectUnionQuery(
                 returnType = returnType,
                 left = leftQuery,
                 right = rightQuery,
                 orderBy = orderBy,
             )
-            SetOperatorType.UNION_ALL -> SelectQueries.selectUnionAllQuery(
+            SetOperator.UNION_ALL -> SelectQueries.selectUnionAllQuery(
                 returnType = returnType,
                 left = leftQuery,
                 right = rightQuery,

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorType.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorType.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.select.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.SinceJdsl
+
+@SinceJdsl("3.6.0")
+@Internal
+enum class SetOperatorType {
+    UNION,
+    UNION_ALL,
+}

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/SetOperatorDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/SetOperatorDslTest.kt
@@ -1,0 +1,210 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.querymodel.jpql.entity.Entities
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnion
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnionAll
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class SetOperatorDslTest : WithAssertions {
+    private val entity1 = Entities.entity(Book::class, "entity1")
+    private val entity2 = Entities.entity(Book::class, "entity2")
+
+    private val sort1 = Sorts.asc(entity1)
+
+    @Test
+    fun `union between two queries`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            union(
+                subquery1,
+                subquery2,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryUnion::class.java)
+
+        val actualUnion = query as JpqlSelectQueryUnion
+
+        assertThat(actualUnion.returnType).isEqualTo(Book::class)
+        assertThat(actualUnion.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnion.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnion.orderBy).isNull()
+    }
+
+    @Test
+    fun `union between two queries with orderBy`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            union(
+                subquery1,
+                subquery2,
+            ).orderBy(
+                sort1,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryUnion::class.java)
+
+        val actualUnion = query as JpqlSelectQueryUnion
+
+        assertThat(actualUnion.returnType).isEqualTo(Book::class)
+        assertThat(actualUnion.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnion.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnion.orderBy).isEqualTo(listOf(sort1))
+    }
+
+    @Test
+    fun `union all between two queries`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            unionAll(
+                subquery1,
+                subquery2,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryUnionAll::class.java)
+
+        val actualUnionAll = query as JpqlSelectQueryUnionAll
+
+        assertThat(actualUnionAll.returnType).isEqualTo(Book::class)
+        assertThat(actualUnionAll.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnionAll.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnionAll.orderBy).isNull()
+    }
+
+    @Test
+    fun `union all between two queries with orderBy`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            unionAll(
+                subquery1,
+                subquery2,
+            ).orderBy(
+                sort1,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryUnionAll::class.java)
+
+        val actualUnionAll = query as JpqlSelectQueryUnionAll
+
+        assertThat(actualUnionAll.returnType).isEqualTo(Book::class)
+        assertThat(actualUnionAll.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnionAll.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnionAll.orderBy).isEqualTo(listOf(sort1))
+    }
+}

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/UnionMutinySessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/UnionMutinySessionExample.kt
@@ -1,0 +1,188 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class UnionMutinySessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getMutinySessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn1 = Isbn("01")
+    private val bookIsbn2 = Isbn("02")
+
+    @Test
+    fun unionBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            union(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun unionAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            unionAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+            bookIsbn1,
+        )
+    }
+
+    @Test
+    fun unionBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).union(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun unionAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).unionAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+            bookIsbn1,
+        )
+    }
+}

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/UnionMutinyStatelessSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/UnionMutinyStatelessSessionExample.kt
@@ -1,0 +1,188 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class UnionMutinyStatelessSessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getMutinySessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn1 = Isbn("01")
+    private val bookIsbn2 = Isbn("02")
+
+    @Test
+    fun unionBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            union(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun unionAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            unionAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+            bookIsbn1,
+        )
+    }
+
+    @Test
+    fun unionBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).union(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun unionAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).unionAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+            bookIsbn1,
+        )
+    }
+}

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/UnionStageSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/UnionStageSessionExample.kt
@@ -1,0 +1,188 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class UnionStageSessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getStageSessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn1 = Isbn("01")
+    private val bookIsbn2 = Isbn("02")
+
+    @Test
+    fun unionBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            union(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun unionAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            unionAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+            bookIsbn1,
+        )
+    }
+
+    @Test
+    fun unionBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).union(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun unionAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).unionAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+            bookIsbn1,
+        )
+    }
+}

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/UnionStageStatelessSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/UnionStageStatelessSessionExample.kt
@@ -1,0 +1,188 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class UnionStageStatelessSessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getStageSessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn1 = Isbn("01")
+    private val bookIsbn2 = Isbn("02")
+
+    @Test
+    fun unionBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            union(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun unionAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            unionAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+            bookIsbn1,
+        )
+    }
+
+    @Test
+    fun unionBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).union(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun unionAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).unionAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+            bookIsbn1,
+        )
+    }
+}

--- a/example/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/select/UnionExample.kt
+++ b/example/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/select/UnionExample.kt
@@ -1,0 +1,171 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.EntityManagerFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.extension.createQuery
+import jakarta.persistence.TypedQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class UnionExample : WithAssertions {
+    private val entityManagerFactory = EntityManagerFactoryTestUtils.getEntityManagerFactory()
+    private val entityManager = entityManagerFactory.createEntityManager()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn1 = Isbn("01")
+    private val bookIsbn2 = Isbn("02")
+
+    @AfterEach
+    fun tearDown() {
+        entityManager.close()
+    }
+
+    @Test
+    fun unionBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            union(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun unionAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            unionAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+            bookIsbn1,
+        )
+    }
+
+    @Test
+    fun unionBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).union(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun unionAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).unionAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+            bookIsbn2,
+            bookIsbn1,
+        )
+    }
+}

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/SelectQueries.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/SelectQueries.kt
@@ -1,11 +1,14 @@
 package com.linecorp.kotlinjdsl.querymodel.jpql.select
 
 import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
 import com.linecorp.kotlinjdsl.querymodel.jpql.from.From
 import com.linecorp.kotlinjdsl.querymodel.jpql.from.Froms
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnion
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnionAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
 import kotlin.reflect.KClass
 
@@ -36,6 +39,36 @@ object SelectQueries {
             where = where,
             groupBy = groupBy,
             having = having,
+            orderBy = orderBy,
+        )
+    }
+
+    @SinceJdsl("3.6.0")
+    fun <T : Any> selectUnionQuery(
+        returnType: KClass<T>,
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+        orderBy: Iterable<Sort>?,
+    ): SelectQuery<T> {
+        return JpqlSelectQueryUnion(
+            returnType = returnType,
+            left = left,
+            right = right,
+            orderBy = orderBy,
+        )
+    }
+
+    @SinceJdsl("3.6.0")
+    fun <T : Any> selectUnionAllQuery(
+        returnType: KClass<T>,
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+        orderBy: Iterable<Sort>?,
+    ): SelectQuery<T> {
+        return JpqlSelectQueryUnionAll(
+            returnType = returnType,
+            left = left,
+            right = right,
             orderBy = orderBy,
         )
     }

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryUnion.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryUnion.kt
@@ -1,0 +1,15 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.select.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import kotlin.reflect.KClass
+
+@Internal
+data class JpqlSelectQueryUnion<T : Any> internal constructor(
+    override val returnType: KClass<T>,
+    val left: JpqlQueryable<SelectQuery<T>>,
+    val right: JpqlQueryable<SelectQuery<T>>,
+    val orderBy: Iterable<Sort>?,
+) : SelectQuery<T>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryUnionAll.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryUnionAll.kt
@@ -1,0 +1,15 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.select.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import kotlin.reflect.KClass
+
+@Internal
+data class JpqlSelectQueryUnionAll<T : Any> internal constructor(
+    override val returnType: KClass<T>,
+    val left: JpqlQueryable<SelectQuery<T>>,
+    val right: JpqlQueryable<SelectQuery<T>>,
+    val orderBy: Iterable<Sort>?,
+) : SelectQuery<T>

--- a/query-model/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/SelectQueriesTest.kt
+++ b/query-model/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/SelectQueriesTest.kt
@@ -13,6 +13,8 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.join.Joins
 import com.linecorp.kotlinjdsl.querymodel.jpql.path.Paths
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnion
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnionAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
 import org.assertj.core.api.WithAssertions
 import org.junit.jupiter.api.Test
@@ -65,6 +67,88 @@ class SelectQueriesTest : WithAssertions {
             where = predicate1,
             groupBy = listOf(expression3, expression4),
             having = predicate2,
+            orderBy = listOf(sort1, sort2),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun selectUnionQuery() {
+        // when
+        val left = SelectQueries.selectQuery(
+            returnType = Class1::class,
+            distinct = false,
+            select = listOf(expression1, expression2),
+            from = listOf(entity1, join1, join2, entity2, entity3),
+            where = predicate1,
+            groupBy = listOf(expression3, expression4),
+            having = predicate2,
+            orderBy = listOf(sort1, sort2),
+        )
+        val right = SelectQueries.selectQuery(
+            returnType = Class1::class,
+            distinct = false,
+            select = listOf(expression1),
+            from = listOf(entity1),
+            where = predicate1,
+            groupBy = listOf(expression3, expression4),
+            having = predicate2,
+            orderBy = listOf(sort1, sort2),
+        )
+        val actual = SelectQueries.selectUnionQuery(
+            returnType = Class1::class,
+            left = left,
+            right = right,
+            orderBy = listOf(sort1, sort2),
+        )
+
+        // then
+        val expected = JpqlSelectQueryUnion(
+            returnType = Class1::class,
+            left = left,
+            right = right,
+            orderBy = listOf(sort1, sort2),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun selectUnionAllQuery() {
+        // when
+        val left = SelectQueries.selectQuery(
+            returnType = Class1::class,
+            distinct = false,
+            select = listOf(expression1, expression2),
+            from = listOf(entity1, join1, join2, entity2, entity3),
+            where = predicate1,
+            groupBy = listOf(expression3, expression4),
+            having = predicate2,
+            orderBy = listOf(sort1, sort2),
+        )
+        val right = SelectQueries.selectQuery(
+            returnType = Class1::class,
+            distinct = false,
+            select = listOf(expression1),
+            from = listOf(entity1),
+            where = predicate1,
+            groupBy = listOf(expression3, expression4),
+            having = predicate2,
+            orderBy = listOf(sort1, sort2),
+        )
+        val actual = SelectQueries.selectUnionAllQuery(
+            returnType = Class1::class,
+            left = left,
+            right = right,
+            orderBy = listOf(sort1, sort2),
+        )
+
+        // then
+        val expected = JpqlSelectQueryUnionAll(
+            returnType = Class1::class,
+            left = left,
+            right = right,
             orderBy = listOf(sort1, sort2),
         )
 

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
@@ -109,6 +109,8 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlPowerSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlPredicateParenthesesSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlRoundSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQuerySerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryUnionAllSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryUnionSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSignSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSizeSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSortSerializer
@@ -372,6 +374,8 @@ private class DefaultModule : JpqlRenderModule {
             JpqlPredicateParenthesesSerializer(),
             JpqlRoundSerializer(),
             JpqlSelectQuerySerializer(),
+            JpqlSelectQueryUnionAllSerializer(),
+            JpqlSelectQueryUnionSerializer(),
             JpqlSignSerializer(),
             JpqlSizeSerializer(),
             JpqlSortSerializer(),

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryUnionAllSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryUnionAllSerializer.kt
@@ -1,0 +1,48 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnionAll
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@Internal
+class JpqlSelectQueryUnionAllSerializer : JpqlSerializer<JpqlSelectQueryUnionAll<*>> {
+    override fun handledType(): KClass<JpqlSelectQueryUnionAll<*>> =
+        JpqlSelectQueryUnionAll::class
+
+    override fun serialize(part: JpqlSelectQueryUnionAll<*>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        val queryContext = context + JpqlRenderStatement.Select
+
+        delegate.serialize(part.left.toQuery(), writer, queryContext)
+
+        writer.write(" UNION ALL ")
+
+        delegate.serialize(part.right.toQuery(), writer, queryContext)
+
+        writeOrderBy(part, queryContext, writer, delegate)
+    }
+
+    private fun writeOrderBy(
+        part: JpqlSelectQueryUnionAll<*>,
+        queryContext: RenderContext,
+        writer: JpqlWriter,
+        delegate: JpqlRenderSerializer,
+    ) {
+        part.orderBy?.takeIf { it.any() }?.let { orderByItems ->
+            val orderByInSetOperationContext = queryContext + JpqlRenderClause.OrderBy
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            writer.writeEach(orderByItems, separator = ", ") { sortElement ->
+                delegate.serialize(sortElement, writer, orderByInSetOperationContext)
+            }
+        }
+    }
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryUnionSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryUnionSerializer.kt
@@ -1,0 +1,49 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnion
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@Internal
+class JpqlSelectQueryUnionSerializer : JpqlSerializer<JpqlSelectQueryUnion<*>> {
+    override fun handledType(): KClass<JpqlSelectQueryUnion<*>> =
+        JpqlSelectQueryUnion::class
+
+    override fun serialize(part: JpqlSelectQueryUnion<*>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        val queryContext = context + JpqlRenderStatement.Select
+
+        delegate.serialize(part.left.toQuery(), writer, queryContext)
+
+        writer.write(" UNION ")
+
+        delegate.serialize(part.right.toQuery(), writer, queryContext)
+
+        writeOrderBy(part, queryContext, writer, delegate)
+    }
+
+    private fun writeOrderBy(
+        part: JpqlSelectQueryUnion<*>,
+        queryContext: RenderContext,
+        writer: JpqlWriter,
+        delegate: JpqlRenderSerializer,
+    ) {
+        // Render ORDER BY clause if present
+        part.orderBy?.takeIf { it.any() }?.let { orderByItems ->
+            val orderByInSetOperationContext = queryContext + JpqlRenderClause.OrderBy
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            writer.writeEach(orderByItems, separator = ", ") { sortElement ->
+                delegate.serialize(sortElement, writer, orderByInSetOperationContext)
+            }
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryUnionAllSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryUnionAllSerializerTest.kt
@@ -1,0 +1,108 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnionAll
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@JpqlSerializerTest
+@ExtendWith(MockKExtension::class)
+class JpqlSelectQueryUnionAllSerializerTest : WithAssertions {
+    private val sut = JpqlSelectQueryUnionAllSerializer()
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    private lateinit var initialContext: RenderContext
+
+    @BeforeEach
+    fun setUp() {
+        initialContext = TestRenderContext(serializer)
+    }
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlSelectQueryUnionAll::class)
+    }
+
+    @Test
+    fun `serialize operation`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        val part = SelectQueries.selectUnionAllQuery(
+            String::class,
+            leftQuery,
+            rightQuery,
+            orderBy = null,
+        ) as JpqlSelectQueryUnionAll
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        // then
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" UNION ALL ")
+            serializer.serialize(rightQuery, writer, queryContext)
+        }
+    }
+
+    @Test
+    fun `serialize operation with order by`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+        val sort = mockk<Sort>()
+        val part = SelectQueries.selectUnionAllQuery(
+            returnType = String::class,
+            left = leftQuery,
+            right = rightQuery,
+            orderBy = listOf(sort),
+        ) as JpqlSelectQueryUnionAll
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        val orderByContext = queryContext + JpqlRenderClause.OrderBy
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        // then
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" UNION ALL ")
+            serializer.serialize(rightQuery, writer, queryContext)
+
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            serializer.serialize(sort, writer, orderByContext)
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryUnionSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryUnionSerializerTest.kt
@@ -1,0 +1,107 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnion
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@JpqlSerializerTest
+@ExtendWith(MockKExtension::class)
+class JpqlSelectQueryUnionSerializerTest : WithAssertions {
+    private val sut = JpqlSelectQueryUnionSerializer()
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    private lateinit var initialContext: RenderContext
+
+    @BeforeEach
+    fun setUp() {
+        initialContext = TestRenderContext(serializer)
+    }
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlSelectQueryUnion::class)
+    }
+
+    @Test
+    fun `serialize operation`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        val part = SelectQueries.selectUnionQuery(
+            String::class,
+            leftQuery,
+            rightQuery,
+            orderBy = null,
+        ) as JpqlSelectQueryUnion
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" UNION ")
+            serializer.serialize(rightQuery, writer, queryContext)
+        }
+    }
+
+    @Test
+    fun `serialize operation with order by`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+        val sort = mockk<Sort>()
+        val part = SelectQueries.selectUnionQuery(
+            returnType = String::class,
+            left = leftQuery,
+            right = rightQuery,
+            orderBy = listOf(sort),
+        ) as JpqlSelectQueryUnion
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        val orderByContext = queryContext + JpqlRenderClause.OrderBy
+
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" UNION ")
+            serializer.serialize(rightQuery, writer, queryContext)
+
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            serializer.serialize(sort, writer, orderByContext)
+        }
+    }
+}


### PR DESCRIPTION
This Pull Request introduces initial support for `UNION` and `UNION ALL` set operations in Kotlin-JDSL. This implementation pioneers a dedicated model and serializer approach for each set operation type, aiming for clarity and extensibility. Support for reactive environments has also been included with corresponding tests.

This work addresses and evolves from the discussions in PR [#880](https://github.com/line/kotlin-jdsl/pull/880), particularly aligning with the JPQL BNF syntax where the result of a set operation can be further combined and can have an `ORDER BY` clause applied to its final result, as formally recognized in the [Jakarta Persistence 3.2 specification](https://jakarta.ee/specifications/persistence/3.2/).

**Key Motivations & Approach:**

*   **Dedicated Query Models:** Introduced `JpqlSelectQueryUnion` and `JpqlSelectQueryUnionAll` as distinct query model classes. This approach separates the concerns for each set operation type, potentially simplifying handling and future extensions for other set operators like `INTERSECT` and `EXCEPT`. These models encapsulate the left and right `SelectQuery` operands and the overall `ORDER BY` clause.
*   **Specific Serializers:** Implemented `JpqlSelectQueryUnionSerializer` and `JpqlSelectQueryUnionAllSerializer` to handle the rendering of their respective query models. This ensures that the specific syntax and nuances of each set operation (e.g., `UNION` vs. `UNION ALL`) are correctly managed.
*   **Adherence to JPQL BNF & JPA 3.2:** The implementation ensures that generated JPQL is consistent with the standard, particularly regarding the placement of `ORDER BY` for set operations.
*   **DSL Integration:** `UNION` and `UNION ALL` operations are integrated into the DSL through extension functions on `JpqlQueryable<SelectQuery<T>>` and as top-level functions within the `jpql` block, returning a `JpqlQueryable` that can be further chained with `orderBy`. No new `Step` interfaces were added for this initial implementation.

**Modifications in this PR:**

*   **New Query Models:**
    *   `JpqlSelectQueryUnion<T>`: Represents a `UNION` operation between two `SelectQuery<T>` instances, holding an optional `List<Sort>` for the final ordering.
    *   `JpqlSelectQueryUnionAll<T>`: Represents a `UNION ALL` operation, structured similarly to `JpqlSelectQueryUnion<T>`.
*   **New Serializers:**
    *   `JpqlSelectQueryUnionSerializer`: Responsible for rendering `JpqlSelectQueryUnion` into valid JPQL, including parenthesizing operands and appending the final `ORDER BY` clause.
    *   `JpqlSelectQueryUnionAllSerializer`: Similarly handles `JpqlSelectQueryUnionAll`.
*   **DSL Integration (`Jpql.kt`):**
    *   Added `union(left, right)` and `unionAll(left, right)` top-level functions in the `jpql` scope.
    *   Added `JpqlQueryable<SelectQuery<T>>.union(right)` and `JpqlQueryable<SelectQuery<T>>.unionAll(right)` extension functions.
    *   These DSL entry points construct the new `JpqlSelectQueryUnion` or `JpqlSelectQueryUnionAll` models.
*   **Query Construction Logic (e.g., within `Jpql.kt` or new helper/builder classes if any):**
    *   When constructing `JpqlSelectQueryUnion` or `JpqlSelectQueryUnionAll`, the `orderBy` clauses from the individual `left` and `right` operand queries are **not** carried into the operands themselves within the set operation model. The `orderBy` list in `JpqlSelectQueryUnion(All)` is intended for the *final* result of the set operation.
*   **Tests:**
    *   Created `UnionExample.kt` (for Hibernate) and corresponding tests for reactive environments, covering various `UNION` and `UNION ALL` scenarios, including combined `ORDER BY` clauses.
    *   All tests are passing, validating that the generated JPQL is correct and adheres to the expected syntax for set operations with ordering.

**Next Steps (Planned):**

*   Address any feedback on this dedicated model/serializer approach for set operations.
*   Implement `INTERSECT` and `EXCEPT` using a similar pattern (i.e., dedicated models and serializers).
*   Refine and polish the implementation based on contributor review.

This PR establishes a clear and specific pattern for handling set operations. We believe this approach offers better maintainability and clarity for future development of other set operators and related features. Feedback is highly appreciated.

--- korean

본 Pull Request는 Kotlin-JDSL에 `UNION` 및 `UNION ALL` 집합 연산 지원을 추가합니다. 이번 구현은 각 집합 연산 유형에 대해 전용 모델과 Serializer를 사용하는 접근 방식을 선도하여 명확성과 확장성을 목표로 합니다. Reactive 환경에 대한 지원 및 관련 테스트도 포함되었습니다.

이 작업은 이전 PR [#880](https://github.com/line/kotlin-jdsl/pull/880)에서의 논의를 기반으로 발전되었으며, 특히 집합 연산의 결과가 추가적인 집합 연산의 일부가 될 수 있고 최종 결과에 `ORDER BY` 절을 적용할 수 있다는 JPQL BNF 구문([Jakarta Persistence 3.2 명세](https://jakarta.ee/specifications/persistence/3.2/)에서 공식화됨)에 부합하도록 하는 데 중점을 두었습니다.

**주요 동기 및 접근 방식:**

*   **전용 쿼리 모델:** `JpqlSelectQueryUnion` 및 `JpqlSelectQueryUnionAll`을 별개의 쿼리 모델 클래스로 도입했습니다. 이 접근 방식은 각 집합 연산 유형에 대한 관심사를 분리하여, `INTERSECT` 및 `EXCEPT`와 같은 다른 집합 연산자에 대한 처리 및 향후 확장을 단순화할 수 있습니다. 이 모델들은 좌항 및 우항 `SelectQuery` 피연산자와 전체 `ORDER BY` 절을 캡슐화합니다.
*   **특정 Serializer:** 각 쿼리 모델의 렌더링을 처리하기 위해 `JpqlSelectQueryUnionSerializer` 및 `JpqlSelectQueryUnionAllSerializer`를 구현했습니다. 이를 통해 각 집합 연산(예: `UNION` 대 `UNION ALL`)의 특정 구문과 미묘한 차이가 올바르게 관리됩니다.
*   **JPQL BNF 및 JPA 3.2 준수:** 생성된 JPQL이 표준과 일치하도록 보장하며, 특히 집합 연산에 대한 `ORDER BY` 배치와 관련하여 더욱 그렇습니다.
*   **DSL 통합:** `UNION` 및 `UNION ALL` 연산은 `JpqlQueryable<SelectQuery<T>>`에 대한 확장 함수와 `jpql` 블록 내의 최상위 레벨 함수를 통해 DSL에 통합되며, 이후 `orderBy`와 체이닝될 수 있는 `JpqlQueryable`을 반환합니다. 이번 초기 구현에서는 새로운 `Step` 인터페이스가 추가되지 않았습니다.

**이 PR의 변경 사항:**

*   **새로운 쿼리 모델:**
    *   `JpqlSelectQueryUnion<T>`: 두 `SelectQuery<T>` 인스턴스 간의 `UNION` 연산을 나타내며, 최종 정렬을 위한 선택적 `List<Sort>`를 가집니다.
    *   `JpqlSelectQueryUnionAll<T>`: `JpqlSelectQueryUnion<T>`와 유사하게 구조화된 `UNION ALL` 연산을 나타냅니다.
*   **새로운 Serializer:**
    *   `JpqlSelectQueryUnionSerializer`: `JpqlSelectQueryUnion`을 유효한 JPQL로 렌더링하며, 피연산자 괄호 처리 및 최종 `ORDER BY` 절 추가를 담당합니다.
    *   `JpqlSelectQueryUnionAllSerializer`: 유사하게 `JpqlSelectQueryUnionAll`을 처리합니다.
*   **DSL 통합 (`Jpql.kt`):**
    *   `jpql` 범위에 `union(left, right)` 및 `unionAll(left, right)` 최상위 레벨 함수를 추가했습니다.
    *   `JpqlQueryable<SelectQuery<T>>.union(right)` 및 `JpqlQueryable<SelectQuery<T>>.unionAll(right)` 확장 함수를 추가했습니다.
    *   이러한 DSL 진입점은 새로운 `JpqlSelectQueryUnion` 또는 `JpqlSelectQueryUnionAll` 모델을 구성합니다.
*   **쿼리 구성 로직 (예: `Jpql.kt` 내부 또는 신규 헬퍼/빌더 클래스):**
    *   `JpqlSelectQueryUnion` 또는 `JpqlSelectQueryUnionAll`을 구성할 때, 개별 `left` 및 `right` 피연산자 쿼리의 `orderBy` 절은 집합 연산 모델 내의 피연산자 자체로 전달되지 않습니다. `JpqlSelectQueryUnion(All)`의 `orderBy` 목록은 집합 연산의 *최종* 결과를 위한 것입니다.
*   **테스트:**
    *   Hibernate용 `UnionExample.kt` 및 reactive 환경용 해당 테스트를 생성하여, `ORDER BY` 절을 포함한 다양한 `UNION` 및 `UNION ALL` 시나리오를 커버합니다.
    *   모든 테스트는 통과하며, 생성된 JPQL이 집합 연산 및 정렬에 대한 예상 구문을 준수함을 검증합니다.

**다음 단계 (계획):**

*   집합 연산에 대한 이 전용 모델/serializer 접근 방식에 대한 피드백을 반영합니다.
*   유사한 패턴(즉, 전용 모델 및 serializer)을 사용하여 `INTERSECT` 및 `EXCEPT`를 구현합니다.
*   기여자 검토를 기반으로 구현을 구체화하고 다듬습니다.

본 PR은 집합 연산 처리를 위한 명확하고 구체적인 패턴을 확립합니다. 이 접근 방식이 향후 다른 집합 연산자 및 관련 기능 개발에 있어 더 나은 유지보수성과 명확성을 제공할 것으로 믿습니다. 피드백을 적극 환영합니다.