### PR TITLE
docs: add FAQ on handling count query in Spring Data JPA Pageable

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -19,4 +19,5 @@
 * [How can I see the generated query?](faq/how-can-i-see-the-generated-query.md)
 * [How can I use Kotlin value class?](faq/how-do-i-use-kotlin-value-class.md)
 * [What is the difference between Kotlin JDSL and jOOQ and QueryDSL?](faq/what-is-the-difference-between-kotlin-jdsl-and-jooq-and-querydsl.md)
+* [How to handle count query in Spring Data JPA Pageable?](faq/how-to-handle-count-query-in-spring-data-jpa-pageable.md)
 * [Why is there a support module that only has a nullable return type](faq/why-is-there-a-support-module-that-only-has-a-nullable-return-type.md)

--- a/docs/en/faq/how-to-handle-count-query-in-spring-data-jpa-pageable.md
+++ b/docs/en/faq/how-to-handle-count-query-in-spring-data-jpa-pageable.md
@@ -1,0 +1,42 @@
+# How to handle count query in Spring Data JPA Pageable?
+
+When using `findPage` from `KotlinJdslJpqlExecutor` with Spring Data JPA's `Pageable`, you might encounter issues with the automatically generated count query, especially with complex queries involving `join` and `groupBy`.
+
+Spring Data JPA, by default, tries to generate a count query from your main query. However, this generated query is often incorrect for complex scenarios.
+
+To solve this, you can provide a separate count query. `KotlinJdslJpqlExecutor` has a `findPage` method that accepts a separate count query lambda.
+
+Here is an example:
+
+```kotlin
+interface BookRepository : JpaRepository<Book, Isbn>, KotlinJdslJpqlExecutor
+
+val page: Page<Book> = bookRepository.findPage(pageable,
+    { // Query
+        select(
+            entity(Book::class)
+        ).from(
+            entity(Book::class),
+            join(Book::author)
+        ).where(
+            // ... some conditions
+        ).groupBy(
+            path(Book::isbn)
+        )
+    },
+    { // Count Query
+        select(
+            countDistinct(path(Book::isbn))
+        ).from(
+            entity(Book::class),
+            join(Book::author)
+        ).where(
+            // ... same conditions
+        )
+    }
+)
+```
+
+By providing a separate, simplified count query, you can avoid the issues with the automatically generated one. The count query should return a single `Long` value. It's important to apply the same `where` conditions to the count query as you do to the main query to get the correct total count.
+
+Note that when you have a `groupBy` clause in your main query, the count query should usually count the distinct values of the grouped expression, as shown in the example with `countDistinct(path(Book::isbn))`.

--- a/docs/ko/SUMMARY.md
+++ b/docs/ko/SUMMARY.md
@@ -19,4 +19,5 @@
 * [어떻게 생성된 쿼리를 볼 수 있나요?](faq/how-can-i-see-the-generated-query.md)
 * [Kotlin value class 를 사용하려면 어떻게 해야할까요?](faq/how-do-i-use-kotlin-value-class.md)
 * [Kotlin JDSL과 jOOQ, QueryDSL의 차이점은 무엇인가요?](faq/what-is-the-difference-between-kotlin-jdsl-and-jooq-and-querydsl.md)
+* [Spring Data JPA Pageable에서 count 쿼리는 어떻게 처리하나요?](faq/how-to-handle-count-query-in-spring-data-jpa-pageable.md)
 * [왜 Kotlin JDSL은 Nullable한 반환 타입을 허용하나요?](faq/why-is-there-a-support-module-that-only-has-a-nullable-return-type.md)

--- a/docs/ko/faq/how-to-handle-count-query-in-spring-data-jpa-pageable.md
+++ b/docs/ko/faq/how-to-handle-count-query-in-spring-data-jpa-pageable.md
@@ -1,0 +1,42 @@
+# Spring Data JPA Pageable에서 count 쿼리는 어떻게 처리하나요?
+
+Spring Data JPA의 `Pageable`과 함께 `KotlinJdslJpqlExecutor`의 `findPage`를 사용할 때, 특히 `join` 및 `groupBy`를 포함하는 복잡한 쿼리에서 자동 생성된 count 쿼리에 문제가 발생할 수 있습니다.
+
+기본적으로 Spring Data JPA는 주 쿼리에서 count 쿼리를 생성하려고 시도합니다. 그러나 이 생성된 쿼리는 복잡한 시나리오에서는 종종 올바르지 않습니다.
+
+이 문제를 해결하기 위해 별도의 count 쿼리를 제공할 수 있습니다. `KotlinJdslJpqlExecutor`에는 별도의 count 쿼리 람다를 허용하는 `findPage` 메서드가 있습니다.
+
+다음은 예시입니다.
+
+```kotlin
+interface BookRepository : JpaRepository<Book, Isbn>, KotlinJdslJpqlExecutor
+
+val page: Page<Book> = bookRepository.findPage(pageable,
+    { // 쿼리
+        select(
+            entity(Book::class)
+        ).from(
+            entity(Book::class),
+            join(Book::author)
+        ).where(
+            // ... 일부 조건
+        ).groupBy(
+            path(Book::isbn)
+        )
+    },
+    { // Count 쿼리
+        select(
+            countDistinct(path(Book::isbn))
+        ).from(
+            entity(Book::class),
+            join(Book::author)
+        ).where(
+            // ... 동일한 조건
+        )
+    }
+)
+```
+
+별도의 간단한 count 쿼리를 제공함으로써 자동 생성된 쿼리의 문제를 피할 수 있습니다. count 쿼리는 단일 `Long` 값을 반환해야 합니다. 정확한 총 개수를 얻으려면 주 쿼리에 적용하는 것과 동일한 `where` 조건을 count 쿼리에도 적용하는 것이 중요합니다.
+
+주 쿼리에 `groupBy` 절이 있는 경우, `countDistinct(path(Book::isbn))` 예제에서 볼 수 있듯이 count 쿼리는 일반적으로 그룹화된 표현식의 고유한 값을 세어야 합니다.


### PR DESCRIPTION
# Motivation

Users often face issues with incorrect count queries when using Spring Data JPA's `Pageable` with complex queries. This PR adds a new FAQ page to explain how to provide a separate, correct count query when using `findPage` in `KotlinJdslJpqlExecutor`.

# Modifications

- Added `docs/en/faq/how-to-handle-count-query-in-spring-data-jpa-pageable.md`
- Added `docs/ko/faq/how-to-handle-count-query-in-spring-data-jpa-pageable.md`
- Updated `docs/en/SUMMARY.md` and `docs/ko/SUMMARY.md` to include the new FAQ.

# Result

After this PR is merged, users will be able to solve common count query problems with pagination, leading to more robust and correct data fetching in their applications.