### PR TITLE
feat: implement cast, right, left, replace expressions

### DIFF
--- a/docs/en/jpql-with-kotlin-jdsl/expressions.md
+++ b/docs/en/jpql-with-kotlin-jdsl/expressions.md
@@ -220,8 +220,11 @@ length(path(Book::title))
 
 locate("Book", path(Book::title))
 
-cast(path(Book::price), String::class)
-cast<String>(path(Book::price))
+cast(path(Book::price)).asString()
+cast(path(Book::authorId)).asInt()
+cast(path(Book::authorId)).asLong()
+cast(path(Book::authorId)).asDouble()
+cast(path(Book::authorId)).asFloat()
 
 left(path(Book::title), 3)
 left(path(Book::title), literal(3))
@@ -230,6 +233,10 @@ right(path(Book::title), 3)
 right(path(Book::title), literal(3))
 
 replace(path(Book::title), "old", "new")
+replace(path(Book::title), stringLiteral("old"), "new")
+replace(path(Book::title), path(Book::name), "new")
+replace(path(Book::title), "old", stringLiteral("new"))
+replace(path(Book::title), "old", path(Book::name))
 replace(path(Book::title), literal("old"), literal("new"))
 ```
 

--- a/docs/en/jpql-with-kotlin-jdsl/expressions.md
+++ b/docs/en/jpql-with-kotlin-jdsl/expressions.md
@@ -199,6 +199,10 @@ Kotlin JDSL provides a series of functions to support built-in functions in JPA.
 * UPPER (upper)
 * LENGTH (length)
 * LOCATE (locate)
+* CAST (cast) - *Added in JPA 3.2*
+* LEFT (left) - *Added in JPA 3.2*
+* RIGHT (right) - *Added in JPA 3.2*
+* REPLACE (replace) - *Added in JPA 3.2*
 
 ```kotlin
 concat(path(Book::title), literal(":"), path(Book::imageUrl))
@@ -215,6 +219,18 @@ upper(path(Book::title))
 length(path(Book::title))
 
 locate("Book", path(Book::title))
+
+cast(path(Book::price), String::class)
+cast<String>(path(Book::price))
+
+left(path(Book::title), 3)
+left(path(Book::title), literal(3))
+
+right(path(Book::title), 3)
+right(path(Book::title), literal(3))
+
+replace(path(Book::title), "old", "new")
+replace(path(Book::title), literal("old"), literal("new"))
 ```
 
 ### Arithmetic functions

--- a/docs/ko/jpql-with-kotlin-jdsl/expressions.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/expressions.md
@@ -197,6 +197,10 @@ Kotlin JDSL은 JPA에서 제공하는 여러 함수들을 지원하기 위한 �
 * UPPER (upper)
 * LENGTH (length)
 * LOCATE (locate)
+* CAST (cast) - *JPA 3.2에 추가됨*
+* LEFT (left) - *JPA 3.2에 추가됨*
+* RIGHT (right) - *JPA 3.2에 추가됨*
+* REPLACE (replace) - *JPA 3.2에 추가됨*
 
 ```kotlin
 concat(path(Book::title), literal(":"), path(Book::imageUrl))
@@ -213,6 +217,18 @@ upper(path(Book::title))
 length(path(Book::title))
 
 locate("Book", path(Book::title))
+
+cast(path(Book::price), String::class)
+cast<String>(path(Book::price))
+
+left(path(Book::title), 3)
+left(path(Book::title), literal(3))
+
+right(path(Book::title), 3)
+right(path(Book::title), literal(3))
+
+replace(path(Book::title), "old", "new")
+replace(path(Book::title), literal("old"), literal("new"))
 ```
 
 ### Arithmetic functions

--- a/docs/ko/jpql-with-kotlin-jdsl/expressions.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/expressions.md
@@ -218,8 +218,11 @@ length(path(Book::title))
 
 locate("Book", path(Book::title))
 
-cast(path(Book::price), String::class)
-cast<String>(path(Book::price))
+cast(path(Book::price)).asString()
+cast(path(Book::authorId)).asInt()
+cast(path(Book::authorId)).asLong()
+cast(path(Book::authorId)).asDouble()
+cast(path(Book::authorId)).asFloat()
 
 left(path(Book::title), 3)
 left(path(Book::title), literal(3))
@@ -228,6 +231,10 @@ right(path(Book::title), 3)
 right(path(Book::title), literal(3))
 
 replace(path(Book::title), "old", "new")
+replace(path(Book::title), stringLiteral("old"), "new")
+replace(path(Book::title), path(Book::name), "new")
+replace(path(Book::title), "old", stringLiteral("new"))
+replace(path(Book::title), "old", path(Book::name))
 replace(path(Book::title), literal("old"), literal("new"))
 ```
 

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -5,9 +5,13 @@ import com.linecorp.kotlinjdsl.dsl.jpql.delete.DeleteQueryWhereStep
 import com.linecorp.kotlinjdsl.dsl.jpql.delete.impl.DeleteQueryDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.CaseThenFirstStep
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.CaseValueWhenFirstStep
+import com.linecorp.kotlinjdsl.dsl.jpql.expression.CastStep
+import com.linecorp.kotlinjdsl.dsl.jpql.expression.StringCastStep
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.TrimFromStep
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.CaseThenFirstStepDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.CaseValueWhenFirstStepDsl
+import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.JpqlCastStep
+import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.JpqlStringCastStep
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.TrimBothFromStepDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.TrimFromStepDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.TrimLeadingFromStepDsl
@@ -1706,19 +1710,19 @@ open class Jpql : JpqlDsl {
     }
 
     /**
-     * Creates an expression that represents the casting of a value to a different type.
+     * Creates a step to cast a string expression to another type.
      */
     @SinceJdsl("3.6.0")
-    fun <T : Any> cast(value: Expressionable<*>, type: KClass<T>): Expression<T> {
-        return Expressions.cast(value.toExpression(), type)
+    fun cast(value: Expressionable<String>): CastStep {
+        return JpqlCastStep(value.toExpression())
     }
 
     /**
-     * Creates an expression that represents the casting of a value to a different type.
+     * Creates a step to cast a scalar expression to a string.
      */
     @SinceJdsl("3.6.0")
-    inline fun <reified T : Any> cast(value: Expressionable<*>): Expression<T> {
-        return Expressions.cast(value.toExpression(), T::class)
+    fun <T : Any> cast(value: Expressionable<T>): StringCastStep {
+        return JpqlStringCastStep(value.toExpression())
     }
 
     /**

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -1725,32 +1725,32 @@ open class Jpql : JpqlDsl {
      * Creates an expression that returns the leftmost count characters from a string.
      */
     @SinceJdsl("3.6.0")
-    fun left(value: Expressionable<String>, count: Expressionable<Int>): Expression<String> {
-        return Expressions.left(value.toExpression(), count.toExpression())
+    fun left(value: Expressionable<String>, len: Expressionable<Int>): Expression<String> {
+        return Expressions.left(value.toExpression(), len.toExpression())
     }
 
     /**
      * Creates an expression that returns the leftmost count characters from a string.
      */
     @SinceJdsl("3.6.0")
-    fun left(value: Expressionable<String>, count: Int): Expression<String> {
-        return Expressions.left(value.toExpression(), intLiteral(count))
+    fun left(value: Expressionable<String>, len: Int): Expression<String> {
+        return left(value.toExpression(), intLiteral(len))
     }
 
     /**
      * Creates an expression that returns the rightmost count characters from a string.
      */
     @SinceJdsl("3.6.0")
-    fun right(value: Expressionable<String>, count: Expressionable<Int>): Expression<String> {
-        return Expressions.right(value.toExpression(), count.toExpression())
+    fun right(value: Expressionable<String>, len: Expressionable<Int>): Expression<String> {
+        return Expressions.right(value.toExpression(), len.toExpression())
     }
 
     /**
      * Creates an expression that returns the rightmost count characters from a string.
      */
     @SinceJdsl("3.6.0")
-    fun right(value: Expressionable<String>, count: Int): Expression<String> {
-        return Expressions.right(value.toExpression(), intLiteral(count))
+    fun right(value: Expressionable<String>, len: Int): Expression<String> {
+        return right(value.toExpression(), intLiteral(len))
     }
 
     /**
@@ -1759,10 +1759,10 @@ open class Jpql : JpqlDsl {
     @SinceJdsl("3.6.0")
     fun replace(
         value: Expressionable<String>,
-        search: Expressionable<String>,
+        substring: Expressionable<String>,
         replacement: Expressionable<String>,
     ): Expression<String> {
-        return Expressions.replace(value.toExpression(), search.toExpression(), replacement.toExpression())
+        return Expressions.replace(value.toExpression(), substring.toExpression(), replacement.toExpression())
     }
 
     /**
@@ -1771,10 +1771,34 @@ open class Jpql : JpqlDsl {
     @SinceJdsl("3.6.0")
     fun replace(
         value: Expressionable<String>,
-        search: String,
+        substring: String,
         replacement: String,
     ): Expression<String> {
-        return Expressions.replace(value.toExpression(), stringLiteral(search), stringLiteral(replacement))
+        return replace(value.toExpression(), stringLiteral(substring), stringLiteral(replacement))
+    }
+
+    /**
+     * Creates an expression that replaces all occurrences of a search string with a replacement string.
+     */
+    @SinceJdsl("3.6.0")
+    fun replace(
+        value: Expressionable<String>,
+        substring: Expressionable<String>,
+        replacement: String,
+    ): Expression<String> {
+        return replace(value.toExpression(), substring, stringLiteral(replacement))
+    }
+
+    /**
+     * Creates an expression that replaces all occurrences of a search string with a replacement string.
+     */
+    @SinceJdsl("3.6.0")
+    fun replace(
+        value: Expressionable<String>,
+        substring: String,
+        replacement: Expressionable<String>,
+    ): Expression<String> {
+        return replace(value.toExpression(), substring, replacement)
     }
 
     /**

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -6,12 +6,12 @@ import com.linecorp.kotlinjdsl.dsl.jpql.delete.impl.DeleteQueryDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.CaseThenFirstStep
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.CaseValueWhenFirstStep
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.CastStep
-import com.linecorp.kotlinjdsl.dsl.jpql.expression.StringCastStep
+import com.linecorp.kotlinjdsl.dsl.jpql.expression.CastStepToString
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.TrimFromStep
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.CaseThenFirstStepDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.CaseValueWhenFirstStepDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.JpqlCastStep
-import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.JpqlStringCastStep
+import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.JpqlCastStepToString
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.TrimBothFromStepDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.TrimFromStepDsl
 import com.linecorp.kotlinjdsl.dsl.jpql.expression.impl.TrimLeadingFromStepDsl
@@ -1721,8 +1721,8 @@ open class Jpql : JpqlDsl {
      * Creates a step to cast a scalar expression to a string.
      */
     @SinceJdsl("3.6.0")
-    fun <T : Any> cast(value: Expressionable<T>): StringCastStep {
-        return JpqlStringCastStep(value.toExpression())
+    fun <T : Any> cast(value: Expressionable<T>): CastStepToString {
+        return JpqlCastStepToString(value.toExpression())
     }
 
     /**

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -1706,6 +1706,78 @@ open class Jpql : JpqlDsl {
     }
 
     /**
+     * Creates an expression that represents the casting of a value to a different type.
+     */
+    @SinceJdsl("3.6.0")
+    fun <T : Any> cast(value: Expressionable<*>, type: KClass<T>): Expression<T> {
+        return Expressions.cast(value.toExpression(), type)
+    }
+
+    /**
+     * Creates an expression that represents the casting of a value to a different type.
+     */
+    @SinceJdsl("3.6.0")
+    inline fun <reified T : Any> cast(value: Expressionable<*>): Expression<T> {
+        return Expressions.cast(value.toExpression(), T::class)
+    }
+
+    /**
+     * Creates an expression that returns the leftmost count characters from a string.
+     */
+    @SinceJdsl("3.6.0")
+    fun left(value: Expressionable<String>, count: Expressionable<Int>): Expression<String> {
+        return Expressions.left(value.toExpression(), count.toExpression())
+    }
+
+    /**
+     * Creates an expression that returns the leftmost count characters from a string.
+     */
+    @SinceJdsl("3.6.0")
+    fun left(value: Expressionable<String>, count: Int): Expression<String> {
+        return Expressions.left(value.toExpression(), intLiteral(count))
+    }
+
+    /**
+     * Creates an expression that returns the rightmost count characters from a string.
+     */
+    @SinceJdsl("3.6.0")
+    fun right(value: Expressionable<String>, count: Expressionable<Int>): Expression<String> {
+        return Expressions.right(value.toExpression(), count.toExpression())
+    }
+
+    /**
+     * Creates an expression that returns the rightmost count characters from a string.
+     */
+    @SinceJdsl("3.6.0")
+    fun right(value: Expressionable<String>, count: Int): Expression<String> {
+        return Expressions.right(value.toExpression(), intLiteral(count))
+    }
+
+    /**
+     * Creates an expression that replaces all occurrences of a search string with a replacement string.
+     */
+    @SinceJdsl("3.6.0")
+    fun replace(
+        value: Expressionable<String>,
+        search: Expressionable<String>,
+        replacement: Expressionable<String>,
+    ): Expression<String> {
+        return Expressions.replace(value.toExpression(), search.toExpression(), replacement.toExpression())
+    }
+
+    /**
+     * Creates an expression that replaces all occurrences of a search string with a replacement string.
+     */
+    @SinceJdsl("3.6.0")
+    fun replace(
+        value: Expressionable<String>,
+        search: String,
+        replacement: String,
+    ): Expression<String> {
+        return Expressions.replace(value.toExpression(), stringLiteral(search), stringLiteral(replacement))
+    }
+
+    /**
      * Creates an expression that represents predefined database functions and user-defined database functions.
      */
     @LowPriorityInOverloadResolution

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/CastStep.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/CastStep.kt
@@ -1,0 +1,35 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.expression
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressionable
+
+/**
+ * A step to specify the target type for a cast from a string expression.
+ * This corresponds to the BNF: CAST(string_expression AS {type})
+ */
+@SinceJdsl("3.6.0")
+interface CastStep {
+    /**
+     * Casts the expression to an INTEGER.
+     */
+    @SinceJdsl("3.6.0")
+    fun asInteger(): Expressionable<Int>
+
+    /**
+     * Casts the expression to a LONG.
+     */
+    @SinceJdsl("3.6.0")
+    fun asLong(): Expressionable<Long>
+
+    /**
+     * Casts the expression to a FLOAT.
+     */
+    @SinceJdsl("3.6.0")
+    fun asFloat(): Expressionable<Float>
+
+    /**
+     * Casts the expression to a DOUBLE.
+     */
+    @SinceJdsl("3.6.0")
+    fun asDouble(): Expressionable<Double>
+}

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/CastStepToString.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/CastStepToString.kt
@@ -8,7 +8,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressionable
  * This corresponds to the BNF: CAST(scalar_expression AS STRING)
  */
 @SinceJdsl("3.6.0")
-interface StringCastStep {
+interface CastStepToString {
     /**
      * Casts the expression to a STRING.
      */

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/StringCastStep.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/StringCastStep.kt
@@ -1,0 +1,17 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.expression
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressionable
+
+/**
+ * A step to cast a scalar expression to a STRING.
+ * This corresponds to the BNF: CAST(scalar_expression AS STRING)
+ */
+@SinceJdsl("3.6.0")
+interface StringCastStep {
+    /**
+     * Casts the expression to a STRING.
+     */
+    @SinceJdsl("3.6.0")
+    fun asString(): Expressionable<String>
+}

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/impl/JpqlCastStep.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/impl/JpqlCastStep.kt
@@ -1,0 +1,27 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.dsl.jpql.expression.CastStep
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressionable
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCast
+
+@PublishedApi
+internal data class JpqlCastStep(
+    private val expression: Expression<String>,
+) : CastStep {
+    override fun asInteger(): Expressionable<Int> {
+        return JpqlCast(expression, Int::class)
+    }
+
+    override fun asLong(): Expressionable<Long> {
+        return JpqlCast(expression, Long::class)
+    }
+
+    override fun asFloat(): Expressionable<Float> {
+        return JpqlCast(expression, Float::class)
+    }
+
+    override fun asDouble(): Expressionable<Double> {
+        return JpqlCast(expression, Double::class)
+    }
+}

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/impl/JpqlCastStepToString.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/impl/JpqlCastStepToString.kt
@@ -1,14 +1,14 @@
 package com.linecorp.kotlinjdsl.dsl.jpql.expression.impl
 
-import com.linecorp.kotlinjdsl.dsl.jpql.expression.StringCastStep
+import com.linecorp.kotlinjdsl.dsl.jpql.expression.CastStepToString
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressionable
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCast
 
 @PublishedApi
-internal data class JpqlStringCastStep<T : Any>(
+internal data class JpqlCastStepToString<T : Any>(
     private val expression: Expression<T>,
-) : StringCastStep {
+) : CastStepToString {
     override fun asString(): Expressionable<String> {
         return JpqlCast(expression, String::class)
     }

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/impl/JpqlStringCastStep.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/impl/JpqlStringCastStep.kt
@@ -1,0 +1,15 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.dsl.jpql.expression.StringCastStep
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressionable
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCast
+
+@PublishedApi
+internal data class JpqlStringCastStep<T : Any>(
+    private val expression: Expression<T>,
+) : StringCastStep {
+    override fun asString(): Expressionable<String> {
+        return JpqlCast(expression, String::class)
+    }
+}

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/ExpressionDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/ExpressionDslTest.kt
@@ -44,4 +44,158 @@ class ExpressionDslTest : WithAssertions {
 
         assertThat(actual).isEqualTo(expected)
     }
+
+    @Test
+    fun `cast() with a expression and a class`() {
+        // when
+        val expression = queryPart {
+            cast(expression(String::class, alias1), Int::class)
+        }.toExpression()
+
+        val actual: Expression<Int> = expression // for type check
+
+        // then
+        val expected = Expressions.cast(
+            Expressions.expression(String::class, alias1),
+            Int::class,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `inline cast() with a expression and a class`() {
+        // when
+        val expression = queryPart {
+            cast<Int>(expression(String::class, alias1))
+        }.toExpression()
+
+        val actual: Expression<Int> = expression // for type check
+
+        // then
+        val expected = Expressions.cast(
+            Expressions.expression(String::class, alias1),
+            Int::class,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `left() with two expressions`() {
+        // when
+        val expression = queryPart {
+            left(expression(String::class, alias1), expression(Int::class, "alias2"))
+        }.toExpression()
+
+        val actual: Expression<String> = expression // for type check
+
+        // then
+        val expected = Expressions.left(
+            Expressions.expression(String::class, alias1),
+            Expressions.expression(Int::class, "alias2"),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `left() literal with two expressions`() {
+        // when
+        val expression = queryPart {
+            left(expression(String::class, alias1), 1)
+        }.toExpression()
+
+        val actual: Expression<String> = expression // for type check
+
+        // then
+        val expected = Expressions.left(
+            Expressions.expression(String::class, alias1),
+            Expressions.intLiteral(1),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `right() with two expressions`() {
+        // when
+        val expression = queryPart {
+            right(expression(String::class, alias1), expression(Int::class, "alias2"))
+        }.toExpression()
+
+        val actual: Expression<String> = expression // for type check
+
+        // then
+        val expected = Expressions.right(
+            Expressions.expression(String::class, alias1),
+            Expressions.expression(Int::class, "alias2"),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `right() literal with two expressions`() {
+        // when
+        val expression = queryPart {
+            right(expression(String::class, alias1), 1)
+        }.toExpression()
+
+        val actual: Expression<String> = expression // for type check
+
+        // then
+        val expected = Expressions.right(
+            Expressions.expression(String::class, alias1),
+            Expressions.intLiteral(1),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `replace() with three expressions`() {
+        // when
+        val expression = queryPart {
+            replace(
+                expression(String::class, alias1),
+                expression(String::class, "alias2"),
+                expression(String::class, "alias3"),
+            )
+        }.toExpression()
+
+        val actual: Expression<String> = expression // for type check
+
+        // then
+        val expected = Expressions.replace(
+            Expressions.expression(String::class, alias1),
+            Expressions.expression(String::class, "alias2"),
+            Expressions.expression(String::class, "alias3"),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `replace() literal with three expressions`() {
+        // when
+        val expression = queryPart {
+            replace(
+                expression(String::class, alias1),
+                "string1",
+                "string2",
+            )
+        }.toExpression()
+
+        val actual: Expression<String> = expression // for type check
+
+        // then
+        val expected = Expressions.replace(
+            Expressions.expression(String::class, alias1),
+            Expressions.stringLiteral("string1"),
+            Expressions.stringLiteral("string2"),
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
 }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/ExpressionDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/ExpressionDslTest.kt
@@ -46,10 +46,10 @@ class ExpressionDslTest : WithAssertions {
     }
 
     @Test
-    fun `cast() with a expression and a class`() {
+    fun `cast() with a string expression as Integer`() {
         // when
         val expression = queryPart {
-            cast(expression(String::class, alias1), Int::class)
+            cast(expression(String::class, alias1)).asInteger()
         }.toExpression()
 
         val actual: Expression<Int> = expression // for type check
@@ -64,18 +64,72 @@ class ExpressionDslTest : WithAssertions {
     }
 
     @Test
-    fun `inline cast() with a expression and a class`() {
+    fun `cast() with a string expression as Long`() {
         // when
         val expression = queryPart {
-            cast<Int>(expression(String::class, alias1))
+            cast(expression(String::class, alias1)).asLong()
         }.toExpression()
 
-        val actual: Expression<Int> = expression // for type check
+        val actual: Expression<Long> = expression // for type check
 
         // then
         val expected = Expressions.cast(
             Expressions.expression(String::class, alias1),
-            Int::class,
+            Long::class,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `cast() with a string expression as Float`() {
+        // when
+        val expression = queryPart {
+            cast(expression(String::class, alias1)).asFloat()
+        }.toExpression()
+
+        val actual: Expression<Float> = expression // for type check
+
+        // then
+        val expected = Expressions.cast(
+            Expressions.expression(String::class, alias1),
+            Float::class,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `cast() with a string expression as Double`() {
+        // when
+        val expression = queryPart {
+            cast(expression(String::class, alias1)).asDouble()
+        }.toExpression()
+
+        val actual: Expression<Double> = expression // for type check
+
+        // then
+        val expected = Expressions.cast(
+            Expressions.expression(String::class, alias1),
+            Double::class,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `cast() with scalar expression as String`() {
+        // when
+        val expression = queryPart {
+            cast(expression(Int::class, alias1)).asString()
+        }.toExpression()
+
+        val actual: Expression<String> = expression // for type check
+
+        // then
+        val expected = Expressions.cast(
+            Expressions.expression(Int::class, alias1),
+            String::class,
         )
 
         assertThat(actual).isEqualTo(expected)

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
@@ -7,6 +7,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlAliasedExpres
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlAvg
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCaseValue
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCaseWhen
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCast
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCeiling
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCoalesce
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlConcat
@@ -22,6 +23,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlExpression
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlExpressionParentheses
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlFloor
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlFunctionExpression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLeft
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLength
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLiteral
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLn
@@ -41,6 +43,8 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlParam
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlPathType
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlPlus
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlPower
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlReplace
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlRight
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlRound
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlSign
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlSize
@@ -721,6 +725,42 @@ object Expressions {
         start: Expression<Int>? = null,
     ): Expression<Int> {
         return JpqlLocate(substring, string, start)
+    }
+
+    /**
+     * Creates an expression that represents the casting of a value to a different type.
+     */
+    @SinceJdsl("3.6.0")
+    fun <T : Any> cast(value: Expression<*>, type: KClass<T>): Expression<T> {
+        return JpqlCast(value, type)
+    }
+
+    /**
+     * Creates an expression that returns the leftmost count characters from a string.
+     */
+    @SinceJdsl("3.6.0")
+    fun left(value: Expression<String>, count: Expression<Int>): Expression<String> {
+        return JpqlLeft(value, count)
+    }
+
+    /**
+     * Creates an expression that returns the rightmost count characters from a string.
+     */
+    @SinceJdsl("3.6.0")
+    fun right(value: Expression<String>, count: Expression<Int>): Expression<String> {
+        return JpqlRight(value, count)
+    }
+
+    /**
+     * Creates an expression that replaces all occurrences of a search string with a replacement string.
+     */
+    @SinceJdsl("3.6.0")
+    fun replace(
+        value: Expression<String>,
+        search: Expression<String>,
+        replacement: Expression<String>,
+    ): Expression<String> {
+        return JpqlReplace(value, search, replacement)
     }
 
     /**

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
@@ -739,16 +739,24 @@ object Expressions {
      * Creates an expression that returns the leftmost count characters from a string.
      */
     @SinceJdsl("3.6.0")
-    fun left(value: Expression<String>, count: Expression<Int>): Expression<String> {
-        return JpqlLeft(value, count)
+    fun left(value: Expression<String>, len: Expression<Int>): Expression<String> {
+        return JpqlLeft(value, len)
+    }
+
+    /**
+     * Creates an expression that returns the leftmost count characters from a string.
+     */
+    @SinceJdsl("3.6.0")
+    fun left(value: Expression<String>, len: Int): Expression<String> {
+        return left(value, intLiteral(len))
     }
 
     /**
      * Creates an expression that returns the rightmost count characters from a string.
      */
     @SinceJdsl("3.6.0")
-    fun right(value: Expression<String>, count: Expression<Int>): Expression<String> {
-        return JpqlRight(value, count)
+    fun right(value: Expression<String>, len: Expression<Int>): Expression<String> {
+        return JpqlRight(value, len)
     }
 
     /**
@@ -757,10 +765,10 @@ object Expressions {
     @SinceJdsl("3.6.0")
     fun replace(
         value: Expression<String>,
-        search: Expression<String>,
+        substring: Expression<String>,
         replacement: Expression<String>,
     ): Expression<String> {
-        return JpqlReplace(value, search, replacement)
+        return JpqlReplace(value, substring, replacement)
     }
 
     /**

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlCast.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlCast.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import kotlin.reflect.KClass
+
+@SinceJdsl("3.6.0")
+data class JpqlCast<T : Any> internal constructor(
+    val value: Expression<*>,
+    val type: KClass<T>,
+) : Expression<T>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlCast.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlCast.kt
@@ -5,7 +5,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
 import kotlin.reflect.KClass
 
 @Internal
-data class JpqlCast<T : Any> internal constructor(
+data class JpqlCast<T : Any>(
     val value: Expression<*>,
     val type: KClass<T>,
 ) : Expression<T>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlCast.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlCast.kt
@@ -1,10 +1,10 @@
 package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
 
-import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
 import kotlin.reflect.KClass
 
-@SinceJdsl("3.6.0")
+@Internal
 data class JpqlCast<T : Any> internal constructor(
     val value: Expression<*>,
     val type: KClass<T>,

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlLeft.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlLeft.kt
@@ -1,0 +1,10 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+
+@SinceJdsl("3.6.0")
+data class JpqlLeft internal constructor(
+    val value: Expression<String>,
+    val length: Expression<Int>,
+) : Expression<String>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlLeft.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlLeft.kt
@@ -1,9 +1,9 @@
 package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
 
-import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
 
-@SinceJdsl("3.6.0")
+@Internal
 data class JpqlLeft internal constructor(
     val value: Expression<String>,
     val length: Expression<Int>,

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlReplace.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlReplace.kt
@@ -1,11 +1,11 @@
 package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
 
-import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
 
-@SinceJdsl("3.6.0")
+@Internal
 data class JpqlReplace internal constructor(
     val value: Expression<String>,
-    val pattern: Expression<String>,
+    val substring: Expression<String>,
     val replacement: Expression<String>,
 ) : Expression<String>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlReplace.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlReplace.kt
@@ -1,0 +1,11 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+
+@SinceJdsl("3.6.0")
+data class JpqlReplace internal constructor(
+    val value: Expression<String>,
+    val pattern: Expression<String>,
+    val replacement: Expression<String>,
+) : Expression<String>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlRight.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlRight.kt
@@ -1,9 +1,9 @@
 package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
 
-import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
 
-@SinceJdsl("3.6.0")
+@Internal
 data class JpqlRight internal constructor(
     val value: Expression<String>,
     val length: Expression<Int>,

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlRight.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlRight.kt
@@ -1,0 +1,10 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+
+@SinceJdsl("3.6.0")
+data class JpqlRight internal constructor(
+    val value: Expression<String>,
+    val length: Expression<Int>,
+) : Expression<String>

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
@@ -20,6 +20,7 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlAvgSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlBetweenSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCaseValueSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCaseWhenSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCastSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCeilingSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlCoalesceSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlConcatSerializer
@@ -68,6 +69,7 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLeftAssociationFe
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLeftAssociationJoinSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLeftFetchJoinSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLeftJoinSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLeftSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLengthSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLessThanAllSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlLessThanAnySerializer
@@ -107,6 +109,8 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlPathTypeSerialize
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlPlusSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlPowerSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlPredicateParenthesesSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlReplaceSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlRightSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlRoundSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQuerySerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryUnionAllSerializer
@@ -285,6 +289,7 @@ private class DefaultModule : JpqlRenderModule {
             JpqlBetweenSerializer(),
             JpqlCaseValueSerializer(),
             JpqlCaseWhenSerializer(),
+            JpqlCastSerializer(),
             JpqlCeilingSerializer(),
             JpqlCoalesceSerializer(),
             JpqlConcatSerializer(),
@@ -333,6 +338,7 @@ private class DefaultModule : JpqlRenderModule {
             JpqlLeftAssociationJoinSerializer(),
             JpqlLeftFetchJoinSerializer(),
             JpqlLeftJoinSerializer(),
+            JpqlLeftSerializer(),
             JpqlLengthSerializer(),
             JpqlLessThanAllSerializer(),
             JpqlLessThanAnySerializer(),
@@ -372,6 +378,8 @@ private class DefaultModule : JpqlRenderModule {
             JpqlPlusSerializer(),
             JpqlPowerSerializer(),
             JpqlPredicateParenthesesSerializer(),
+            JpqlRightSerializer(),
+            JpqlReplaceSerializer(),
             JpqlRoundSerializer(),
             JpqlSelectQuerySerializer(),
             JpqlSelectQueryUnionAllSerializer(),

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlCastSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlCastSerializer.kt
@@ -1,0 +1,27 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCast
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@SinceJdsl("3.6.0")
+class JpqlCastSerializer : JpqlSerializer<JpqlCast<*>> {
+    override fun handledType(): KClass<JpqlCast<*>> {
+        return JpqlCast::class
+    }
+
+    override fun serialize(part: JpqlCast<*>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        writer.write("CAST")
+        writer.writeParentheses {
+            delegate.serialize(part.value, writer, context)
+            writer.write(" AS ")
+            writer.write(part.type.simpleName!!)
+        }
+    }
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftSerializer.kt
@@ -1,0 +1,27 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLeft
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@SinceJdsl("3.6.0")
+class JpqlLeftSerializer : JpqlSerializer<JpqlLeft> {
+    override fun handledType(): KClass<JpqlLeft> {
+        return JpqlLeft::class
+    }
+
+    override fun serialize(part: JpqlLeft, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        writer.write("LEFT")
+        writer.writeParentheses {
+            delegate.serialize(part.value, writer, context)
+            writer.write(", ")
+            delegate.serialize(part.length, writer, context)
+        }
+    }
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlReplaceSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlReplaceSerializer.kt
@@ -1,0 +1,29 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlReplace
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@SinceJdsl("3.6.0")
+class JpqlReplaceSerializer : JpqlSerializer<JpqlReplace> {
+    override fun handledType(): KClass<JpqlReplace> {
+        return JpqlReplace::class
+    }
+
+    override fun serialize(part: JpqlReplace, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        writer.write("REPLACE")
+        writer.writeParentheses {
+            delegate.serialize(part.value, writer, context)
+            writer.write(", ")
+            delegate.serialize(part.pattern, writer, context)
+            writer.write(", ")
+            delegate.serialize(part.replacement, writer, context)
+        }
+    }
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlReplaceSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlReplaceSerializer.kt
@@ -1,6 +1,6 @@
 package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
 
-import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.Internal
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlReplace
 import com.linecorp.kotlinjdsl.render.RenderContext
 import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
@@ -8,7 +8,7 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
 import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
 import kotlin.reflect.KClass
 
-@SinceJdsl("3.6.0")
+@Internal
 class JpqlReplaceSerializer : JpqlSerializer<JpqlReplace> {
     override fun handledType(): KClass<JpqlReplace> {
         return JpqlReplace::class
@@ -21,7 +21,7 @@ class JpqlReplaceSerializer : JpqlSerializer<JpqlReplace> {
         writer.writeParentheses {
             delegate.serialize(part.value, writer, context)
             writer.write(", ")
-            delegate.serialize(part.pattern, writer, context)
+            delegate.serialize(part.substring, writer, context)
             writer.write(", ")
             delegate.serialize(part.replacement, writer, context)
         }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlRightSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlRightSerializer.kt
@@ -1,0 +1,27 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlRight
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@SinceJdsl("3.6.0")
+class JpqlRightSerializer : JpqlSerializer<JpqlRight> {
+    override fun handledType(): KClass<JpqlRight> {
+        return JpqlRight::class
+    }
+
+    override fun serialize(part: JpqlRight, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        writer.write("RIGHT")
+        writer.writeParentheses {
+            delegate.serialize(part.value, writer, context)
+            writer.write(", ")
+            delegate.serialize(part.length, writer, context)
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlCastSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlCastSerializerTest.kt
@@ -1,0 +1,56 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlCast
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@JpqlSerializerTest
+internal class JpqlCastSerializerTest {
+    private val sut = JpqlCastSerializer()
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    @Test
+    fun `handledType should return Expression`() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlCast::class)
+    }
+
+    @Test
+    fun `serialize should write CAST`() {
+        // given
+        val expression = Expressions.cast(Expressions.value(1), String::class)
+
+        every { context.getValue(JpqlRenderSerializer) } returns serializer
+
+        // when
+        sut.serialize(expression as JpqlCast<*>, writer, context)
+
+        // then
+        verify {
+            writer.write("CAST")
+            writer.writeParentheses(any())
+            serializer.serialize(expression.value, writer, context)
+            writer.write(" AS ")
+            writer.write(String::class.simpleName!!)
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlLeftSerializerTest.kt
@@ -1,0 +1,56 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLeft
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@JpqlSerializerTest
+internal class JpqlLeftSerializerTest {
+    private val sut = JpqlLeftSerializer()
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    @Test
+    fun `handledType should return Expression`() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlLeft::class)
+    }
+
+    @Test
+    fun `serialize should write LEFT`() {
+        // given
+        val expression = Expressions.left(Expressions.value("abc"), Expressions.value(1)) as JpqlLeft
+
+        every { context.getValue(JpqlRenderSerializer) } returns serializer
+
+        // when
+        sut.serialize(expression, writer, context)
+
+        // then
+        verify {
+            writer.write("LEFT")
+            writer.writeParentheses(any())
+            serializer.serialize(expression.value, writer, context)
+            writer.write(", ")
+            serializer.serialize(expression.length, writer, context)
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlReplaceSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlReplaceSerializerTest.kt
@@ -1,0 +1,62 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlReplace
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@JpqlSerializerTest
+internal class JpqlReplaceSerializerTest {
+    private val sut = JpqlReplaceSerializer()
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    @Test
+    fun `handledType should return Expression`() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlReplace::class)
+    }
+
+    @Test
+    fun `serialize should write REPLACE`() {
+        // given
+        val expression = Expressions.replace(
+            Expressions.value("abc"),
+            Expressions.value("a"),
+            Expressions.value("b"),
+        ) as JpqlReplace
+
+        every { context.getValue(JpqlRenderSerializer) } returns serializer
+
+        // when
+        sut.serialize(expression, writer, context)
+
+        // then
+        verify {
+            writer.write("REPLACE")
+            writer.writeParentheses(any())
+            serializer.serialize(expression.value, writer, context)
+            writer.write(", ")
+            serializer.serialize(expression.pattern, writer, context)
+            writer.write(", ")
+            serializer.serialize(expression.replacement, writer, context)
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlReplaceSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlReplaceSerializerTest.kt
@@ -54,7 +54,7 @@ internal class JpqlReplaceSerializerTest {
             writer.writeParentheses(any())
             serializer.serialize(expression.value, writer, context)
             writer.write(", ")
-            serializer.serialize(expression.pattern, writer, context)
+            serializer.serialize(expression.substring, writer, context)
             writer.write(", ")
             serializer.serialize(expression.replacement, writer, context)
         }

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlRightSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlRightSerializerTest.kt
@@ -1,0 +1,56 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlRight
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@JpqlSerializerTest
+internal class JpqlRightSerializerTest {
+    private val sut = JpqlRightSerializer()
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    @MockK
+    private lateinit var context: RenderContext
+
+    @Test
+    fun `handledType should return Expression`() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlRight::class)
+    }
+
+    @Test
+    fun `serialize should write RIGHT`() {
+        // given
+        val expression = Expressions.right(Expressions.value("abc"), Expressions.value(1)) as JpqlRight
+
+        every { context.getValue(JpqlRenderSerializer) } returns serializer
+
+        // when
+        sut.serialize(expression, writer, context)
+
+        // then
+        verify {
+            writer.write("RIGHT")
+            writer.writeParentheses(any())
+            serializer.serialize(expression.value, writer, context)
+            writer.write(", ")
+            serializer.serialize(expression.length, writer, context)
+        }
+    }
+}


### PR DESCRIPTION
# Motivation

- This PR introduces new string manipulation functions (`CAST`, `LEFT`, `RIGHT`, `REPLACE`) to the Kotlin JDSL JPQL DSL. These functions align with the JPA 3.2 specification, providing enhanced capabilities for string operations directly within JPQL queries. This change aims to expand the functionality of Kotlin JDSL to support more advanced JPQL features as defined in the latest JPA specifications.

# Modifications

- Added `cast`, `left`, `right`, and `replace` functions to `dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt` for use within `jpql {}` blocks.  
- Implemented corresponding `JpqlCast`, `JpqlLeft`, `JpqlRight`, `JpqlReplace` expression types in `query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/`.  
- Added serializers for these new expression types in `render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/`.  
- Created unit tests for the new serializers in `render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/`.  
- Added DSL usage tests for the new functions in `dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/ExpressionDslTest.kt`.  
- Updated documentation (`docs/en/jpql-with-kotlin-jdsl/expressions.md` and `docs/ko/jpql-with-kotlin-jdsl/expressions.md`) to include details and examples of the new functions, noting their addition in JPA 3.2.

# Result

- After this PR is merged, users will be able to utilize `CAST`, `LEFT`, `RIGHT`, and `REPLACE` functions directly within their Kotlin JDSL JPQL queries, enabling more powerful and flexible string manipulation operations. The documentation will also be updated to reflect these new capabilities.

# Closes

- N/A (No specific issue is being closed by this PR, it's a new feature implementation)

---

# 동기

- 이 PR은 Kotlin JDSL JPQL DSL에 새로운 문자열 조작 함수(`CAST`, `LEFT`, `RIGHT`, `REPLACE`)를 도입합니다. 이 함수들은 JPA 3.2 스펙에 맞춰 JPQL 쿼리 내에서 문자열 연산을 위한 향상된 기능을 제공합니다. 이 변경은 최신 JPA 스펙에 정의된 고급 JPQL 기능을 지원하기 위해 Kotlin JDSL의 기능을 확장하는 것을 목표로 합니다.

# 수정 사항

- `jpql {}` 블록 내에서 사용할 수 있도록 `dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt`에 `cast`, `left`, `right`, `replace` 함수를 추가했습니다.  
- `query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/`에 해당 `JpqlCast`, `JpqlLeft`, `JpqlRight`, `JpqlReplace` expression 타입을 구현했습니다.  
- `render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/`에 새로운 expression 타입에 대한 Serializer를 추가했습니다.  
- `render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/`에 새로운 Serializer에 대한 단위 테스트를 생성했습니다.  
- `dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/ExpressionDslTest.kt`에 새로운 함수에 대한 DSL 사용 테스트를 추가했습니다.  
- JPA 3.2에 추가된 기능임을 명시하고 새로운 함수에 대한 세부 정보 및 예제를 포함하도록 문서(`docs/en/jpql-with-kotlin-jdsl/expressions.md` 및 `docs/ko/jpql-with-kotlin-jdsl/expressions.md`)를 업데이트했습니다.

# 결과

- 이 PR이 병합되면 사용자는 Kotlin JDSL JPQL 쿼리 내에서 `CAST`, `LEFT`, `RIGHT`, `REPLACE` 함수를 직접 활용하여 더욱 강력하고 유연한 문자열 조작 작업을 수행할 수 있게 됩니다. 문서 또한 이러한 새로운 기능을 반영하여 업데이트될 것입니다.

# 닫는 이슈

- N/A (이 PR은 특정 이슈를 닫지 않으며, 새로운 기능 구현입니다.)