### PR TITLE
feat: implement id, version functions

### DIFF
--- a/docs/en/jpql-with-kotlin-jdsl/expressions.md
+++ b/docs/en/jpql-with-kotlin-jdsl/expressions.md
@@ -367,3 +367,57 @@ customExpression(String::class, "CAST({0} AS VARCHAR)", path(Book::price))
 ```
 
 If you frequently use `customExpression()`, you can create [your own DSL](custom-dsl.md).
+
+## ID
+
+You can get the identifier of an entity. This function was added in JPA 3.2.
+The function takes an `Entity` or a path expression that evaluates to a single-valued entity (`single_valued_object_path_expression`). It returns the identifier of the entity.
+
+```kotlin
+// Example using an entity alias
+val query = jpql {
+    select(
+        id(entity(Book::class))
+    ).from(
+        entity(Book::class)
+    )
+}
+```
+
+```kotlin
+// Example using a path expression
+val query = jpql {
+    select(
+        id(path(BookOrder::customer))
+    ).from(
+        entity(BookOrder::class)
+    )
+}
+```
+
+## VERSION
+
+You can get the version of an entity. This function was added in JPA 3.2.
+The function takes an `Entity` or a path expression that evaluates to a single-valued entity with a version mapping. It returns the version of the entity.
+
+```kotlin
+// Example using an entity alias
+val query = jpql {
+    select(
+        version(entity(Book::class))
+    ).from(
+        entity(Book::class)
+    )
+}
+```
+
+```kotlin
+// Example using a path expression
+val query = jpql {
+    select(
+        version(path(BookOrder::customer))
+    ).from(
+        entity(BookOrder::class)
+    )
+}
+```

--- a/docs/ko/jpql-with-kotlin-jdsl/expressions.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/expressions.md
@@ -365,3 +365,57 @@ customExpression(String::class, "CAST({0} AS VARCHAR)", path(Book::price))
 ```
 
 만약 `customExpression()`을 많이 사용한다면 [나만의 DSL](custom-dsl.md)을 만드는 것을 고려해보세요.
+
+## ID
+
+엔티티의 식별자를 가져올 수 있습니다. 이 함수는 JPA 3.2에서 추가되었습니다.
+함수는 `Entity` 또는 단일 값 엔티티로 귀결되는 경로 표현식(`single_valued_object_path_expression`)을 인자로 받습니다. 함수는 엔티티의 식별자를 반환합니다.
+
+```kotlin
+// 엔티티 별칭을 사용하는 예제
+val query = jpql {
+    select(
+        id(entity(Book::class))
+    ).from(
+        entity(Book::class)
+    )
+}
+```
+
+```kotlin
+// 경로 표현식을 사용하는 예제
+val query = jpql {
+    select(
+        id(path(BookOrder::customer))
+    ).from(
+        entity(BookOrder::class)
+    )
+}
+```
+
+## VERSION
+
+엔티티의 버전을 가져올 수 있습니다. 이 함수는 JPA 3.2에서 추가되었습니다.
+함수는 `Entity` 또는 버전 매핑이 있는 단일 값 엔티티로 귀결되는 경로 표현식을 인자로 받습니다. 함수는 엔티티의 버전을 반환합니다.
+
+```kotlin
+// 엔티티 별칭을 사용하는 예제
+val query = jpql {
+    select(
+        version(entity(Book::class))
+    ).from(
+        entity(Book::class)
+    )
+}
+```
+
+```kotlin
+// 경로 표현식을 사용하는 예제
+val query = jpql {
+    select(
+        version(path(BookOrder::customer))
+    ).from(
+        entity(BookOrder::class)
+    )
+}
+```

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -653,7 +653,7 @@ open class Jpql : JpqlDsl {
      * Creates an expression that represents the version of the entity.
      */
     @SinceJdsl("3.6.0")
-    fun <V : Any> version(entity: KClass<*>): Expression<V> {
+    fun <VERSION : Any> version(entity: KClass<*>): Expression<VERSION> {
         return Expressions.version(Entities.entity(entity))
     }
 
@@ -661,7 +661,7 @@ open class Jpql : JpqlDsl {
      * Creates an expression that represents the version of the entity.
      */
     @SinceJdsl("3.6.0")
-    fun <V : Any> version(expression: Expressionable<*>): Expression<V> {
+    fun <VERSION : Any> version(expression: Expressionable<*>): Expression<VERSION> {
         return Expressions.version(expression)
     }
 

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -634,6 +634,38 @@ open class Jpql : JpqlDsl {
     }
 
     /**
+     * Creates an expression that represents the id of the entity.
+     */
+    @SinceJdsl("3.6.0")
+    fun <ID : Any> id(entity: KClass<*>): Expression<ID> {
+        return Expressions.id(Entities.entity(entity))
+    }
+
+    /**
+     * Creates an expression that represents the id of the entity.
+     */
+    @SinceJdsl("3.6.0")
+    fun <ID : Any> id(entity: Expressionable<*>): Expression<ID> {
+        return Expressions.id(entity)
+    }
+
+    /**
+     * Creates an expression that represents the version of the entity.
+     */
+    @SinceJdsl("3.6.0")
+    fun <V : Any> version(entity: KClass<*>): Expression<V> {
+        return Expressions.version(Entities.entity(entity))
+    }
+
+    /**
+     * Creates an expression that represents the version of the entity.
+     */
+    @SinceJdsl("3.6.0")
+    fun <V : Any> version(expression: Expressionable<*>): Expression<V> {
+        return Expressions.version(expression)
+    }
+
+    /**
      * Creates an expression that represents the natural logarithm of value.
      */
     @SinceJdsl("3.4.0")

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/IdDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/IdDslTest.kt
@@ -19,7 +19,7 @@ class IdDslTest : WithAssertions {
             id<Isbn>(Book::class)
         }.toExpression()
 
-        val actual: Expression<Any> = expression // for type check
+        val actual: Expression<Isbn> = expression // for type check
 
         // then
         val expected = Expressions.id<Isbn>(
@@ -36,7 +36,7 @@ class IdDslTest : WithAssertions {
             id<Isbn>(entity)
         }.toExpression()
 
-        val actual: Expression<Any> = expression // for type check
+        val actual: Expression<Isbn> = expression // for type check
 
         // then
         val expected = Expressions.id<Isbn>(

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/IdDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/IdDslTest.kt
@@ -1,0 +1,48 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.expression
+
+import com.linecorp.kotlinjdsl.dsl.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.dsl.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.dsl.jpql.queryPart
+import com.linecorp.kotlinjdsl.querymodel.jpql.entity.Entities
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class IdDslTest : WithAssertions {
+    private val entity = Entities.entity(Book::class)
+
+    @Test
+    fun `id() with a class`() {
+        // when
+        val expression = queryPart {
+            id<Isbn>(Book::class)
+        }.toExpression()
+
+        val actual: Expression<Any> = expression // for type check
+
+        // then
+        val expected = Expressions.id<Isbn>(
+            entity,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `id() with an entity path`() {
+        // when
+        val expression = queryPart {
+            id<Isbn>(entity)
+        }.toExpression()
+
+        val actual: Expression<Any> = expression // for type check
+
+        // then
+        val expected = Expressions.id<Isbn>(
+            entity,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/VersionDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/VersionDslTest.kt
@@ -1,0 +1,47 @@
+package com.linecorp.kotlinjdsl.dsl.jpql.expression
+
+import com.linecorp.kotlinjdsl.dsl.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.dsl.jpql.queryPart
+import com.linecorp.kotlinjdsl.querymodel.jpql.entity.Entities
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+
+class VersionDslTest : WithAssertions {
+    private val entity = Entities.entity(Book::class)
+
+    @Test
+    fun `version() with a class`() {
+        // when
+        val expression = queryPart {
+            version<Long>(Book::class)
+        }.toExpression()
+
+        val actual: Expression<Any> = expression // for type check
+
+        // then
+        val expected = Expressions.version<Long>(
+            entity,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `version() with an entity path`() {
+        // when
+        val expression = queryPart {
+            version<Long>(entity)
+        }.toExpression()
+
+        val actual: Expression<Any> = expression // for type check
+
+        // then
+        val expected = Expressions.version<Long>(
+            entity,
+        )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/dsl/jpql/src/testFixtures/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/entity/book/Book.kt
+++ b/dsl/jpql/src/testFixtures/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/entity/book/Book.kt
@@ -12,4 +12,5 @@ class Book(
     val publishDate: OffsetDateTime,
     val authors: MutableSet<BookAuthor>,
     val publisher: BookPublisher,
+    val version: Long,
 )

--- a/example/hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/entity/book/Book.kt
+++ b/example/hibernate-reactive/src/main/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/entity/book/Book.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import jakarta.persistence.Version
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -42,6 +43,9 @@ class Book(
 
     @OneToMany(mappedBy = "book", cascade = [CascadeType.ALL], orphanRemoval = true)
     val publishers: List<BookPublisher>,
+
+    @Version
+    val version: Long = 0L,
 ) {
     init {
         authors.forEach { it.book = this }

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/SelectMutinySessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/SelectMutinySessionExample.kt
@@ -301,4 +301,76 @@ class SelectMutinySessionExample : WithAssertions {
         // then
         assertThat(actual).isEqualTo(listOf(7L))
     }
+
+    @Test
+    fun `id of book`() {
+        // when
+        val query = jpql {
+            select(
+                id(Book::class),
+            ).from(
+                entity(Book::class),
+            ).orderBy(
+                path(Book::isbn).asc(),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+                Isbn("06"),
+                Isbn("07"),
+                Isbn("08"),
+                Isbn("09"),
+                Isbn("10"),
+                Isbn("11"),
+                Isbn("12"),
+            ),
+        )
+    }
+
+    @Test
+    fun `version of book`() {
+        // when
+        val query = jpql {
+            select(
+                version(Book::class),
+            ).from(
+                entity(Book::class),
+            ).orderBy(
+                path(Book::isbn).asc(),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+            ),
+        )
+    }
 }

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/SelectMutinyStatelessSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/SelectMutinyStatelessSessionExample.kt
@@ -301,4 +301,76 @@ class SelectMutinyStatelessSessionExample : WithAssertions {
         // then
         assertThat(actual).isEqualTo(listOf(7L))
     }
+
+    @Test
+    fun `id of book`() {
+        // when
+        val query = jpql {
+            select(
+                id(Book::class),
+            ).from(
+                entity(Book::class),
+            ).orderBy(
+                path(Book::isbn).asc(),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+                Isbn("06"),
+                Isbn("07"),
+                Isbn("08"),
+                Isbn("09"),
+                Isbn("10"),
+                Isbn("11"),
+                Isbn("12"),
+            ),
+        )
+    }
+
+    @Test
+    fun `version of book`() {
+        // when
+        val query = jpql {
+            select(
+                version(Book::class),
+            ).from(
+                entity(Book::class),
+            ).orderBy(
+                path(Book::isbn).asc(),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+            ),
+        )
+    }
 }

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/SelectStageSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/SelectStageSessionExample.kt
@@ -301,4 +301,76 @@ class SelectStageSessionExample : WithAssertions {
         // then
         assertThat(actual).isEqualTo(listOf(7L))
     }
+
+    @Test
+    fun `id of book`() {
+        // when
+        val query = jpql {
+            select(
+                id(Book::class),
+            ).from(
+                entity(Book::class),
+            ).orderBy(
+                path(Book::isbn).asc(),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+                Isbn("06"),
+                Isbn("07"),
+                Isbn("08"),
+                Isbn("09"),
+                Isbn("10"),
+                Isbn("11"),
+                Isbn("12"),
+            ),
+        )
+    }
+
+    @Test
+    fun `version of book`() {
+        // when
+        val query = jpql {
+            select(
+                version(Book::class),
+            ).from(
+                entity(Book::class),
+            ).orderBy(
+                path(Book::isbn).asc(),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+            ),
+        )
+    }
 }

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/SelectStageStatelessSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/SelectStageStatelessSessionExample.kt
@@ -301,4 +301,76 @@ class SelectStageStatelessSessionExample : WithAssertions {
         // then
         assertThat(actual).isEqualTo(listOf(7L))
     }
+
+    @Test
+    fun `id of book`() {
+        // when
+        val query = jpql {
+            select(
+                id(Book::class),
+            ).from(
+                entity(Book::class),
+            ).orderBy(
+                path(Book::isbn).asc(),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+                Isbn("06"),
+                Isbn("07"),
+                Isbn("08"),
+                Isbn("09"),
+                Isbn("10"),
+                Isbn("11"),
+                Isbn("12"),
+            ),
+        )
+    }
+
+    @Test
+    fun `version of book`() {
+        // when
+        val query = jpql {
+            select(
+                version(Book::class),
+            ).from(
+                entity(Book::class),
+            ).orderBy(
+                path(Book::isbn).asc(),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+            ),
+        )
+    }
 }

--- a/example/hibernate/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/entity/book/Book.kt
+++ b/example/hibernate/src/main/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/entity/book/Book.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import jakarta.persistence.Version
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -42,6 +43,9 @@ class Book(
 
     @OneToMany(mappedBy = "book", cascade = [CascadeType.ALL], orphanRemoval = true)
     val publishers: List<BookPublisher>,
+
+    @Version
+    val version: Long = 0L,
 ) {
     init {
         authors.forEach { it.book = this }

--- a/example/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/select/SelectExample.kt
+++ b/example/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/select/SelectExample.kt
@@ -312,4 +312,72 @@ class SelectExample : WithAssertions {
         // then
         assertThat(actual).isEqualTo(listOf(7L))
     }
+
+    @Test
+    fun `id of book`() {
+        // when
+        val query = jpql {
+            select(
+                id(entity(Book::class)),
+            ).from(
+                entity(Book::class),
+            ).orderBy(
+                path(Book::isbn).asc(),
+            )
+        }
+
+        val actual = entityManager.createQuery(query, context).resultList
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                Isbn("01"),
+                Isbn("02"),
+                Isbn("03"),
+                Isbn("04"),
+                Isbn("05"),
+                Isbn("06"),
+                Isbn("07"),
+                Isbn("08"),
+                Isbn("09"),
+                Isbn("10"),
+                Isbn("11"),
+                Isbn("12"),
+            ),
+        )
+    }
+
+    @Test
+    fun `version of book`() {
+        // when
+        val query = jpql {
+            select(
+                version(Book::class),
+            ).from(
+                entity(Book::class),
+            ).orderBy(
+                path(Book::isbn).asc(),
+            )
+        }
+
+        val actual = entityManager.createQuery(query, context).resultList
+
+        // then
+        assertThat(actual).isEqualTo(
+            listOf(
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+            ),
+        )
+    }
 }

--- a/example/src/main/resources/schema.sql
+++ b/example/src/main/resources/schema.sql
@@ -21,7 +21,8 @@ create table book
     publish_date datetime(6)    not null,
 
     price        numeric(38, 2) not null,
-    sale_price   numeric(38, 2) not null
+    sale_price   numeric(38, 2) not null,
+    version      bigint         not null default 0
 );
 
 create table book_author

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/Expressions.kt
@@ -22,6 +22,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlExpression
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlExpressionParentheses
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlFloor
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlFunctionExpression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlId
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLength
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLiteral
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlLn
@@ -55,6 +56,7 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlTrimLeading
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlTrimTrailing
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlUpper
 import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlValue
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlVersion
 import com.linecorp.kotlinjdsl.querymodel.jpql.path.Path
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.impl.JpqlIndex
@@ -812,5 +814,21 @@ object Expressions {
     @SinceJdsl("3.0.0")
     fun <T : Any> parentheses(expr: Expression<T>): Expression<T> {
         return JpqlExpressionParentheses(expr)
+    }
+
+    /**
+     * Creates an expression that represents the id of the entity.
+     */
+    @SinceJdsl("3.6.0")
+    fun <ID : Any> id(entity: Expressionable<*>): Expression<ID> {
+        return JpqlId(entity)
+    }
+
+    /**
+     * Creates an expression that represents the version of the entity.
+     */
+    @SinceJdsl("3.6.0")
+    fun <VERSION : Any> version(expr: Expressionable<*>): Expression<VERSION> {
+        return JpqlVersion(expr)
     }
 }

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlId.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlId.kt
@@ -1,0 +1,10 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressionable
+
+@Internal
+data class JpqlId<ID : Any>(
+    val expr: Expressionable<*>,
+) : Expression<ID>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlVersion.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/JpqlVersion.kt
@@ -1,0 +1,10 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expression
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressionable
+
+@Internal
+data class JpqlVersion<V : Any>(
+    val expr: Expressionable<*>,
+) : Expression<V>

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
@@ -52,6 +52,7 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlGreaterThanOrEqua
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlGreaterThanOrEqualToAnySerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlGreaterThanOrEqualToSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlGreaterThanSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlIdSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlInSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlInSubquerySerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlIndexSerializer
@@ -128,6 +129,7 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlTrimTrailingSeria
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlUpdateQuerySerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlUpperSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlValueSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlVersionSerializer
 
 /**
  * RenderContext for rendering JPQL.
@@ -319,6 +321,7 @@ private class DefaultModule : JpqlRenderModule {
             JpqlGreaterThanOrEqualToAnySerializer(),
             JpqlGreaterThanOrEqualToSerializer(),
             JpqlGreaterThanSerializer(),
+            JpqlIdSerializer(),
             JpqlIndexSerializer(),
             JpqlInnerAssociationFetchJoinSerializer(),
             JpqlInnerAssociationJoinSerializer(),
@@ -395,6 +398,7 @@ private class DefaultModule : JpqlRenderModule {
             JpqlUpdateQuerySerializer(),
             JpqlUpperSerializer(),
             JpqlValueSerializer(),
+            JpqlVersionSerializer(),
         )
     }
 }

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlIdSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlIdSerializer.kt
@@ -1,0 +1,26 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlId
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@Internal
+class JpqlIdSerializer : JpqlSerializer<JpqlId<*>> {
+    override fun handledType(): KClass<JpqlId<*>> {
+        return JpqlId::class
+    }
+
+    override fun serialize(part: JpqlId<*>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        writer.write("ID")
+
+        writer.writeParentheses {
+            delegate.serialize(part.expr.toExpression(), writer, context)
+        }
+    }
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlVersionSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlVersionSerializer.kt
@@ -1,0 +1,26 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlVersion
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import kotlin.reflect.KClass
+
+@Internal
+class JpqlVersionSerializer : JpqlSerializer<JpqlVersion<*>> {
+    override fun handledType(): KClass<JpqlVersion<*>> {
+        return JpqlVersion::class
+    }
+
+    override fun serialize(part: JpqlVersion<*>, writer: JpqlWriter, context: RenderContext) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        writer.write("VERSION")
+
+        writer.writeParentheses {
+            delegate.serialize(part.expr.toExpression(), writer, context)
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlIdSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlIdSerializerTest.kt
@@ -1,0 +1,54 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.entity.Entities
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlId
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.render.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.verifySequence
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class JpqlIdSerializerTest {
+    private val entity = Entities.entity(Book::class)
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var delegate: JpqlRenderSerializer
+
+    private val context: TestRenderContext by lazy { TestRenderContext(delegate) }
+
+    private val sut = JpqlIdSerializer()
+
+    @BeforeEach
+    fun setUp() {
+        every { delegate.key } returns JpqlRenderSerializer.Key
+        every { writer.write(any<String>()) } just Runs
+        every { writer.writeParentheses(any()) } just Runs
+        every { delegate.serialize(any(), any(), any()) } just Runs
+    }
+
+    @Test
+    fun serialize() {
+        // when
+        sut.serialize(Expressions.id<Isbn>(entity) as JpqlId<*>, writer, context)
+
+        // then
+        verifySequence {
+            writer.write("ID")
+            writer.writeParentheses(any())
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlVersionSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlVersionSerializerTest.kt
@@ -1,0 +1,54 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.entity.Entities
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.impl.JpqlVersion
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.verifySequence
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class JpqlVersionSerializerTest {
+    class Book
+
+    private val entity = Entities.entity(Book::class)
+
+    @MockK
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var delegate: JpqlRenderSerializer
+
+    private val context: TestRenderContext by lazy { TestRenderContext(delegate) }
+
+    private val sut = JpqlVersionSerializer()
+
+    @BeforeEach
+    fun setUp() {
+        every { delegate.key } returns JpqlRenderSerializer.Key
+        every { writer.write(any<String>()) } just Runs
+        every { writer.writeParentheses(any()) } just Runs
+        every { delegate.serialize(any(), any(), any()) } just Runs
+    }
+
+    @Test
+    fun serialize() {
+        // when
+        sut.serialize(Expressions.version<Long>(entity) as JpqlVersion<*>, writer, context)
+
+        // then
+        verifySequence {
+            writer.write("VERSION")
+            writer.writeParentheses(any())
+        }
+    }
+}


### PR DESCRIPTION
# Motivation

* This PR implements the new `ID` and `VERSION` functions in Kotlin JDSL to align with the JPA 3.2 specification. According to the specification, the BNF syntax for these functions is as follows:
  ```
  id_function ::= ID( general_identification_variable | single_valued_object_path_expression )
  version_function ::= VERSION( general_identification_variable | single_valued_object_path_expression )
  ```
* To fully support this syntax, which allows both an entity alias (`general_identification_variable`) and a path resolving to an entity (`single_valued_object_path_expression`), we designed the functions to accept the more generic `Expressionable` type. This approach enables powerful and flexible queries, such as `id(path(A::b))`, which was a key goal of this implementation.

# Modifications

*   Implemented `JpqlId` and `JpqlVersion` expression types in `query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/`. These models now take an `Expressionable<*>` parameter to support both entity aliases and path expressions that resolve to an entity, as defined in the JPQL BNF.
*   Added the new `id` and `version` functions to `dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt` for use within `jpql {}` blocks.
*   Added serializers for these new expression types in `render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/`.
*   Created unit tests for the new serializers in `render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/`.
*   Added DSL usage tests in `dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/ExpressionDslTest.kt` to verify the new `id` and `version` functions.
*   Updated documentation (`docs/en/jpql-with-kotlin-jdsl/expressions.md` and `docs/ko/jpql-with-kotlin-jdsl/expressions.md`) to include details and examples of the new functions, noting their addition in JPA 3.2.

# Result

* After this PR is merged, users will be able to use the newly implemented `id()` and `version()` functions in their Kotlin JDSL queries. This allows for powerful and specification-compliant ways to access entity identifiers and versions, such as `id(path(Order::customer))` or `version(entity(Book::class))`.

# Closes

*   N/A (This PR implements a new feature based on the JPA specification.)

--- korean

# 동기

* 이 PR은 JPA 3.2 스펙에 맞춰 새로운 `ID` 및 `VERSION` 함수를 Kotlin JDSL에 구현합니다. 스펙에 따르면, 이 함수들의 BNF 구문은 다음과 같습니다.
  ```
  id_function ::= ID( general_identification_variable | single_valued_object_path_expression )
  version_function ::= VERSION( general_identification_variable | single_valued_object_path_expression )
  ```
* 엔티티 별칭(`general_identification_variable`)과 엔티티로 귀결되는 경로(`single_valued_object_path_expression`)를 모두 지원하는 이 구문을 완전히 구현하기 위해, 저희는 함수가 더 일반적인 타입인 `Expressionable`을 인자로 받도록 설계했습니다. 이 접근 방식은 이번 구현의 핵심 목표였던 `id(path(A::b))`와 같이 강력하고 유연한 쿼리 작성을 가능하게 합니다.

# 수정 사항

*   `query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/expression/impl/`에 `JpqlId`와 `JpqlVersion` expression 타입을 구현했습니다. 이 모델들은 JPQL BNF에 정의된 대로 엔티티 별칭과 엔티티로 귀결되는 경로 표현식을 모두 지원하기 위해 `Expressionable<*>` 파라미터를 받습니다.
*   `jpql {}` 블록 내에서 사용할 수 있도록 `dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt`에 새로운 `id` 및 `version` 함수를 추가했습니다.
*   `render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/`에 새로운 expression 타입에 대한 Serializer를 추가했습니다.
*   `render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/`에 새로운 Serializer에 대한 단위 테스트를 생성했습니다.
*   `dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/expression/ExpressionDslTest.kt`에 새로운 `id` 및 `version` 함수를 검증하는 DSL 사용 테스트를 추가했습니다.
*   JPA 3.2에 추가된 기능임을 명시하고 새로운 함수에 대한 세부 정보 및 예제를 포함하도록 문서(`docs/en/jpql-with-kotlin-jdsl/expressions.md` 및 `docs/ko/jpql-with-kotlin-jdsl/expressions.md`)를 업데이트했습니다.

# 결과

*   이 PR이 병합되면, 사용자는 새로 구현된 `id()` 및 `version()` 함수를 Kotlin JDSL 쿼리에서 사용할 수 있게 됩니다. 이를 통해 `id(path(Order::customer))`나 `version(entity(Book::class))`와 같이 엔티티 식별자와 버전에 접근하는 스펙에 부합하는 강력한 방법을 제공합니다.

# 닫는 이슈

*   N/A (이 PR은 JPA 스펙에 기반한 새로운 기능 구현입니다.)