### PR TITLE
feat: implement EXCEPT and EXCEPT ALL with dedicated query models and serializers (follow-up to #880)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,7 +37,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
       - name: Lint Kotlin with Gradle
         run: ./gradlew lintKotlin
       - name: Cleanup Gradle Cache

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
       - name: Build with Grade
         run: ./gradlew build
       - name: Publish to the Maven Central Repository

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
       - name: CodeCoverage(with test) with Gradle
         run: ./gradlew koverXmlReport
       - name: Upload coverage to Codecov

--- a/docs/ko/jpql-with-kotlin-jdsl/statements.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/statements.md
@@ -168,18 +168,20 @@ having(
 )
 ```
 
-### 집합 연산 (`UNION`, `UNION ALL`)
+### 집합 연산 (`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`)
 
-Jakarta Persistence 3.2부터 JPQL은 집합 연산자를 사용하여 둘 이상의 `SELECT` 쿼리 결과를 결합하는 기능을 공식적으로 지원합니다. Kotlin JDSL은 이러한 새로운 표준 기능인 `UNION` 및 `UNION ALL` 연산을 지원합니다. (`INTERSECT` 및 `EXCEPT` 또한 JPA 3.2에 추가되었습니다.)
+Jakarta Persistence 3.2부터 JPQL은 집합 연산자를 사용하여 둘 이상의 `SELECT` 쿼리 결과를 결합하는 기능을 공식적으로 지원합니다. Kotlin JDSL은 이러한 새로운 표준 기능인 `UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL` 연산을 지원합니다. (`INTERSECT` 또한 JPA 3.2에 추가되었습니다.)
 
 *   `UNION`: 두 쿼리의 결과 집합을 결합하고 중복된 행을 제거합니다.
 *   `UNION ALL`: 두 쿼리의 결과 집합을 결합하고 모든 중복된 행을 포함합니다.
+*   `EXCEPT`: 첫 번째 쿼리에서 두 번째 쿼리에 없는 행을 반환하며, 중복을 제거합니다.
+*   `EXCEPT ALL`: 첫 번째 쿼리에서 두 번째 쿼리에 없는 행을 반환하며, 모든 중복을 포함합니다.
 
-`UNION` 또는 `UNION ALL` 연산에 포함되는 `SELECT` 문들은 select 목록에 동일한 수의 열을 가져야 하며, 해당 열의 데이터 타입은 서로 호환되어야 합니다.
+집합 연산(`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`)에 포함되는 `SELECT` 문들은 select 목록에 동일한 수의 열을 가져야 하며, 해당 열의 데이터 타입은 서로 호환되어야 합니다.
 
 **연결된 Select 쿼리와 함께 사용:**
 
-select 쿼리 구조(예: `select`, `from`, `where`, `groupBy`, 또는 `having` 절 뒤)에 `union()` 또는 `unionAll()`을 연결하여 사용할 수 있습니다. `orderBy()` 절이 사용되는 경우, 집합 연산의 최종 결과에 적용됩니다.
+select 쿼리 구조(예: `select`, `from`, `where`, `groupBy`, 또는 `having` 절 뒤)에 `union()`, `unionAll()`, `except()`, 또는 `exceptAll()`을 연결하여 사용할 수 있습니다. `orderBy()` 절이 사용되는 경우, 집합 연산의 최종 결과에 적용됩니다.
 
 ```kotlin
 // UNION 예제
@@ -223,11 +225,53 @@ val unionAllQuery = jpql {
         path(Author::name).desc()
     )
 }
+
+// EXCEPT 예제
+val exceptQuery = jpql {
+    select(
+        path(Book::isbn)
+    ).from(
+        entity(Book::class)
+    ).where(
+        path(Book::price)(BookPrice::value).lessThan(BigDecimal.valueOf(30))
+    ).except( // 우측 쿼리 또한 select 구조입니다.
+        select(
+            path(Book::isbn)
+        ).from(
+            entity(Book::class)
+        ).where(
+            path(Book::salePrice)(BookPrice::value).lessThan(BigDecimal.valueOf(20))
+        )
+    ).orderBy(
+        path(Book::isbn).asc()
+    )
+}
+
+// EXCEPT ALL 예제
+val exceptAllQuery = jpql {
+    select(
+        path(Author::name)
+    ).from(
+        entity(Author::class)
+    ).where(
+        path(Author::name).like("%Fantasy%")
+    ).exceptAll( // 우측 쿼리 또한 select 구조입니다.
+        select(
+            path(Author::name)
+        ).from(
+            entity(Author::class)
+        ).where(
+            path(Author::name).like("%Mystery%")
+        )
+    ).orderBy(
+        path(Author::name).desc()
+    )
+}
 ```
 
 **최상위 레벨 연산으로 사용:**
 
-`jpql` 블록 내에서 두 개의 `JpqlQueryable<SelectQuery<T>>` 인스턴스를 결합하여 `union()` 및 `unionAll()`을 최상위 레벨 연산으로 사용할 수도 있습니다.
+`jpql` 블록 내에서 두 개의 `JpqlQueryable<SelectQuery<T>>` 인스턴스를 결합하여 `union()`, `unionAll()`, `except()`, `exceptAll()`을 최상위 레벨 연산으로 사용할 수도 있습니다.
 
 ```kotlin
 val query1 = jpql {
@@ -255,11 +299,26 @@ val topLevelUnionAllQuery = jpql {
     unionAll(query1, query2)
         .orderBy(path(Book::isbn).asc())
 }
+
+// 최상위 레벨 EXCEPT ALL
+val topLevelExceptAllQuery = jpql {
+    exceptAll(query1, query2)
+        .orderBy(path(Book::isbn).asc())
+}
 ```
 
 **`ORDER BY`에 대한 중요 참고 사항:**
 
-`ORDER BY` 절은 `UNION` 또는 `UNION ALL` 연산의 최종 결과 집합에 적용됩니다. 집합 연산 자체에 영향을 미치는 방식으로 집합 연산의 일부인 개별 `SELECT` 쿼리에 적용될 수 없습니다. (물론, 하위 쿼리가 집합 연산 전에 결과를 제한하는 등의 다른 목적으로 자체 `ORDER BY`를 가질 수 있지만, 일반적으로 JPQL에서 `UNION`과 최종 정렬을 위해 상호 작용하는 방식은 아닙니다.) `ORDER BY` 절의 정렬 기준은 일반적으로 첫 번째 쿼리의 `SELECT` 목록에 있는 열의 별칭 또는 위치를 참조합니다.
+`ORDER BY` 절은 집합 연산(`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`)의 최종 결과 집합에 적용됩니다. 집합 연산 자체에 영향을 미치는 방식으로 집합 연산의 일부인 개별 `SELECT` 쿼리에 적용될 수 없습니다. (물론, 하위 쿼리가 집합 연산 전에 결과를 제한하는 등의 다른 목적으로 자체 `ORDER BY`를 가질 수 있지만, 일반적으로 JPQL에서 집합 연산과 최종 정렬을 위해 상호 작용하는 방식은 아닙니다.) `ORDER BY` 절의 정렬 기준은 일반적으로 첫 번째 쿼리의 `SELECT` 목록에 있는 열의 별칭 또는 위치를 참조합니다.
+
+**데이터베이스 호환성 참고사항:**
+
+이러한 집합 연산은 JPA 3.2 사양의 일부이지만, 모든 데이터베이스가 모든 연산을 지원하는 것은 아닙니다. 예를 들어:
+- H2 데이터베이스(버전 1.4.192 - 2.3.232)는 `UNION`, `UNION ALL`, `EXCEPT`를 지원하지만 `EXCEPT ALL`은 지원하지 않습니다
+- PostgreSQL, Oracle, SQL Server는 네 가지 연산(`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`)을 모두 지원합니다
+- MySQL은 `UNION`, `UNION ALL`은 지원하지만 `EXCEPT` 연산은 지원하지 않습니다 (대안으로 `NOT EXISTS` 또는 `LEFT JOIN` 사용)
+
+이러한 연산을 사용할 때는 대상 데이터베이스가 이를 지원하는지 확인하거나, 지원하지 않는 데이터베이스에 대한 대체 쿼리 전략을 제공해야 합니다.
 
 ### Order by clause
 

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -3382,6 +3382,62 @@ open class Jpql : JpqlDsl {
         return unionAll(this, right)
     }
 
+    /**
+     * Creates an EXCEPT query with two select queries.
+     */
+    @SinceJdsl("3.6.0")
+    @JvmName("except")
+    inline fun <reified T : Any> except(
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return SetOperatorQueryDsl(
+            returnType = T::class,
+            leftQuery = left,
+            setOperator = SetOperator.EXCEPT,
+            rightQuery = right,
+        )
+    }
+
+    /**
+     * Creates an EXCEPT ALL query with two select queries.
+     */
+    @JvmName("exceptAll")
+    @SinceJdsl("3.6.0")
+    inline fun <reified T : Any> exceptAll(
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return SetOperatorQueryDsl(
+            returnType = T::class,
+            leftQuery = left,
+            setOperator = SetOperator.EXCEPT_ALL,
+            rightQuery = right,
+        )
+    }
+
+    /**
+     * Creates an EXCEPT query that represents the except of this query and the [right] query.
+     */
+    @JvmName("exceptExtension")
+    @SinceJdsl("3.6.0")
+    inline fun <reified T : Any> JpqlQueryable<SelectQuery<T>>.except(
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return except(this, right)
+    }
+
+    /**
+     * Creates an EXCEPT ALL that represents the except all of this query and the [right] query.
+     */
+    @JvmName("exceptAllExtension")
+    @SinceJdsl("3.6.0")
+    inline fun <reified T : Any> JpqlQueryable<SelectQuery<T>>.exceptAll(
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return exceptAll(this, right)
+    }
+
     private fun valueOrExpression(value: Any): Expression<*> {
         return if (value is Expression<*>) {
             value

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperator.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperator.kt
@@ -7,4 +7,6 @@ import com.linecorp.kotlinjdsl.SinceJdsl
 internal enum class SetOperator {
     UNION,
     UNION_ALL,
+    EXCEPT,
+    EXCEPT_ALL,
 }

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorSelectQueryBuilder.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorSelectQueryBuilder.kt
@@ -33,6 +33,18 @@ internal data class SetOperatorSelectQueryBuilder<T : Any>(
                 right = rightQuery,
                 orderBy = orderBy,
             )
+            SetOperator.EXCEPT -> SelectQueries.selectExceptQuery(
+                returnType = returnType,
+                left = leftQuery,
+                right = rightQuery,
+                orderBy = orderBy,
+            )
+            SetOperator.EXCEPT_ALL -> SelectQueries.selectExceptAllQuery(
+                returnType = returnType,
+                left = leftQuery,
+                right = rightQuery,
+                orderBy = orderBy,
+            )
         }
     }
 }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/SetOperatorDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/SetOperatorDslTest.kt
@@ -4,6 +4,8 @@ import com.linecorp.kotlinjdsl.dsl.jpql.entity.book.Book
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.querymodel.jpql.entity.Entities
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExcept
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExceptAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnion
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnionAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
@@ -201,6 +203,198 @@ class SetOperatorDslTest : WithAssertions {
         assertThat(query).isInstanceOf(JpqlSelectQueryUnionAll::class.java)
 
         val actualUnionAll = query as JpqlSelectQueryUnionAll
+
+        assertThat(actualUnionAll.returnType).isEqualTo(Book::class)
+        assertThat(actualUnionAll.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnionAll.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnionAll.orderBy).isEqualTo(listOf(sort1))
+    }
+
+    @Test
+    fun `except between two queries`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            except(
+                subquery1,
+                subquery2,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryExcept::class.java)
+
+        val actualUnion = query as JpqlSelectQueryExcept
+
+        assertThat(actualUnion.returnType).isEqualTo(Book::class)
+        assertThat(actualUnion.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnion.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnion.orderBy).isNull()
+    }
+
+    @Test
+    fun `except between two queries with orderBy`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            except(
+                subquery1,
+                subquery2,
+            ).orderBy(
+                sort1,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryExcept::class.java)
+
+        val actualUnion = query as JpqlSelectQueryExcept
+
+        assertThat(actualUnion.returnType).isEqualTo(Book::class)
+        assertThat(actualUnion.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnion.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnion.orderBy).isEqualTo(listOf(sort1))
+    }
+
+    @Test
+    fun `except all between two queries`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            exceptAll(
+                subquery1,
+                subquery2,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryExceptAll::class.java)
+
+        val actualUnionAll = query as JpqlSelectQueryExceptAll
+
+        assertThat(actualUnionAll.returnType).isEqualTo(Book::class)
+        assertThat(actualUnionAll.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnionAll.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnionAll.orderBy).isNull()
+    }
+
+    @Test
+    fun `except all between two queries with orderBy`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            exceptAll(
+                subquery1,
+                subquery2,
+            ).orderBy(
+                sort1,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryExceptAll::class.java)
+
+        val actualUnionAll = query as JpqlSelectQueryExceptAll
 
         assertThat(actualUnionAll.returnType).isEqualTo(Book::class)
         assertThat(actualUnionAll.left.toQuery()).isEqualTo(subquery1)

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/ExceptMutinySessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/ExceptMutinySessionExample.kt
@@ -1,0 +1,206 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class ExceptMutinySessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getMutinySessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn2 = Isbn("02")
+
+    @Test
+    fun exceptBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            except(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    /**
+     * Test for EXCEPT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support EXCEPT ALL.
+     * H2 only supports EXCEPT but not EXCEPT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL EXCEPT ALL support: https://modern-sql.com/caniuse/except-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting EXCEPT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support EXCEPT ALL - only EXCEPT is supported")
+    fun exceptAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            exceptAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun exceptBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).except(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    /**
+     * Test for EXCEPT ALL operation using extension function syntax.
+     *
+     * Note: This test is disabled because H2 database does not support EXCEPT ALL.
+     * H2 only supports EXCEPT but not EXCEPT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL EXCEPT ALL support: https://modern-sql.com/caniuse/except-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting EXCEPT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support EXCEPT ALL - only EXCEPT is supported")
+    fun exceptAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).exceptAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+}

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/ExceptMutinyStatelessSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/ExceptMutinyStatelessSessionExample.kt
@@ -1,0 +1,206 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class ExceptMutinyStatelessSessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getMutinySessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn2 = Isbn("02")
+
+    @Test
+    fun exceptBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            except(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    /**
+     * Test for EXCEPT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support EXCEPT ALL.
+     * H2 only supports EXCEPT but not EXCEPT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL EXCEPT ALL support: https://modern-sql.com/caniuse/except-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting EXCEPT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support EXCEPT ALL - only EXCEPT is supported")
+    fun exceptAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            exceptAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun exceptBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).except(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    /**
+     * Test for EXCEPT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support EXCEPT ALL.
+     * H2 only supports EXCEPT but not EXCEPT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL EXCEPT ALL support: https://modern-sql.com/caniuse/except-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting EXCEPT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support EXCEPT ALL - only EXCEPT is supported")
+    fun exceptAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).exceptAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+}

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/ExceptStageSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/ExceptStageSessionExample.kt
@@ -1,0 +1,206 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class ExceptStageSessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getStageSessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn2 = Isbn("02")
+
+    @Test
+    fun exceptBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            except(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    /**
+     * Test for EXCEPT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support EXCEPT ALL.
+     * H2 only supports EXCEPT but not EXCEPT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL EXCEPT ALL support: https://modern-sql.com/caniuse/except-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting EXCEPT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support EXCEPT ALL - only EXCEPT is supported")
+    fun exceptAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            exceptAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun exceptBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).except(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    /**
+     * Test for EXCEPT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support EXCEPT ALL.
+     * H2 only supports EXCEPT but not EXCEPT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL EXCEPT ALL support: https://modern-sql.com/caniuse/except-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting EXCEPT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support EXCEPT ALL - only EXCEPT is supported")
+    fun exceptAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).exceptAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+}

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/ExceptStageStatelessSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/ExceptStageStatelessSessionExample.kt
@@ -1,0 +1,206 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class ExceptStageStatelessSessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getStageSessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn2 = Isbn("02")
+
+    @Test
+    fun exceptBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            except(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    /**
+     * Test for EXCEPT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support EXCEPT ALL.
+     * H2 only supports EXCEPT but not EXCEPT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL EXCEPT ALL support: https://modern-sql.com/caniuse/except-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting EXCEPT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support EXCEPT ALL - only EXCEPT is supported")
+    fun exceptAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            exceptAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun exceptBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).except(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    /**
+     * Test for EXCEPT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support EXCEPT ALL.
+     * H2 only supports EXCEPT but not EXCEPT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL EXCEPT ALL support: https://modern-sql.com/caniuse/except-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting EXCEPT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support EXCEPT ALL - only EXCEPT is supported")
+    fun exceptAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).exceptAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+}

--- a/example/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/select/ExceptExample.kt
+++ b/example/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/select/ExceptExample.kt
@@ -1,0 +1,189 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.EntityManagerFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.extension.createQuery
+import jakarta.persistence.TypedQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class ExceptExample : WithAssertions {
+    private val entityManagerFactory = EntityManagerFactoryTestUtils.getEntityManagerFactory()
+    private val entityManager = entityManagerFactory.createEntityManager()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn2 = Isbn("02")
+
+    @AfterEach
+    fun tearDown() {
+        entityManager.close()
+    }
+
+    @Test
+    fun exceptBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            except(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    /**
+     * Test for EXCEPT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support EXCEPT ALL.
+     * H2 only supports EXCEPT but not EXCEPT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL EXCEPT ALL support: https://modern-sql.com/caniuse/except-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting EXCEPT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support EXCEPT ALL - only EXCEPT is supported")
+    fun exceptAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            exceptAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    @Test
+    fun exceptBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).except(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+
+    /**
+     * Test for EXCEPT ALL operation using extension function syntax.
+     *
+     * Note: This test is disabled because H2 database does not support EXCEPT ALL.
+     * H2 only supports EXCEPT but not EXCEPT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL EXCEPT ALL support: https://modern-sql.com/caniuse/except-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting EXCEPT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support EXCEPT ALL - only EXCEPT is supported")
+    fun exceptAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).exceptAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn2,
+        )
+    }
+}

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/SelectQueries.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/SelectQueries.kt
@@ -7,6 +7,8 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.from.From
 import com.linecorp.kotlinjdsl.querymodel.jpql.from.Froms
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExcept
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExceptAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnion
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnionAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
@@ -66,6 +68,36 @@ object SelectQueries {
         orderBy: Iterable<Sort>?,
     ): SelectQuery<T> {
         return JpqlSelectQueryUnionAll(
+            returnType = returnType,
+            left = left,
+            right = right,
+            orderBy = orderBy,
+        )
+    }
+
+    @SinceJdsl("3.6.0")
+    fun <T : Any> selectExceptQuery(
+        returnType: KClass<T>,
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+        orderBy: Iterable<Sort>?,
+    ): SelectQuery<T> {
+        return JpqlSelectQueryExcept(
+            returnType = returnType,
+            left = left,
+            right = right,
+            orderBy = orderBy,
+        )
+    }
+
+    @SinceJdsl("3.6.0")
+    fun <T : Any> selectExceptAllQuery(
+        returnType: KClass<T>,
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+        orderBy: Iterable<Sort>?,
+    ): SelectQuery<T> {
+        return JpqlSelectQueryExceptAll(
             returnType = returnType,
             left = left,
             right = right,

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryExcept.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryExcept.kt
@@ -1,0 +1,15 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.select.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import kotlin.reflect.KClass
+
+@Internal
+data class JpqlSelectQueryExcept<T : Any> internal constructor(
+    override val returnType: KClass<T>,
+    val left: JpqlQueryable<SelectQuery<T>>,
+    val right: JpqlQueryable<SelectQuery<T>>,
+    val orderBy: Iterable<Sort>?,
+) : SelectQuery<T>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryExceptAll.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryExceptAll.kt
@@ -1,0 +1,15 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.select.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import kotlin.reflect.KClass
+
+@Internal
+data class JpqlSelectQueryExceptAll<T : Any> internal constructor(
+    override val returnType: KClass<T>,
+    val left: JpqlQueryable<SelectQuery<T>>,
+    val right: JpqlQueryable<SelectQuery<T>>,
+    val orderBy: Iterable<Sort>?,
+) : SelectQuery<T>

--- a/query-model/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/SelectQueriesTest.kt
+++ b/query-model/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/SelectQueriesTest.kt
@@ -13,6 +13,8 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.join.Joins
 import com.linecorp.kotlinjdsl.querymodel.jpql.path.Paths
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicates
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExcept
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExceptAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnion
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnionAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
@@ -146,6 +148,88 @@ class SelectQueriesTest : WithAssertions {
 
         // then
         val expected = JpqlSelectQueryUnionAll(
+            returnType = Class1::class,
+            left = left,
+            right = right,
+            orderBy = listOf(sort1, sort2),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun selectExceptQuery() {
+        // when
+        val left = SelectQueries.selectQuery(
+            returnType = Class1::class,
+            distinct = false,
+            select = listOf(expression1, expression2),
+            from = listOf(entity1, join1, join2, entity2, entity3),
+            where = predicate1,
+            groupBy = listOf(expression3, expression4),
+            having = predicate2,
+            orderBy = listOf(sort1, sort2),
+        )
+        val right = SelectQueries.selectQuery(
+            returnType = Class1::class,
+            distinct = false,
+            select = listOf(expression1),
+            from = listOf(entity1),
+            where = predicate1,
+            groupBy = listOf(expression3, expression4),
+            having = predicate2,
+            orderBy = listOf(sort1, sort2),
+        )
+        val actual = SelectQueries.selectExceptQuery(
+            returnType = Class1::class,
+            left = left,
+            right = right,
+            orderBy = listOf(sort1, sort2),
+        )
+
+        // then
+        val expected = JpqlSelectQueryExcept(
+            returnType = Class1::class,
+            left = left,
+            right = right,
+            orderBy = listOf(sort1, sort2),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun selectExceptAllQuery() {
+        // when
+        val left = SelectQueries.selectQuery(
+            returnType = Class1::class,
+            distinct = false,
+            select = listOf(expression1, expression2),
+            from = listOf(entity1, join1, join2, entity2, entity3),
+            where = predicate1,
+            groupBy = listOf(expression3, expression4),
+            having = predicate2,
+            orderBy = listOf(sort1, sort2),
+        )
+        val right = SelectQueries.selectQuery(
+            returnType = Class1::class,
+            distinct = false,
+            select = listOf(expression1),
+            from = listOf(entity1),
+            where = predicate1,
+            groupBy = listOf(expression3, expression4),
+            having = predicate2,
+            orderBy = listOf(sort1, sort2),
+        )
+        val actual = SelectQueries.selectExceptAllQuery(
+            returnType = Class1::class,
+            left = left,
+            right = right,
+            orderBy = listOf(sort1, sort2),
+        )
+
+        // then
+        val expected = JpqlSelectQueryExceptAll(
             returnType = Class1::class,
             left = left,
             right = right,

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
@@ -108,6 +108,8 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlPlusSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlPowerSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlPredicateParenthesesSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlRoundSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryExceptAllSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryExceptSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQuerySerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryUnionAllSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryUnionSerializer
@@ -373,6 +375,8 @@ private class DefaultModule : JpqlRenderModule {
             JpqlPowerSerializer(),
             JpqlPredicateParenthesesSerializer(),
             JpqlRoundSerializer(),
+            JpqlSelectQueryExceptAllSerializer(),
+            JpqlSelectQueryExceptSerializer(),
             JpqlSelectQuerySerializer(),
             JpqlSelectQueryUnionAllSerializer(),
             JpqlSelectQueryUnionSerializer(),

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryExceptAllSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryExceptAllSerializer.kt
@@ -1,0 +1,48 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExceptAll
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@Internal
+class JpqlSelectQueryExceptAllSerializer : JpqlSerializer<JpqlSelectQueryExceptAll<*>> {
+    override fun handledType(): KClass<JpqlSelectQueryExceptAll<*>> =
+        JpqlSelectQueryExceptAll::class
+
+    override fun serialize(part: JpqlSelectQueryExceptAll<*>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        val queryContext = context + JpqlRenderStatement.Select
+
+        delegate.serialize(part.left.toQuery(), writer, queryContext)
+
+        writer.write(" EXCEPT ALL ")
+
+        delegate.serialize(part.right.toQuery(), writer, queryContext)
+
+        writeOrderBy(part, queryContext, writer, delegate)
+    }
+
+    private fun writeOrderBy(
+        part: JpqlSelectQueryExceptAll<*>,
+        queryContext: RenderContext,
+        writer: JpqlWriter,
+        delegate: JpqlRenderSerializer,
+    ) {
+        part.orderBy?.takeIf { it.any() }?.let { orderByItems ->
+            val orderByInSetOperationContext = queryContext + JpqlRenderClause.OrderBy
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            writer.writeEach(orderByItems, separator = ", ") { sortElement ->
+                delegate.serialize(sortElement, writer, orderByInSetOperationContext)
+            }
+        }
+    }
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryExceptSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryExceptSerializer.kt
@@ -1,0 +1,48 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExcept
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@Internal
+class JpqlSelectQueryExceptSerializer : JpqlSerializer<JpqlSelectQueryExcept<*>> {
+    override fun handledType(): KClass<JpqlSelectQueryExcept<*>> =
+        JpqlSelectQueryExcept::class
+
+    override fun serialize(part: JpqlSelectQueryExcept<*>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        val queryContext = context + JpqlRenderStatement.Select
+
+        delegate.serialize(part.left.toQuery(), writer, queryContext)
+
+        writer.write(" EXCEPT ")
+
+        delegate.serialize(part.right.toQuery(), writer, queryContext)
+
+        writeOrderBy(part, queryContext, writer, delegate)
+    }
+
+    private fun writeOrderBy(
+        part: JpqlSelectQueryExcept<*>,
+        queryContext: RenderContext,
+        writer: JpqlWriter,
+        delegate: JpqlRenderSerializer,
+    ) {
+        part.orderBy?.takeIf { it.any() }?.let { orderByItems ->
+            val orderByInSetOperationContext = queryContext + JpqlRenderClause.OrderBy
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            writer.writeEach(orderByItems, separator = ", ") { sortElement ->
+                delegate.serialize(sortElement, writer, orderByInSetOperationContext)
+            }
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryExceptAllSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryExceptAllSerializerTest.kt
@@ -1,0 +1,108 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExceptAll
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@JpqlSerializerTest
+@ExtendWith(MockKExtension::class)
+class JpqlSelectQueryExceptAllSerializerTest : WithAssertions {
+    private val sut = JpqlSelectQueryExceptAllSerializer()
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    private lateinit var initialContext: RenderContext
+
+    @BeforeEach
+    fun setUp() {
+        initialContext = TestRenderContext(serializer)
+    }
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlSelectQueryExceptAll::class)
+    }
+
+    @Test
+    fun `serialize operation`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        val part = SelectQueries.selectExceptAllQuery(
+            String::class,
+            leftQuery,
+            rightQuery,
+            orderBy = null,
+        ) as JpqlSelectQueryExceptAll
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        // then
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" EXCEPT ALL ")
+            serializer.serialize(rightQuery, writer, queryContext)
+        }
+    }
+
+    @Test
+    fun `serialize operation with order by`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+        val sort = mockk<Sort>()
+        val part = SelectQueries.selectExceptAllQuery(
+            returnType = String::class,
+            left = leftQuery,
+            right = rightQuery,
+            orderBy = listOf(sort),
+        ) as JpqlSelectQueryExceptAll
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        val orderByContext = queryContext + JpqlRenderClause.OrderBy
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        // then
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" EXCEPT ALL ")
+            serializer.serialize(rightQuery, writer, queryContext)
+
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            serializer.serialize(sort, writer, orderByContext)
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryExceptSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryExceptSerializerTest.kt
@@ -1,0 +1,108 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExcept
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@JpqlSerializerTest
+@ExtendWith(MockKExtension::class)
+class JpqlSelectQueryExceptSerializerTest : WithAssertions {
+    private val sut = JpqlSelectQueryExceptSerializer()
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    private lateinit var initialContext: RenderContext
+
+    @BeforeEach
+    fun setUp() {
+        initialContext = TestRenderContext(serializer)
+    }
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlSelectQueryExcept::class)
+    }
+
+    @Test
+    fun `serialize operation`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        val part = SelectQueries.selectExceptQuery(
+            String::class,
+            leftQuery,
+            rightQuery,
+            orderBy = null,
+        ) as JpqlSelectQueryExcept
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        // then
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" EXCEPT ")
+            serializer.serialize(rightQuery, writer, queryContext)
+        }
+    }
+
+    @Test
+    fun `serialize operation with order by`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+        val sort = mockk<Sort>()
+        val part = SelectQueries.selectExceptQuery(
+            returnType = String::class,
+            left = leftQuery,
+            right = rightQuery,
+            orderBy = listOf(sort),
+        ) as JpqlSelectQueryExcept
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        val orderByContext = queryContext + JpqlRenderClause.OrderBy
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        // then
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" EXCEPT ")
+            serializer.serialize(rightQuery, writer, queryContext)
+
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            serializer.serialize(sort, writer, orderByContext)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for `EXCEPT` and `EXCEPT ALL` set operations in Kotlin-JDSL, following the same pattern established in PR #883 for UNION operations. The implementation uses dedicated query models and serializers for each operation type to maintain consistency and extensibility.

## What's Changed

**New Query Models:**
- `JpqlSelectQueryExcept<T>` - represents `EXCEPT` operations 
- `JpqlSelectQueryExceptAll<T>` - represents `EXCEPT ALL` operations

**New Serializers:**
- `JpqlSelectQueryExceptSerializer` - renders ` EXCEPT ` with proper spacing
- `JpqlSelectQueryExceptAllSerializer` - renders ` EXCEPT ALL ` with proper spacing

**DSL Integration:**
- Added `except()` and `exceptAll()` functions to `Jpql.kt`
- Support for both chained style: `select(...).except(...)` 
- And top-level style: `jpql { except(query1, query2) }`

**Examples & Tests:**
- Created `ExceptExample.kt` for hibernate and hibernate-reactive modules
- Added comprehensive test coverage for both operations
- **Note on H2 compatibility:** `EXCEPT ALL` tests are disabled with `@Disabled` because H2 database (versions 1.4.192-2.3.232) doesn't support `EXCEPT ALL` - only `EXCEPT`. Added detailed comments explaining the limitation and referencing H2 documentation.

**Documentation:**
- Updated both English and Korean docs in `statements.md`
- Added EXCEPT/EXCEPT ALL to the existing "Set Operations" section 
- Included database compatibility notes and usage examples

**CI/CD Updates:**
- Updated deprecated `gradle/wrapper-validation-action` to `gradle/actions/wrapper-validation` as per [Gradle Actions deprecation guide](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlewrapper-validation-action-has-been-replaced-by-gradleactionswrapper-validation)

## Database Support

- ✅ H2: `EXCEPT` only (no `EXCEPT ALL`)
- ✅ PostgreSQL, Oracle, SQL Server: Both operations
- ❌ MySQL: Neither (use `NOT EXISTS` or `LEFT JOIN` instead)

The implementation follows JPA 3.2 specification and generates standard JPQL that works across supported databases.

---

## Korean

이 PR은 Kotlin-JDSL에 `EXCEPT` 및 `EXCEPT ALL` 집합 연산 지원을 추가합니다. UNION 연산을 위해 PR #883에서 확립된 동일한 패턴을 따라 일관성과 확장성을 유지하기 위해 각 연산 타입에 대해 전용 쿼리 모델과 serializer를 사용합니다.

## 변경사항

**새로운 쿼리 모델:**
- `JpqlSelectQueryExcept<T>` - `EXCEPT` 연산 표현
- `JpqlSelectQueryExceptAll<T>` - `EXCEPT ALL` 연산 표현

**새로운 Serializer:**
- `JpqlSelectQueryExceptSerializer` - 적절한 공백으로 ` EXCEPT ` 렌더링
- `JpqlSelectQueryExceptAllSerializer` - 적절한 공백으로 ` EXCEPT ALL ` 렌더링

**DSL 통합:**
- `Jpql.kt`에 `except()` 및 `exceptAll()` 함수 추가
- 체이닝 스타일 지원: `select(...).except(...)`
- 최상위 스타일 지원: `jpql { except(query1, query2) }`

**예제 및 테스트:**
- hibernate 및 hibernate-reactive 모듈용 `ExceptExample.kt` 생성
- 두 연산 모두에 대한 포괄적인 테스트 커버리지 추가
- **H2 호환성 참고:** H2 데이터베이스(버전 1.4.192-2.3.232)가 `EXCEPT ALL`을 지원하지 않고 `EXCEPT`만 지원하므로 `EXCEPT ALL` 테스트는 `@Disabled`로 비활성화됨. 제한사항을 설명하고 H2 문서를 참조하는 상세한 주석 추가.

**문서화:**
- `statements.md`의 영문 및 한글 문서 업데이트
- 기존 "집합 연산" 섹션에 EXCEPT/EXCEPT ALL 추가
- 데이터베이스 호환성 참고사항 및 사용 예제 포함

**CI/CD 업데이트:**
- [Gradle Actions deprecation 가이드](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlewrapper-validation-action-has-been-replaced-by-gradleactionswrapper-validation)에 따라 deprecated된 `gradle/wrapper-validation-action`을 `gradle/actions/wrapper-validation`으로 업데이트

## 데이터베이스 지원

- ✅ H2: `EXCEPT`만 지원 (`EXCEPT ALL` 지원 안함)
- ✅ PostgreSQL, Oracle, SQL Server: 두 연산 모두 지원
- ❌ MySQL: 둘 다 지원 안함 (대신 `NOT EXISTS` 또는 `LEFT JOIN` 사용)

구현은 JPA 3.2 사양을 따르며 지원되는 데이터베이스에서 작동하는 표준 JPQL을 생성합니다.