### PR TITLE
docs: add FAQ on how to use database-specific functions

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -19,4 +19,5 @@
 * [How can I see the generated query?](faq/how-can-i-see-the-generated-query.md)
 * [How can I use Kotlin value class?](faq/how-do-i-use-kotlin-value-class.md)
 * [What is the difference between Kotlin JDSL and jOOQ and QueryDSL?](faq/what-is-the-difference-between-kotlin-jdsl-and-jooq-and-querydsl.md)
+* [How to use database-specific functions?](faq/how-to-use-database-specific-functions.md)
 * [Why is there a support module that only has a nullable return type](faq/why-is-there-a-support-module-that-only-has-a-nullable-return-type.md)

--- a/docs/en/faq/how-to-use-database-specific-functions.md
+++ b/docs/en/faq/how-to-use-database-specific-functions.md
@@ -1,0 +1,58 @@
+# How to use database-specific functions?
+
+You can use database-specific functions that are not part of the standard JPQL specification by using the `function()` DSL function. This is useful for functions like `JSON_VALUE`, `GROUP_CONCAT`, etc.
+
+To use a database function, you need to provide the return type, the function name, and the arguments.
+
+Here is an example of using `GROUP_CONCAT` in MySQL:
+
+```kotlin
+val query = jpql {
+    select(
+        function(
+            String::class,
+            "GROUP_CONCAT",
+            path(Book::name)
+        )
+    ).from(
+        entity(Book::class)
+    )
+}
+```
+
+## Registering the function in your JPA provider
+
+For the JPA provider to understand the function, you might need to register it.
+
+### Hibernate
+
+If you are using Hibernate, you need to register the function using a `FunctionContributor`.
+
+```kotlin
+class MyFunctionContributor : FunctionContributor {
+    override fun contributeFunctions(functionContributions: FunctionContributions) {
+        functionContributions.functionRegistry.register(
+            "group_concat",
+            StandardSQLFunction("group_concat", StandardBasicTypes.STRING)
+        )
+    }
+}
+```
+
+And then you need to register this contributor. You can do this by creating a file `src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor` with the fully qualified name of your contributor class.
+
+```
+com.example.MyFunctionContributor
+```
+
+Or if you are using Spring Boot, you can set the property in `application.yml`:
+
+```yaml
+spring:
+  jpa:
+    properties:
+      hibernate:
+        metadata_builder_contributor: com.example.MyFunctionContributor
+```
+
+With this setup, you can use `group_concat` in your queries.

--- a/docs/ko/SUMMARY.md
+++ b/docs/ko/SUMMARY.md
@@ -19,4 +19,5 @@
 * [어떻게 생성된 쿼리를 볼 수 있나요?](faq/how-can-i-see-the-generated-query.md)
 * [Kotlin value class 를 사용하려면 어떻게 해야할까요?](faq/how-do-i-use-kotlin-value-class.md)
 * [Kotlin JDSL과 jOOQ, QueryDSL의 차이점은 무엇인가요?](faq/what-is-the-difference-between-kotlin-jdsl-and-jooq-and-querydsl.md)
+* [데이터베이스별 함수는 어떻게 사용하나요?](faq/how-to-use-database-specific-functions.md)
 * [왜 Kotlin JDSL은 Nullable한 반환 타입을 허용하나요?](faq/why-is-there-a-support-module-that-only-has-a-nullable-return-type.md)

--- a/docs/ko/faq/how-to-use-database-specific-functions.md
+++ b/docs/ko/faq/how-to-use-database-specific-functions.md
@@ -1,0 +1,58 @@
+# 데이터베이스별 함수는 어떻게 사용하나요?
+
+표준 JPQL 사양에 포함되지 않은 데이터베이스별 함수는 `function()` DSL 함수를 사용하여 호출할 수 있습니다. `JSON_VALUE`, `GROUP_CONCAT` 등과 같은 함수에 유용합니다.
+
+데이터베이스 함수를 사용하려면 반환 유형, 함수 이름 및 인수를 제공해야 합니다.
+
+다음은 MySQL에서 `GROUP_CONCAT`을 사용하는 예입니다.
+
+```kotlin
+val query = jpql {
+    select(
+        function(
+            String::class,
+            "GROUP_CONCAT",
+            path(Book::name)
+        )
+    ).from(
+        entity(Book::class)
+    )
+}
+```
+
+## JPA 제공업체에 함수 등록
+
+JPA 제공업체가 함수를 이해하려면 함수를 등록해야 할 수 있습니다.
+
+### Hibernate
+
+Hibernate를 사용하는 경우 `FunctionContributor`를 사용하여 함수를 등록해야 합니다.
+
+```kotlin
+class MyFunctionContributor : FunctionContributor {
+    override fun contributeFunctions(functionContributions: FunctionContributions) {
+        functionContributions.functionRegistry.register(
+            "group_concat",
+            StandardSQLFunction("group_concat", StandardBasicTypes.STRING)
+        )
+    }
+}
+```
+
+그런 다음 이 기여자를 등록해야 합니다. `src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor` 파일을 만들고 기여자 클래스의 정규화된 이름을 내용으로 추가하여 등록할 수 있습니다.
+
+```
+com.example.MyFunctionContributor
+```
+
+또는 Spring Boot를 사용하는 경우 `application.yml`에서 속성을 설정할 수 있습니다.
+
+```yaml
+spring:
+  jpa:
+    properties:
+      hibernate:
+        metadata_builder_contributor: com.example.MyFunctionContributor
+```
+
+이렇게 설정하면 쿼리에서 `group_concat`을 사용할 수 있습니다.


### PR DESCRIPTION
# Motivation

The documentation lacked guidance on using database-specific functions that are not part of the standard JPQL specification. This PR adds a new FAQ page to explain how to use functions like `GROUP_CONCAT` with Kotlin JDSL and how to register them with the JPA provider.

# Modifications

- Added `docs/en/faq/how-to-use-database-specific-functions.md`
- Added `docs/ko/faq/how-to-use-database-specific-functions.md`
- Updated `docs/en/SUMMARY.md` and `docs/ko/SUMMARY.md` to include the new FAQ.

# Result

After this PR is merged, users will have a clear guide on how to use database-specific functions, enabling them to leverage the full power of their underlying database.