### PR TITLE
feat: implement intersect, intersect-all for JPA 3.2 specification

### DIFF
--- a/docs/ko/jpql-with-kotlin-jdsl/statements.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/statements.md
@@ -168,20 +168,22 @@ having(
 )
 ```
 
-### 집합 연산 (`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`)
+### 집합 연산 (`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`, `INTERSECT`, `INTERSECT ALL`)
 
-Jakarta Persistence 3.2부터 JPQL은 집합 연산자를 사용하여 둘 이상의 `SELECT` 쿼리 결과를 결합하는 기능을 공식적으로 지원합니다. Kotlin JDSL은 이러한 새로운 표준 기능인 `UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL` 연산을 지원합니다. (`INTERSECT` 또한 JPA 3.2에 추가되었습니다.)
+Jakarta Persistence 3.2부터 JPQL은 집합 연산자를 사용하여 둘 이상의 `SELECT` 쿼리 결과를 결합하는 기능을 공식적으로 지원합니다. Kotlin JDSL은 이러한 새로운 표준 기능인 `UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`, `INTERSECT`, `INTERSECT ALL` 연산을 지원합니다.
 
 *   `UNION`: 두 쿼리의 결과 집합을 결합하고 중복된 행을 제거합니다.
 *   `UNION ALL`: 두 쿼리의 결과 집합을 결합하고 모든 중복된 행을 포함합니다.
 *   `EXCEPT`: 첫 번째 쿼리에서 두 번째 쿼리에 없는 행을 반환하며, 중복을 제거합니다.
 *   `EXCEPT ALL`: 첫 번째 쿼리에서 두 번째 쿼리에 없는 행을 반환하며, 모든 중복을 포함합니다.
+*   `INTERSECT`: 두 결과 집합 모두에 존재하는 행만 반환하며, 중복을 제거합니다.
+*   `INTERSECT ALL`: 두 결과 집합 모두에 존재하는 행만 반환하며, 모든 중복을 포함합니다.
 
-집합 연산(`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`)에 포함되는 `SELECT` 문들은 select 목록에 동일한 수의 열을 가져야 하며, 해당 열의 데이터 타입은 서로 호환되어야 합니다.
+집합 연산(`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`, `INTERSECT`, `INTERSECT ALL`)에 포함되는 `SELECT` 문들은 select 목록에 동일한 수의 열을 가져야 하며, 해당 열의 데이터 타입은 서로 호환되어야 합니다.
 
 **연결된 Select 쿼리와 함께 사용:**
 
-select 쿼리 구조(예: `select`, `from`, `where`, `groupBy`, 또는 `having` 절 뒤)에 `union()`, `unionAll()`, `except()`, 또는 `exceptAll()`을 연결하여 사용할 수 있습니다. `orderBy()` 절이 사용되는 경우, 집합 연산의 최종 결과에 적용됩니다.
+select 쿼리 구조(예: `select`, `from`, `where`, `groupBy`, 또는 `having` 절 뒤)에 `union()`, `unionAll()`, `except()`, `exceptAll()`, `intersect()`, 또는 `intersectAll()`을 연결하여 사용할 수 있습니다. `orderBy()` 절이 사용되는 경우, 집합 연산의 최종 결과에 적용됩니다.
 
 ```kotlin
 // UNION 예제
@@ -267,11 +269,53 @@ val exceptAllQuery = jpql {
         path(Author::name).desc()
     )
 }
+
+// INTERSECT 예제
+val intersectQuery = jpql {
+    select(
+        path(Book::isbn)
+    ).from(
+        entity(Book::class)
+    ).where(
+        path(Book::price)(BookPrice::value).lessThan(BigDecimal.valueOf(20))
+    ).intersect( // 우측 쿼리 또한 select 구조입니다.
+        select(
+            path(Book::isbn)
+        ).from(
+            entity(Book::class)
+        ).where(
+            path(Book::salePrice)(BookPrice::value).lessThan(BigDecimal.valueOf(15))
+        )
+    ).orderBy(
+        path(Book::isbn).asc()
+    )
+}
+
+// INTERSECT ALL 예제
+val intersectAllQuery = jpql {
+    select(
+        path(Author::name)
+    ).from(
+        entity(Author::class)
+    ).where(
+        path(Author::name).like("%Fantasy%")
+    ).intersectAll( // 우측 쿼리 또한 select 구조입니다.
+        select(
+            path(Author::name)
+        ).from(
+            entity(Author::class)
+        ).where(
+            path(Author::name).like("%Sci-Fi%")
+        )
+    ).orderBy(
+        path(Author::name).desc()
+    )
+}
 ```
 
 **최상위 레벨 연산으로 사용:**
 
-`jpql` 블록 내에서 두 개의 `JpqlQueryable<SelectQuery<T>>` 인스턴스를 결합하여 `union()`, `unionAll()`, `except()`, `exceptAll()`을 최상위 레벨 연산으로 사용할 수도 있습니다.
+`jpql` 블록 내에서 두 개의 `JpqlQueryable<SelectQuery<T>>` 인스턴스를 결합하여 `union()`, `unionAll()`, `except()`, `exceptAll()`, `intersect()`, `intersectAll()`을 최상위 레벨 연산으로 사용할 수도 있습니다.
 
 ```kotlin
 val query1 = jpql {
@@ -305,18 +349,27 @@ val topLevelExceptAllQuery = jpql {
     exceptAll(query1, query2)
         .orderBy(path(Book::isbn).asc())
 }
+
+// 최상위 레벨 INTERSECT
+val topLevelIntersectQuery = jpql {
+    intersect(query1, query2)
+        .orderBy(path(Book::isbn).asc())
+}
 ```
 
 **`ORDER BY`에 대한 중요 참고 사항:**
 
-`ORDER BY` 절은 집합 연산(`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`)의 최종 결과 집합에 적용됩니다. 집합 연산 자체에 영향을 미치는 방식으로 집합 연산의 일부인 개별 `SELECT` 쿼리에 적용될 수 없습니다. (물론, 하위 쿼리가 집합 연산 전에 결과를 제한하는 등의 다른 목적으로 자체 `ORDER BY`를 가질 수 있지만, 일반적으로 JPQL에서 집합 연산과 최종 정렬을 위해 상호 작용하는 방식은 아닙니다.) `ORDER BY` 절의 정렬 기준은 일반적으로 첫 번째 쿼리의 `SELECT` 목록에 있는 열의 별칭 또는 위치를 참조합니다.
+`ORDER BY` 절은 집합 연산(`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`, `INTERSECT`, `INTERSECT ALL`)의 최종 결과 집합에 적용됩니다. 집합 연산 자체에 영향을 미치는 방식으로 집합 연산의 일부인 개별 `SELECT` 쿼리에 적용될 수 없습니다. (물론, 하위 쿼리가 집합 연산 전에 결과를 제한하는 등의 다른 목적으로 자체 `ORDER BY`를 가질 수 있지만, 일반적으로 JPQL에서 집합 연산과 최종 정렬을 위해 상호 작용하는 방식은 아닙니다.) `ORDER BY` 절의 정렬 기준은 일반적으로 첫 번째 쿼리의 `SELECT` 목록에 있는 열의 별칭 또는 위치를 참조합니다.
 
 **데이터베이스 호환성 참고사항:**
 
 이러한 집합 연산은 JPA 3.2 사양의 일부이지만, 모든 데이터베이스가 모든 연산을 지원하는 것은 아닙니다. 예를 들어:
-- H2 데이터베이스(버전 1.4.192 - 2.3.232)는 `UNION`, `UNION ALL`, `EXCEPT`를 지원하지만 `EXCEPT ALL`은 지원하지 않습니다
-- PostgreSQL, Oracle, SQL Server는 네 가지 연산(`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`)을 모두 지원합니다
-- MySQL은 `UNION`, `UNION ALL`은 지원하지만 `EXCEPT` 연산은 지원하지 않습니다 (대안으로 `NOT EXISTS` 또는 `LEFT JOIN` 사용)
+- H2 데이터베이스(버전 1.4.192 - 2.3.232)는 `UNION`, `UNION ALL`, `INTERSECT`, `EXCEPT`를 지원하지만 `EXCEPT ALL`이나 `INTERSECT ALL`은 지원하지 않습니다.
+- PostgreSQL, Oracle, SQL Server는 여섯 가지 연산(`UNION`, `UNION ALL`, `EXCEPT`, `EXCEPT ALL`, `INTERSECT`, `INTERSECT ALL`)을 모두 지원합니다.
+- MySQL은 `UNION`과 `UNION ALL`은 지원하지만 다른 연산자에는 제한이 있습니다:
+    - `EXCEPT`를 지원하지 않습니다. 이는 `NOT EXISTS` 또는 `LEFT JOIN`을 사용하여 에뮬레이션할 수 있습니다.
+    - `INTERSECT`를 지원하지 않습니다. 이는 `INNER JOIN` 또는 `IN`을 사용하여 에뮬레이션할 수 있습니다.
+    - `EXCEPT ALL` 및 `INTERSECT ALL`은 지원하지 않으며, 간단한 대체 쿼리가 없습니다.
 
 이러한 연산을 사용할 때는 대상 데이터베이스가 이를 지원하는지 확인하거나, 지원하지 않는 데이터베이스에 대한 대체 쿼리 전략을 제공해야 합니다.
 

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/Jpql.kt
@@ -3570,6 +3570,62 @@ open class Jpql : JpqlDsl {
         return exceptAll(this, right)
     }
 
+    /**
+     * Creates an INTERSECT query with two select queries.
+     */
+    @SinceJdsl("3.6.0")
+    @JvmName("intersect")
+    inline fun <reified T : Any> intersect(
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return SetOperatorQueryDsl(
+            returnType = T::class,
+            leftQuery = left,
+            setOperator = SetOperator.INTERSECT,
+            rightQuery = right,
+        )
+    }
+
+    /**
+     * Creates an INTERSECT ALL query with two select queries.
+     */
+    @JvmName("intersectAll")
+    @SinceJdsl("3.6.0")
+    inline fun <reified T : Any> intersectAll(
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return SetOperatorQueryDsl(
+            returnType = T::class,
+            leftQuery = left,
+            setOperator = SetOperator.INTERSECT_ALL,
+            rightQuery = right,
+        )
+    }
+
+    /**
+     * Creates an INTERSECT query that represents the intersecting of this query and the [right] query.
+     */
+    @JvmName("intersectExtension")
+    @SinceJdsl("3.6.0")
+    inline fun <reified T : Any> JpqlQueryable<SelectQuery<T>>.intersect(
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return intersect(this, right)
+    }
+
+    /**
+     * Creates an INTERSECT ALL that represents to intersect all of this query and the [right] query.
+     */
+    @JvmName("intersectAllExtension")
+    @SinceJdsl("3.6.0")
+    inline fun <reified T : Any> JpqlQueryable<SelectQuery<T>>.intersectAll(
+        right: JpqlQueryable<SelectQuery<T>>,
+    ): SelectQueryOrderByStep<T> {
+        return intersectAll(this, right)
+    }
+
     private fun valueOrExpression(value: Any): Expression<*> {
         return if (value is Expression<*>) {
             value

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperator.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperator.kt
@@ -9,4 +9,6 @@ internal enum class SetOperator {
     UNION_ALL,
     EXCEPT,
     EXCEPT_ALL,
+    INTERSECT,
+    INTERSECT_ALL,
 }

--- a/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorSelectQueryBuilder.kt
+++ b/dsl/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/impl/SetOperatorSelectQueryBuilder.kt
@@ -45,6 +45,18 @@ internal data class SetOperatorSelectQueryBuilder<T : Any>(
                 right = rightQuery,
                 orderBy = orderBy,
             )
+            SetOperator.INTERSECT -> SelectQueries.selectIntersectQuery(
+                returnType = returnType,
+                left = leftQuery,
+                right = rightQuery,
+                orderBy = orderBy,
+            )
+            SetOperator.INTERSECT_ALL -> SelectQueries.selectIntersectAllQuery(
+                returnType = returnType,
+                left = leftQuery,
+                right = rightQuery,
+                orderBy = orderBy,
+            )
         }
     }
 }

--- a/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/SetOperatorDslTest.kt
+++ b/dsl/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/dsl/jpql/select/SetOperatorDslTest.kt
@@ -6,6 +6,8 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.entity.Entities
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExcept
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExceptAll
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryIntersect
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryIntersectAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnion
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnionAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
@@ -395,6 +397,198 @@ class SetOperatorDslTest : WithAssertions {
         assertThat(query).isInstanceOf(JpqlSelectQueryExceptAll::class.java)
 
         val actualUnionAll = query as JpqlSelectQueryExceptAll
+
+        assertThat(actualUnionAll.returnType).isEqualTo(Book::class)
+        assertThat(actualUnionAll.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnionAll.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnionAll.orderBy).isEqualTo(listOf(sort1))
+    }
+
+    @Test
+    fun `intersect between two queries`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            intersect(
+                subquery1,
+                subquery2,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryIntersect::class.java)
+
+        val actualUnion = query as JpqlSelectQueryIntersect
+
+        assertThat(actualUnion.returnType).isEqualTo(Book::class)
+        assertThat(actualUnion.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnion.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnion.orderBy).isNull()
+    }
+
+    @Test
+    fun `intersect between two queries with orderBy`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            intersect(
+                subquery1,
+                subquery2,
+            ).orderBy(
+                sort1,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryIntersect::class.java)
+
+        val actualUnion = query as JpqlSelectQueryIntersect
+
+        assertThat(actualUnion.returnType).isEqualTo(Book::class)
+        assertThat(actualUnion.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnion.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnion.orderBy).isEqualTo(listOf(sort1))
+    }
+
+    @Test
+    fun `intersect all between two queries`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            intersectAll(
+                subquery1,
+                subquery2,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryIntersectAll::class.java)
+
+        val actualUnionAll = query as JpqlSelectQueryIntersectAll
+
+        assertThat(actualUnionAll.returnType).isEqualTo(Book::class)
+        assertThat(actualUnionAll.left.toQuery()).isEqualTo(subquery1)
+        assertThat(actualUnionAll.right.toQuery()).isEqualTo(subquery2)
+        assertThat(actualUnionAll.orderBy).isNull()
+    }
+
+    @Test
+    fun `intersect all between two queries with orderBy`() {
+        // when
+        val query = jpql {
+            val subquery1 = select(
+                entity1,
+            ).from(
+                entity1,
+            )
+
+            val subquery2 = select(
+                entity2,
+            ).from(
+                entity2,
+            )
+
+            intersectAll(
+                subquery1,
+                subquery2,
+            ).orderBy(
+                sort1,
+            )
+        }
+
+        // then
+        val subquery1 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity1),
+            from = listOf(entity1),
+        )
+
+        val subquery2 = SelectQueries.selectQuery(
+            returnType = Book::class,
+            distinct = false,
+            select = listOf(entity2),
+            from = listOf(entity2),
+        )
+
+        assertThat(query).isInstanceOf(JpqlSelectQueryIntersectAll::class.java)
+
+        val actualUnionAll = query as JpqlSelectQueryIntersectAll
 
         assertThat(actualUnionAll.returnType).isEqualTo(Book::class)
         assertThat(actualUnionAll.left.toQuery()).isEqualTo(subquery1)

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/IntersectMutinySessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/IntersectMutinySessionExample.kt
@@ -1,0 +1,206 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class IntersectMutinySessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getMutinySessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn1 = Isbn("01")
+
+    @Test
+    fun intersectBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            intersect(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    /**
+     * Test for INTERSECT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support INTERSECT ALL.
+     * H2 only supports INTERSECT but not INTERSECT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL INTERSECT ALL support: https://modern-sql.com/caniuse/intersect-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting INTERSECT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support INTERSECT ALL - only INTERSECT is supported")
+    fun intersectAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            intersectAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    @Test
+    fun intersectBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).intersect(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    /**
+     * Test for INTERSECT ALL operation using extension function syntax.
+     *
+     * Note: This test is disabled because H2 database does not support INTERSECT ALL.
+     * H2 only supports INTERSECT but not INTERSECT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL INTERSECT ALL support: https://modern-sql.com/caniuse/intersect-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting INTERSECT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support INTERSECT ALL - only INTERSECT is supported")
+    fun intersectAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).intersectAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+}

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/IntersectMutinyStatelessSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/IntersectMutinyStatelessSessionExample.kt
@@ -1,0 +1,206 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class IntersectMutinyStatelessSessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getMutinySessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn1 = Isbn("01")
+
+    @Test
+    fun intersectBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            intersect(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    /**
+     * Test for INTERSECT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support INTERSECT ALL.
+     * H2 only supports INTERSECT but not INTERSECT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL INTERSECT ALL support: https://modern-sql.com/caniuse/intersect-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting INTERSECT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support INTERSECT ALL - only INTERSECT is supported")
+    fun intersectAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            intersectAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    @Test
+    fun intersectBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).intersect(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    /**
+     * Test for INTERSECT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support INTERSECT ALL.
+     * H2 only supports INTERSECT but not INTERSECT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL INTERSECT ALL support: https://modern-sql.com/caniuse/intersect-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting INTERSECT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support INTERSECT ALL - only INTERSECT is supported")
+    fun intersectAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).intersectAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.await().indefinitely()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+}

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/IntersectStageSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/IntersectStageSessionExample.kt
@@ -1,0 +1,206 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class IntersectStageSessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getStageSessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn1 = Isbn("01")
+
+    @Test
+    fun intersectBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            intersect(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    /**
+     * Test for INTERSECT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support INTERSECT ALL.
+     * H2 only supports INTERSECT but not INTERSECT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL INTERSECT ALL support: https://modern-sql.com/caniuse/intersect-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting INTERSECT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support INTERSECT ALL - only INTERSECT is supported")
+    fun intersectAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            intersectAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    @Test
+    fun intersectBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).intersect(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    /**
+     * Test for INTERSECT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support INTERSECT ALL.
+     * H2 only supports INTERSECT but not INTERSECT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL INTERSECT ALL support: https://modern-sql.com/caniuse/intersect-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting INTERSECT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support INTERSECT ALL - only INTERSECT is supported")
+    fun intersectAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).intersectAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+}

--- a/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/IntersectStageStatelessSessionExample.kt
+++ b/example/hibernate-reactive/src/test/kotlin/com/linecorp/kotlinjdsl/example/hibernate/reactive/jakarta/jpql/select/IntersectStageStatelessSessionExample.kt
@@ -1,0 +1,206 @@
+package com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.SessionFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jakarta.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.hibernate.reactive.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class IntersectStageStatelessSessionExample : WithAssertions {
+    private val sessionFactory = SessionFactoryTestUtils.getStageSessionFactory()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn1 = Isbn("01")
+
+    @Test
+    fun intersectBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            intersect(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    /**
+     * Test for INTERSECT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support INTERSECT ALL.
+     * H2 only supports INTERSECT but not INTERSECT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL INTERSECT ALL support: https://modern-sql.com/caniuse/intersect-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting INTERSECT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support INTERSECT ALL - only INTERSECT is supported")
+    fun intersectAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            intersectAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    @Test
+    fun intersectBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).intersect(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    /**
+     * Test for INTERSECT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support INTERSECT ALL.
+     * H2 only supports INTERSECT but not INTERSECT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL INTERSECT ALL support: https://modern-sql.com/caniuse/intersect-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting INTERSECT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support INTERSECT ALL - only INTERSECT is supported")
+    fun intersectAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(
+                Expressions.expression(
+                    Isbn::class,
+                    aliasName,
+                ),
+            )
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).intersectAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val actual = sessionFactory.withStatelessSession {
+            it.createQuery(query, context).resultList
+        }.toCompletableFuture().get()
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+}

--- a/example/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/select/IntersectExample.kt
+++ b/example/hibernate/src/test/kotlin/com/linecorp/kotlinjdsl/example/jpql/hibernate/select/IntersectExample.kt
@@ -1,0 +1,189 @@
+package com.linecorp.kotlinjdsl.example.jpql.hibernate.select
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.EntityManagerFactoryTestUtils
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.entity.book.Book
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.entity.book.BookPrice
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.jpql.hibernate.jpql.JpqlRenderContextUtils
+import com.linecorp.kotlinjdsl.querymodel.jpql.expression.Expressions
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts
+import com.linecorp.kotlinjdsl.support.hibernate.extension.createQuery
+import jakarta.persistence.TypedQuery
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class IntersectExample : WithAssertions {
+    private val entityManagerFactory = EntityManagerFactoryTestUtils.getEntityManagerFactory()
+    private val entityManager = entityManagerFactory.createEntityManager()
+
+    private val context = JpqlRenderContextUtils.getJpqlRenderContext()
+    private val aliasName = "isbnAlias"
+
+    private val bookIsbn1 = Isbn("01")
+
+    @AfterEach
+    fun tearDown() {
+        entityManager.close()
+    }
+
+    @Test
+    fun intersectBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            intersect(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    /**
+     * Test for INTERSECT ALL operation.
+     *
+     * Note: This test is disabled because H2 database does not support INTERSECT ALL.
+     * H2 only supports INTERSECT but not INTERSECT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL INTERSECT ALL support: https://modern-sql.com/caniuse/intersect-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting INTERSECT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support INTERSECT ALL - only INTERSECT is supported")
+    fun intersectAllBooksByPriceAndSalePrice() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            intersectAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+                ),
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    @Test
+    fun intersectBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).intersect(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+
+    /**
+     * Test for INTERSECT ALL operation using extension function syntax.
+     *
+     * Note: This test is disabled because H2 database does not support INTERSECT ALL.
+     * H2 only supports INTERSECT but not INTERSECT ALL as of version 2.3.232.
+     *
+     * References:
+     * - H2 Database Commands documentation: https://h2database.com/html/commands.html#select
+     * - Modern SQL INTERSECT ALL support: https://modern-sql.com/caniuse/intersect-all
+     *   (Shows H2 versions 1.4.192 - 2.3.232 as not supporting INTERSECT ALL)
+     */
+    @Test
+    @Disabled("H2 database does not support INTERSECT ALL - only INTERSECT is supported")
+    fun intersectAllBooksByPriceAndSalePriceWithNewDsl() {
+        // When
+        val query = jpql {
+            val isbnPath = path(Book::isbn).`as`(Expressions.expression(Isbn::class, aliasName))
+            select(
+                isbnPath,
+            ).from(
+                entity(Book::class),
+            ).where(
+                path(Book::price)(BookPrice::value).lessThan(3.toBigDecimal()),
+            ).intersectAll(
+                select(
+                    isbnPath,
+                ).from(
+                    entity(Book::class),
+                ).where(
+                    path(Book::salePrice)(BookPrice::value).lessThan(2.toBigDecimal()),
+                ),
+            ).orderBy(
+                Sorts.asc(isbnPath),
+            )
+        }
+
+        val typedQuery: TypedQuery<Isbn> = entityManager.createQuery(query, context)
+        val actual: List<Isbn> = typedQuery.resultList
+
+        // Then
+        assertThat(actual).containsExactly(
+            bookIsbn1,
+        )
+    }
+}

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/SelectQueries.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/SelectQueries.kt
@@ -9,6 +9,8 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.predicate.Predicate
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQuery
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExcept
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryExceptAll
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryIntersect
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryIntersectAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnion
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryUnionAll
 import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
@@ -98,6 +100,36 @@ object SelectQueries {
         orderBy: Iterable<Sort>?,
     ): SelectQuery<T> {
         return JpqlSelectQueryExceptAll(
+            returnType = returnType,
+            left = left,
+            right = right,
+            orderBy = orderBy,
+        )
+    }
+
+    @SinceJdsl("3.6.0")
+    fun <T : Any> selectIntersectQuery(
+        returnType: KClass<T>,
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+        orderBy: Iterable<Sort>?,
+    ): SelectQuery<T> {
+        return JpqlSelectQueryIntersect(
+            returnType = returnType,
+            left = left,
+            right = right,
+            orderBy = orderBy,
+        )
+    }
+
+    @SinceJdsl("3.6.0")
+    fun <T : Any> selectIntersectAllQuery(
+        returnType: KClass<T>,
+        left: JpqlQueryable<SelectQuery<T>>,
+        right: JpqlQueryable<SelectQuery<T>>,
+        orderBy: Iterable<Sort>?,
+    ): SelectQuery<T> {
+        return JpqlSelectQueryIntersectAll(
             returnType = returnType,
             left = left,
             right = right,

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryIntersect.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryIntersect.kt
@@ -1,0 +1,17 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.select.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import kotlin.reflect.KClass
+
+@Internal
+@SinceJdsl("3.6.0")
+data class JpqlSelectQueryIntersect<T : Any> internal constructor(
+    override val returnType: KClass<T>,
+    val left: JpqlQueryable<SelectQuery<T>>,
+    val right: JpqlQueryable<SelectQuery<T>>,
+    val orderBy: Iterable<Sort>?,
+) : SelectQuery<T>

--- a/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryIntersectAll.kt
+++ b/query-model/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/querymodel/jpql/select/impl/JpqlSelectQueryIntersectAll.kt
@@ -1,0 +1,17 @@
+package com.linecorp.kotlinjdsl.querymodel.jpql.select.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import kotlin.reflect.KClass
+
+@Internal
+@SinceJdsl("3.6.0")
+data class JpqlSelectQueryIntersectAll<T : Any> internal constructor(
+    override val returnType: KClass<T>,
+    val left: JpqlQueryable<SelectQuery<T>>,
+    val right: JpqlQueryable<SelectQuery<T>>,
+    val orderBy: Iterable<Sort>?,
+) : SelectQuery<T>

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/JpqlRenderContext.kt
@@ -115,6 +115,8 @@ import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlRightSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlRoundSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryExceptAllSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryExceptSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryIntersectAllSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryIntersectSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQuerySerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryUnionAllSerializer
 import com.linecorp.kotlinjdsl.render.jpql.serializer.impl.JpqlSelectQueryUnionSerializer
@@ -388,6 +390,8 @@ private class DefaultModule : JpqlRenderModule {
             JpqlRoundSerializer(),
             JpqlSelectQueryExceptAllSerializer(),
             JpqlSelectQueryExceptSerializer(),
+            JpqlSelectQueryIntersectAllSerializer(),
+            JpqlSelectQueryIntersectSerializer(),
             JpqlSelectQuerySerializer(),
             JpqlSelectQueryUnionAllSerializer(),
             JpqlSelectQueryUnionSerializer(),

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectAllSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectAllSerializer.kt
@@ -1,0 +1,51 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryIntersectAll
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+
+@Internal
+@SinceJdsl("3.6.0")
+class JpqlSelectQueryIntersectAllSerializer : JpqlSerializer<JpqlSelectQueryIntersectAll<*>> {
+    override fun handledType() = JpqlSelectQueryIntersectAll::class
+    override fun serialize(
+        part: JpqlSelectQueryIntersectAll<*>,
+        writer: JpqlWriter,
+        context: RenderContext,
+    ) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        val queryContext = context + JpqlRenderStatement.Select
+
+        delegate.serialize(part.left.toQuery(), writer, queryContext)
+
+        writer.write(" INTERSECT ALL ")
+
+        delegate.serialize(part.right.toQuery(), writer, queryContext)
+
+        writeOrderBy(part, queryContext, writer, delegate)
+    }
+
+    private fun writeOrderBy(
+        part: JpqlSelectQueryIntersectAll<*>,
+        queryContext: RenderContext,
+        writer: JpqlWriter,
+        delegate: JpqlRenderSerializer,
+    ) {
+        part.orderBy?.takeIf { it.any() }?.let { orderByItems ->
+            val orderByInSetOperationContext = queryContext + JpqlRenderClause.OrderBy
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            writer.writeEach(orderByItems, separator = ", ") { sortElement ->
+                delegate.serialize(sortElement, writer, orderByInSetOperationContext)
+            }
+        }
+    }
+}

--- a/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectSerializer.kt
+++ b/render/jpql/src/main/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectSerializer.kt
@@ -1,0 +1,51 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.Internal
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryIntersect
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializer
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+
+@Internal
+@SinceJdsl("3.6.0")
+class JpqlSelectQueryIntersectSerializer : JpqlSerializer<JpqlSelectQueryIntersect<*>> {
+    override fun handledType() = JpqlSelectQueryIntersect::class
+    override fun serialize(
+        part: JpqlSelectQueryIntersect<*>,
+        writer: JpqlWriter,
+        context: RenderContext,
+    ) {
+        val delegate = context.getValue(JpqlRenderSerializer)
+
+        val queryContext = context + JpqlRenderStatement.Select
+
+        delegate.serialize(part.left.toQuery(), writer, queryContext)
+
+        writer.write(" INTERSECT ")
+
+        delegate.serialize(part.right.toQuery(), writer, queryContext)
+
+        writeOrderBy(part, queryContext, writer, delegate)
+    }
+
+    private fun writeOrderBy(
+        part: JpqlSelectQueryIntersect<*>,
+        queryContext: RenderContext,
+        writer: JpqlWriter,
+        delegate: JpqlRenderSerializer,
+    ) {
+        part.orderBy?.takeIf { it.any() }?.let { orderByItems ->
+            val orderByInSetOperationContext = queryContext + JpqlRenderClause.OrderBy
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            writer.writeEach(orderByItems, separator = ", ") { sortElement ->
+                delegate.serialize(sortElement, writer, orderByInSetOperationContext)
+            }
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectAllSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectAllSerializerTest.kt
@@ -1,0 +1,108 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryIntersectAll
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@JpqlSerializerTest
+@ExtendWith(MockKExtension::class)
+class JpqlSelectQueryIntersectAllSerializerTest : WithAssertions {
+    private val sut = JpqlSelectQueryIntersectAllSerializer()
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    private lateinit var initialContext: RenderContext
+
+    @BeforeEach
+    fun setUp() {
+        initialContext = TestRenderContext(serializer)
+    }
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlSelectQueryIntersectAll::class)
+    }
+
+    @Test
+    fun `serialize operation`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        val part = SelectQueries.selectIntersectAllQuery(
+            String::class,
+            leftQuery,
+            rightQuery,
+            orderBy = null,
+        ) as JpqlSelectQueryIntersectAll
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        // then
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" INTERSECT ALL ")
+            serializer.serialize(rightQuery, writer, queryContext)
+        }
+    }
+
+    @Test
+    fun `serialize operation with order by`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+        val sort = mockk<Sort>()
+        val part = SelectQueries.selectIntersectAllQuery(
+            returnType = String::class,
+            left = leftQuery,
+            right = rightQuery,
+            orderBy = listOf(sort),
+        ) as JpqlSelectQueryIntersectAll
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        val orderByContext = queryContext + JpqlRenderClause.OrderBy
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        // then
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" INTERSECT ALL ")
+            serializer.serialize(rightQuery, writer, queryContext)
+
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            serializer.serialize(sort, writer, orderByContext)
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectAllSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectAllSerializerTest.kt
@@ -90,6 +90,7 @@ class JpqlSelectQueryIntersectAllSerializerTest : WithAssertions {
         ) as JpqlSelectQueryIntersectAll
         val queryContext = initialContext + JpqlRenderStatement.Select
         val orderByContext = queryContext + JpqlRenderClause.OrderBy
+
         // when
         sut.serialize(part, writer, initialContext)
 

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectSerializerTest.kt
@@ -1,0 +1,108 @@
+package com.linecorp.kotlinjdsl.render.jpql.serializer.impl
+
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQueries
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.impl.JpqlSelectQueryIntersect
+import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sort
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.render.TestRenderContext
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderClause
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderSerializer
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlRenderStatement
+import com.linecorp.kotlinjdsl.render.jpql.serializer.JpqlSerializerTest
+import com.linecorp.kotlinjdsl.render.jpql.writer.JpqlWriter
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@JpqlSerializerTest
+@ExtendWith(MockKExtension::class)
+class JpqlSelectQueryIntersectSerializerTest : WithAssertions {
+    private val sut = JpqlSelectQueryIntersectSerializer()
+
+    @MockK(relaxUnitFun = true)
+    private lateinit var writer: JpqlWriter
+
+    @MockK
+    private lateinit var serializer: JpqlRenderSerializer
+
+    private lateinit var initialContext: RenderContext
+
+    @BeforeEach
+    fun setUp() {
+        initialContext = TestRenderContext(serializer)
+    }
+
+    @Test
+    fun handledType() {
+        // when
+        val actual = sut.handledType()
+
+        // then
+        assertThat(actual).isEqualTo(JpqlSelectQueryIntersect::class)
+    }
+
+    @Test
+    fun `serialize operation`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        val part = SelectQueries.selectIntersectQuery(
+            String::class,
+            leftQuery,
+            rightQuery,
+            orderBy = null,
+        ) as JpqlSelectQueryIntersect
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        // then
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" INTERSECT ")
+            serializer.serialize(rightQuery, writer, queryContext)
+        }
+    }
+
+    @Test
+    fun `serialize operation with order by`() {
+        // given
+        val leftQuery = mockk<SelectQuery<String>>()
+        val rightQuery = mockk<SelectQuery<String>>()
+        every { leftQuery.toQuery() } returns leftQuery
+        every { rightQuery.toQuery() } returns rightQuery
+        val sort = mockk<Sort>()
+        val part = SelectQueries.selectIntersectQuery(
+            returnType = String::class,
+            left = leftQuery,
+            right = rightQuery,
+            orderBy = listOf(sort),
+        ) as JpqlSelectQueryIntersect
+        val queryContext = initialContext + JpqlRenderStatement.Select
+        val orderByContext = queryContext + JpqlRenderClause.OrderBy
+        // when
+        sut.serialize(part, writer, initialContext)
+
+        // then
+        verify {
+            serializer.serialize(leftQuery, writer, queryContext)
+            writer.write(" INTERSECT ")
+            serializer.serialize(rightQuery, writer, queryContext)
+
+            writer.write(" ")
+            writer.write("ORDER BY")
+            writer.write(" ")
+            serializer.serialize(sort, writer, orderByContext)
+        }
+    }
+}

--- a/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectSerializerTest.kt
+++ b/render/jpql/src/test/kotlin/com/linecorp/kotlinjdsl/render/jpql/serializer/impl/JpqlSelectQueryIntersectSerializerTest.kt
@@ -90,6 +90,7 @@ class JpqlSelectQueryIntersectSerializerTest : WithAssertions {
         ) as JpqlSelectQueryIntersect
         val queryContext = initialContext + JpqlRenderStatement.Select
         val orderByContext = queryContext + JpqlRenderClause.OrderBy
+
         // when
         sut.serialize(part, writer, initialContext)
 


### PR DESCRIPTION
### Description

This pull request introduces support for the `INTERSECT` and `INTERSECT ALL` set operators, aligning with the Jakarta Persistence 3.2 specification. These additions enhance Kotlin JDSL's capabilities for composing complex queries.

### Implementation Details

According to the JPQL BNF grammar in the Jakarta Persistence 3.2 specification, the `INTERSECT` operator has higher precedence than `UNION` or `EXCEPT`.
[BNF](https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#set-operators-in-select-statements) is below.
```
select_statement ::= union
union ::= intersection | union {UNION [ALL] | EXCEPT [ALL]} intersection
intersection ::= query_expression | intersection INTERSECT [ALL] query_expression
query_expression ::= select_query | (union)
```


Initially, we considered adding logic within the serializer to manage this operator precedence, for instance by automatically adding parentheses around lower-precedence operations. However, we concluded that handling operator precedence is the responsibility of the JPA provider's JPQL parser, not the query generator.

Therefore, this implementation focuses on generating a syntactically correct JPQL string. The serializers for `INTERSECT` and `INTERSECT ALL` simply produce the corresponding string, trusting the persistence provider to parse and execute the query correctly according to the specification's rules.

### Documentation

The official documentation (`statements.md`) has been updated in both English and Korean to include:
- Descriptions of the `INTERSECT` and `INTERSECT ALL` operators.
- Usage examples for both chained and top-level operations.
- Updated database compatibility notes.

--- korean

### Description

이 Pull Request는 Jakarta Persistence 3.2 스펙에 맞춰 `INTERSECT` 및 `INTERSECT ALL` 집합 연산자에 대한 지원을 추가합니다. 이 추가 사항은 복잡한 쿼리를 작성하는 Kotlin JDSL의 기능을 향상시킵니다.

### Implementation Details

Jakarta Persistence 3.2 명세의 JPQL BNF 문법에 따르면, `INTERSECT` 연산자는 `UNION`이나 `EXCEPT`보다 높은 우선순위를 가집니다.
[BNF](https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#set-operators-in-select-statements) 는 아래와 같습니다.

```
select_statement ::= union
union ::= intersection | union {UNION [ALL] | EXCEPT [ALL]} intersection
intersection ::= query_expression | intersection INTERSECT [ALL] query_expression
query_expression ::= select_query | (union)
```

처음에는 연산자 우선순위를 관리하기 위해 직렬 변환기(serializer) 내에 괄호를 자동으로 추가하는 등의 로직을 넣는 것을 고려했습니다. 하지만 연산자 우선순위를 처리하는 것은 쿼리 생성기가 아닌 JPA 프로바이더의 JPQL 파서의 책임이라고 결론 내렸습니다.

따라서 이 구현은 문법적으로 올바른 JPQL 문자열을 생성하는 데 중점을 둡니다. `INTERSECT` 및 `INTERSECT ALL`을 위한 직렬 변환기는 단순히 해당 문자열을 생성하며, 실제 쿼리의 파싱과 실행은 명세의 규칙에 따라 JPA 프로바이더가 올바르게 처리할 것으로 기대합니다.

### Documentation

공식 문서(`statements.md`)가 다음과 같은 내용을 포함하도록 한국어와 영어 버전 모두 업데이트되었습니다:
- `INTERSECT` 및 `INTERSECT ALL` 연산자에 대한 설명
- 체이닝 방식과 최상위 레벨 연산 방식의 사용 예제
- 업데이트된 데이터베이스 호환성 정보를 정확히 기술하였습니다.
