### PR TITLE
feat: seperate legacy example toml versions

### DIFF
--- a/example/eclipselink-javax/build.gradle.kts
+++ b/example/eclipselink-javax/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    implementation(exampleLibs.eclipselink2)
+    implementation(exampleLegacyLibs.eclipselink2)
     implementation(exampleLibs.logback)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
@@ -16,7 +16,7 @@ dependencies {
 
     runtimeOnly(exampleLibs.h2)
 
-    testFixturesImplementation(exampleLibs.eclipselink2)
+    testFixturesImplementation(exampleLegacyLibs.eclipselink2)
     testFixturesImplementation(projects.jpqlRender)
 }
 

--- a/example/hibernate-javax/build.gradle.kts
+++ b/example/hibernate-javax/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    implementation(exampleLibs.hibernate5.core)
+    implementation(exampleLegacyLibs.hibernate5.core)
     implementation(exampleLibs.logback)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
@@ -16,7 +16,7 @@ dependencies {
 
     runtimeOnly(exampleLibs.h2)
 
-    testFixturesImplementation(exampleLibs.hibernate5.core)
+    testFixturesImplementation(exampleLegacyLibs.hibernate5.core)
     testFixturesImplementation(projects.jpqlRender)
 }
 

--- a/example/hibernate-reactive-javax/build.gradle.kts
+++ b/example/hibernate-reactive-javax/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    implementation(exampleLibs.hibernate.reactive1.core)
+    implementation(exampleLegacyLibs.hibernate.reactive1.core)
     implementation(exampleLibs.vertx.jdbc.client)
     implementation(exampleLibs.agroal.pool)
     implementation(exampleLibs.logback)
@@ -18,7 +18,7 @@ dependencies {
 
     runtimeOnly(exampleLibs.h2)
 
-    testFixturesImplementation(exampleLibs.hibernate.reactive1.core)
+    testFixturesImplementation(exampleLegacyLibs.hibernate.reactive1.core)
     testFixturesImplementation(projects.jpqlRender)
 }
 

--- a/example/spring-batch-javax/build.gradle.kts
+++ b/example/spring-batch-javax/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
-    alias(exampleLibs.plugins.spring.boot2)
+    alias(exampleLegacyLibs.plugins.spring.boot2)
     alias(libs.plugins.kotlin.noarg)
     alias(libs.plugins.kotlin.allopen)
     alias(libs.plugins.kotlin.spring)
@@ -10,9 +10,9 @@ plugins {
 
 dependencies {
     @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
-    implementation(exampleLibs.spring.boot2.batch)
-    implementation(exampleLibs.spring.boot2.jpa)
-    implementation(exampleLibs.spring.boot2.p6spy)
+    implementation(exampleLegacyLibs.spring.boot2.batch)
+    implementation(exampleLegacyLibs.spring.boot2.jpa)
+    implementation(exampleLegacyLibs.spring.boot2.p6spy)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
@@ -20,8 +20,8 @@ dependencies {
 
     runtimeOnly(exampleLibs.h2)
 
-    testImplementation(exampleLibs.spring.boot2.test)
-    testImplementation(exampleLibs.spring.batch4.test)
+    testImplementation(exampleLegacyLibs.spring.boot2.test)
+    testImplementation(exampleLegacyLibs.spring.batch4.test)
 }
 
 kotlin {

--- a/example/spring-data-jpa-javax/build.gradle.kts
+++ b/example/spring-data-jpa-javax/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
-    alias(exampleLibs.plugins.spring.boot2)
+    alias(exampleLegacyLibs.plugins.spring.boot2)
     alias(libs.plugins.kotlin.noarg)
     alias(libs.plugins.kotlin.allopen)
     alias(libs.plugins.kotlin.spring)
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
-    implementation(exampleLibs.spring.boot2.jpa)
-    implementation(exampleLibs.spring.boot2.p6spy)
+    implementation(exampleLegacyLibs.spring.boot2.jpa)
+    implementation(exampleLegacyLibs.spring.boot2.p6spy)
     implementation(projects.example)
     implementation(projects.jpqlDsl)
     implementation(projects.jpqlRender)
@@ -19,7 +19,7 @@ dependencies {
 
     runtimeOnly(exampleLibs.h2)
 
-    testImplementation(exampleLibs.spring.boot2.test)
+    testImplementation(exampleLegacyLibs.spring.boot2.test)
 }
 
 kotlin {

--- a/libs.example.legacy.versions.toml
+++ b/libs.example.legacy.versions.toml
@@ -1,0 +1,27 @@
+[versions]
+spring-boot2 = "2.7.18"
+
+[libraries]
+# jpa
+javax-persistence-api = { module = "javax.persistence:javax.persistence-api", version = "2.2" }
+
+# spring boot
+spring-boot2-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "spring-boot2" }
+spring-boot2-batch = { module = "org.springframework.boot:spring-boot-starter-batch", version.ref = "spring-boot2" }
+spring-boot2-p6spy = { module = "com.github.gavlyukovskiy:p6spy-spring-boot-starter", version = "1.8.1" }
+spring-boot2-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot2" }
+
+# spring
+spring-batch4-test = { module = "org.springframework.batch:spring-batch-test", version = "4.3.10" }
+
+# hibernate
+hibernate5-core = { module = "org.hibernate:hibernate-core", version = "5.6.15.Final" }
+
+# hibernate-reactive
+hibernate-reactive1-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "1.1.9.Final" }
+
+# eclipse-link
+eclipselink2 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "2.7.16" }
+
+[plugins]
+spring-boot2 = { id = "org.springframework.boot", version.ref = "spring-boot2" }

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 spring-boot3 = "3.5.4"
-spring-boot2 = "2.7.18"
 
 [libraries]
 # log
@@ -8,7 +7,6 @@ slf4j = { module = "org.slf4j:slf4j-api", version = "2.0.17" }
 logback = { module = "ch.qos.logback:logback-classic", version = "1.5.18" }
 
 # jpa
-javax-persistence-api = { module = "javax.persistence:javax.persistence-api", version = "2.2" }
 jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api", version = "3.2.0" }
 
 # spring boot
@@ -17,25 +15,16 @@ spring-boot3-batch = { module = "org.springframework.boot:spring-boot-starter-ba
 spring-boot3-p6spy = { module = "com.github.gavlyukovskiy:p6spy-spring-boot-starter", version = "1.12.0" }
 spring-boot3-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot3" }
 
-spring-boot2-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "spring-boot2" }
-spring-boot2-batch = { module = "org.springframework.boot:spring-boot-starter-batch", version.ref = "spring-boot2" }
-spring-boot2-p6spy = { module = "com.github.gavlyukovskiy:p6spy-spring-boot-starter", version = "1.8.1" }
-spring-boot2-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot2" }
-
 # spring
-spring-batch4-test = { module = "org.springframework.batch:spring-batch-test", version = "4.3.10" }
 spring-batch5-test = { module = "org.springframework.batch:spring-batch-test", version = "5.2.2" }
 
 # hibernate
-hibernate5-core = { module = "org.hibernate:hibernate-core", version = "5.6.15.Final" }
 hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.0.7.Final" }
 
 # hibernate-reactive
-hibernate-reactive1-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "1.1.9.Final" }
 hibernate-reactive2-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "3.0.5.Final" }
 
 # eclipse-link
-eclipselink2 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "2.7.16" }
 eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "4.0.7" }
 
 # vertx
@@ -46,4 +35,3 @@ h2 = { module = "com.h2database:h2", version = "2.3.232" }
 
 [plugins]
 spring-boot3 = { id = "org.springframework.boot", version.ref = "spring-boot3" }
-spring-boot2 = { id = "org.springframework.boot", version.ref = "spring-boot2" }

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,14 @@
     "includePaths": [
       "libs.example.versions.toml"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "matchFileNames": [
+        "libs.example.legacy.versions.toml",
+        "libs.versions.toml"
+      ],
+      "enabled": false
+    }
+  ]
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,6 +56,10 @@ dependencyResolutionManagement {
         create("exampleLibs") {
             from(files("libs.example.versions.toml"))
         }
+
+        create("exampleLegacyLibs") {
+            from(files("libs.example.legacy.versions.toml"))
+        }
     }
 }
 


### PR DESCRIPTION
# Motivation

- The renovate bot was creating incorrect pull requests by attempting to update legacy library versions that are no longer maintained, such as hibernate 5.6.15.
- These libraries are intentionally kept for backward compatibility testing, so it was necessary to configure renovate to stop proposing unnecessary updates for them.

# Modifications

- Separated Legacy Library Files:
  - Created a new file, libs.example.legacy.versions.toml.
  - Moved definitions for outdated libraries, such as spring-boot2 and hibernate5-core, from the existing libs.example.versions.toml to the new file.

- Updated `renovate` Configuration:
   - Added packageRules to the renovate.json file to exclude libs.example.legacy.versions.toml and libs.versions.toml from renovate's version management scope. The libs.versions.toml file was explicitly excluded because its versions are intended to be fixed.

# Result

- After this PR is merged, renovate will no longer check for updates to the libraries defined in libs.example.legacy.versions.toml and libs.versions.toml.
- This resolves the issue of unnecessary pull requests being generated for libraries that are intentionally kept at older or fixed versions.

--- korean
# Motivation

- renovate가 더 이상 업데이트되지 않는 레거시 라이브러리(예: hibernate 5.6.15)의 버전을 계속해서 업데이트하려고 시도하여 잘못된 PR을 생성하는 문제가 있었습니다.
- 이러한 라이브러리는 하위 호환성 테스트를 위해 의도적으로 유지되고 있으므로, renovate가 불필요한 업데이트를 제안하지 않도록 설정할 필요가 있습니다.

# Modifications

- 레거시 라이브러리 파일 분리:
  - libs.example.legacy.versions.toml 파일을 새로 생성했습니다.
  - 기존 libs.example.versions.toml에 있던 spring-boot2, hibernate5-core 등 지원이 중단된 라이브러리 정의를 새 파일로 이전했습니다.

- `renovate` 설정 수정:
  - renovate.json 파일에 packageRules를 추가하여, libs.example.legacy.versions.toml,  libs.versions.toml 파일을 renovate의 버전 관리 대상에서 제외하도록 설정했습니다. libs.versions.toml 의 경우 버전을 고정해서 사용하기 때문에 대상을 명시적으로 제외했습니다.

# Result

- 이 PR이 머지되면, renovate는 더 이상 libs.example.legacy.versions.toml, libs.versions.toml 파일에 정의된 라이브러리들의 업데이트를 확인하지 않습니다.
- 결과적으로, 의도적으로 낮은 버전을 유지하는 라이브러리에 대해 불필요한 PR이 생성되는 문제가 해결됩니다.
