### PR TITLE
docs: add hibernate reactive supports document

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -11,6 +11,7 @@
     * [Subqueries](jpql-with-kotlin-jdsl/subqueries.md)
     * [Custom DSL](jpql-with-kotlin-jdsl/custom-dsl.md)
     * [Spring supports](jpql-with-kotlin-jdsl/spring-supports.md)
+    * [Hibernate Reactive supports](jpql-with-kotlin-jdsl/hibernate-reactive-supports.md)
     * [Migration 2.X to 3.X](jpql-with-kotlin-jdsl/migration-2.x-to-3.x.md)
 * [Kotlin JDSL Roadmap](kotlin-jdsl-roadmap.md)
 

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -19,4 +19,5 @@
 * [How can I see the generated query?](faq/how-can-i-see-the-generated-query.md)
 * [How can I use Kotlin value class?](faq/how-do-i-use-kotlin-value-class.md)
 * [What is the difference between Kotlin JDSL and jOOQ and QueryDSL?](faq/what-is-the-difference-between-kotlin-jdsl-and-jooq-and-querydsl.md)
+* [How to build dynamic queries?](faq/how-to-build-dynamic-queries.md)
 * [Why is there a support module that only has a nullable return type](faq/why-is-there-a-support-module-that-only-has-a-nullable-return-type.md)

--- a/docs/en/faq/how-to-build-dynamic-queries.md
+++ b/docs/en/faq/how-to-build-dynamic-queries.md
@@ -1,0 +1,60 @@
+# How to build dynamic queries?
+
+You can build dynamic queries by adding predicates to the `where` clause based on conditions.
+Kotlin JDSL's `where` clause can take a list of predicates. The `and()` and `or()` functions are useful for this.
+
+A common pattern is to create a mutable list of `Predicate`s and add conditions to it. Then, you can pass this list to the `where` clause using `and()`.
+
+If the list of predicates passed to `and()` is empty, it is treated as `1 = 1`, which means no filtering is applied. This is useful for dynamic queries where all conditions might be optional.
+
+{% hint style="warning" %}
+Be cautious when building dynamic queries. If no conditions are applied, the query will select all rows from the entity, which could lead to performance issues with large tables. Always consider the case where no filters are active.
+{% endhint %}
+
+Here is an example:
+
+```kotlin
+fun findBooks(title: String?, authorName: String?): List<Book> {
+    val query = jpql {
+        select(
+            entity(Book::class)
+        ).from(
+            entity(Book::class)
+        ).where(
+            and(
+                title?.let { path(Book::title).like("%$it%") },
+                authorName?.let { path(Book::author)(Author::name).like("%$it%") },
+            )
+        )
+    }
+    return entityManager.createQuery(query, context).resultList
+}
+```
+
+In the example above, if `title` is not null, a `like` predicate is created. The same applies to `authorName`. The `and()` function will filter out any `null` predicates that result from the `let` blocks when the parameters are null. If both `title` and `authorName` are `null`, the `where` clause will be effectively empty, and all books will be returned.
+
+Alternatively, you can build a list of predicates:
+
+```kotlin
+fun findBooks(title: String?, authorName: String?): List<Book> {
+    val query = jpql {
+        select(
+            entity(Book::class)
+        ).from(
+            entity(Book::class)
+        ).whereAnd(
+            mutableListOf<Predicate?>().apply {
+                if (!title.isNullOrBlank()) {
+                    add(path(Book::title).like("%$title%"))
+                }
+                if (!authorName.isNullOrBlank()) {
+                    add(path(Book::author)(Author::name).like("%$authorName%"))
+                }
+            }
+        )
+    }
+    return entityManager.createQuery(query, context).resultList
+}
+```
+
+The `whereAnd` is a shorthand for `where(and(...))`. If the list is empty, it will not add any conditions to the query.

--- a/docs/en/jpql-with-kotlin-jdsl/hibernate-reactive-supports.md
+++ b/docs/en/jpql-with-kotlin-jdsl/hibernate-reactive-supports.md
@@ -1,0 +1,183 @@
+# Hibernate Reactive supports
+
+Kotlin JDSL provides the `hibernate-reactive-support` module to easily execute queries using [Hibernate Reactive](https://hibernate.org/reactive/).
+
+This module offers extension functions for Hibernate Reactive's `Session` and `StatelessSession` objects, allowing you to pass a Kotlin JDSL query object directly to create a reactive query.
+
+## Executing Queries
+
+The main extension functions provided are:
+- `createQuery()`: For `SELECT` statements on both `Session` and `StatelessSession`. For `StatelessSession`, it is also used for `UPDATE` and `DELETE` statements.
+- `createMutationQuery()`: For `UPDATE` and `DELETE` statements on a stateful `Session`.
+
+These functions are used on a `Session` or `StatelessSession` instance, which you typically get from a `SessionFactory`.
+
+### Mutiny
+
+#### Stateful Session
+With a stateful `Mutiny.Session`, use `createQuery` for select statements and `createMutationQuery` for update/delete statements.
+
+```kotlin
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createMutationQuery
+import io.smallrye.mutiny.Uni
+import org.hibernate.reactive.mutiny.Mutiny
+
+val sessionFactory: Mutiny.SessionFactory = ...
+val context = JpqlRenderContext()
+
+// Get a list of results
+val selectQuery = jpql {
+    select(
+        entity(Book::class)
+    ).from(
+        entity(Book::class)
+    )
+}
+val books: Uni<List<Book>> = sessionFactory.withSession { session ->
+    session.createQuery(selectQuery, context).resultList
+}
+
+// Execute an update statement
+val updateQuery = jpql {
+    update(
+        entity(Book::class)
+    ).set(
+        path(Book::price), BookPrice(10)
+    ).where(
+        path(Book::isbn).eq(Isbn("01"))
+    )
+}
+val updatedRows: Uni<Int> = sessionFactory.withTransaction { session, _ ->
+    session.createMutationQuery(updateQuery, context).executeUpdate()
+}
+```
+
+#### Stateless Session
+With a `Mutiny.StatelessSession`, the `createQuery` extension function is used for all types of statements (`SELECT`, `UPDATE`, `DELETE`).
+
+```kotlin
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+
+// Execute a delete statement with a stateless session
+val deleteQuery = jpql {
+    deleteFrom(
+        entity(Book::class)
+    ).where(
+        path(Book::isbn).eq(Isbn("01"))
+    )
+}
+val deletedRows: Uni<Int> = sessionFactory.withStatelessTransaction { session, _ ->
+    session.createQuery(deleteQuery, context).executeUpdate()
+}
+```
+
+### Stage
+
+The usage pattern for `Stage.Session` and `Stage.StatelessSession` is similar to Mutiny's.
+
+#### Stateful Session
+```kotlin
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createMutationQuery
+import java.util.concurrent.CompletionStage
+import org.hibernate.reactive.stage.Stage
+
+val sessionFactory: Stage.SessionFactory = ...
+val context = JpqlRenderContext()
+
+// Get a list of results
+val selectQuery = jpql {
+    select(
+        entity(Book::class)
+    ).from(
+        entity(Book::class)
+    )
+}
+val books: CompletionStage<List<Book>> = sessionFactory.withSession { session ->
+    session.createQuery(selectQuery, context).resultList
+}
+
+// Execute a delete statement
+val deleteQuery = jpql {
+    deleteFrom(
+        entity(Book::class)
+    ).where(
+        path(Book::isbn).eq(Isbn("01"))
+    )
+}
+val deletedRows: CompletionStage<Int> = sessionFactory.withTransaction { session, _ ->
+    session.createMutationQuery(deleteQuery, context).executeUpdate()
+}
+```
+
+#### Stateless Session
+```kotlin
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+
+// Execute a delete statement with a stateless session
+val deleteQuery = jpql {
+    deleteFrom(
+        entity(Book::class)
+    ).where(
+        path(Book::isbn).eq(Isbn("01"))
+    )
+}
+val deletedRows: CompletionStage<Int> = sessionFactory.withStatelessTransaction { session, _ ->
+    session.createQuery(deleteQuery, context).executeUpdate()
+}
+```
+
+## A Note on Fetching Strategies and Session Scope
+
+{% hint style="danger" %}
+Accessing lazy-loaded associations outside of an active reactive session will cause a `LazyInitializationException`.
+{% endhint %}
+
+The scope of a reactive session is typically limited to the lambda block of methods like `withSession` or `withTransaction`. Once the reactive stream completes and the block finishes executing, the session is closed.
+
+#### Safe: Accessing Lazy Associations Inside the Session Scope
+You can safely access lazy-loaded associations as long as it's done **inside** the session's scope.
+
+```kotlin
+val query = jpql {
+    select(
+        entity(Book::class)
+    ).from(
+        entity(Book::class)
+    )
+}
+
+val bookAuthorSizes: Uni<List<Int>> = sessionFactory.withSession { session ->
+    session.createQuery(query, context).resultList.onItem().transform { bookList ->
+        // Accessing book.authors here is safe because the session is still active.
+        bookList.map { it.authors.size }
+    }
+}
+```
+
+#### Required: Using `fetch join` for Access Outside the Session Scope
+If you need to access associations **after** the session is closed (e.g., in a subsequent step of your reactive pipeline), you **must** initialize them eagerly using a `fetch join`.
+
+```kotlin
+// Use fetch join to load authors eagerly
+val query = jpql {
+    select(
+        distinct(entity(Book::class))
+    ).from(
+        entity(Book::class),
+        fetchJoin(Book::authors) // Eagerly fetch the authors collection
+    )
+}
+
+val books: Uni<List<Book>> = sessionFactory.withSession { session ->
+    session.createQuery(query, context).resultList
+}
+
+// This is now safe because the authors collection was eagerly fetched.
+books.onItem().invoke { bookList ->
+    bookList.forEach { book ->
+        println(book.authors.size)
+    }
+}
+```

--- a/docs/ko/SUMMARY.md
+++ b/docs/ko/SUMMARY.md
@@ -11,6 +11,7 @@
     * [Subqueries](jpql-with-kotlin-jdsl/subqueries.md)
     * [Custom DSL](jpql-with-kotlin-jdsl/custom-dsl.md)
     * [Spring supports](jpql-with-kotlin-jdsl/spring-supports.md)
+    * [Hibernate Reactive supports](jpql-with-kotlin-jdsl/hibernate-reactive-supports.md)
     * [Migration 2.X to 3.X](jpql-with-kotlin-jdsl/migration-2.x-to-3.x.md)
 * [Kotlin JDSL Roadmap](kotlin-jdsl-roadmap.md)
 

--- a/docs/ko/SUMMARY.md
+++ b/docs/ko/SUMMARY.md
@@ -19,4 +19,5 @@
 * [어떻게 생성된 쿼리를 볼 수 있나요?](faq/how-can-i-see-the-generated-query.md)
 * [Kotlin value class 를 사용하려면 어떻게 해야할까요?](faq/how-do-i-use-kotlin-value-class.md)
 * [Kotlin JDSL과 jOOQ, QueryDSL의 차이점은 무엇인가요?](faq/what-is-the-difference-between-kotlin-jdsl-and-jooq-and-querydsl.md)
+* [동적 쿼리는 어떻게 만드나요?](faq/how-to-build-dynamic-queries.md)
 * [왜 Kotlin JDSL은 Nullable한 반환 타입을 허용하나요?](faq/why-is-there-a-support-module-that-only-has-a-nullable-return-type.md)

--- a/docs/ko/faq/how-to-build-dynamic-queries.md
+++ b/docs/ko/faq/how-to-build-dynamic-queries.md
@@ -1,0 +1,60 @@
+# 동적 쿼리는 어떻게 만드나요?
+
+조건에 따라 `where` 절에 조건자를 추가하여 동적 쿼리를 만들 수 있습니다.
+Kotlin JDSL의 `where` 절은 조건자 목록을 받을 수 있으며, `and()` 및 `or()` 함수가 이럴 때 유용합니다.
+
+일반적인 패턴은 `Predicate`의 가변 목록을 만들고 여기에 조건을 추가한 다음, 이 목록을 `and()`를 사용하여 `where` 절에 전달하는 것입니다.
+
+`and()`에 전달된 조건자 목록이 비어 있으면 `1 = 1`로 처리되어 필터링이 적용되지 않습니다. 이는 모든 조건이 선택 사항일 수 있는 동적 쿼리에 유용합니다.
+
+{% hint style="warning" %}
+동적 쿼리를 작성할 때는 주의가 필요합니다. 만약 아무 조건도 적용되지 않으면, 쿼리는 엔티티의 모든 행을 조회하게 되어 대용량 테이블에서 성능 문제를 일으킬 수 있습니다. 항상 필터가 활성화되지 않는 경우를 고려해야 합니다.
+{% endhint %}
+
+다음은 예시입니다.
+
+```kotlin
+fun findBooks(title: String?, authorName: String?): List<Book> {
+    val query = jpql {
+        select(
+            entity(Book::class)
+        ).from(
+            entity(Book::class)
+        ).where(
+            and(
+                title?.let { path(Book::title).like("%$it%") },
+                authorName?.let { path(Book::author)(Author::name).like("%$it%") },
+            )
+        )
+    }
+    return entityManager.createQuery(query, context).resultList
+}
+```
+
+위 예제에서 `title`이 null이 아니면 `like` 조건자가 생성됩니다. `authorName`도 마찬가지입니다. `and()` 함수는 매개변수가 null일 때 `let` 블록에서 발생하는 `null` 조건자를 필터링합니다. `title`과 `authorName`이 모두 `null`이면 `where` 절은 사실상 비어 있게 되어 모든 책을 반환합니다.
+
+또는 조건자 목록을 만들 수도 있습니다.
+
+```kotlin
+fun findBooks(title: String?, authorName: String?): List<Book> {
+    val query = jpql {
+        select(
+            entity(Book::class)
+        ).from(
+            entity(Book::class)
+        ).whereAnd(
+            mutableListOf<Predicate?>().apply {
+                if (!title.isNullOrBlank()) {
+                    add(path(Book::title).like("%$title%"))
+                }
+                if (!authorName.isNullOrBlank()) {
+                    add(path(Book::author)(Author::name).like("%$authorName%"))
+                }
+            }
+        )
+    }
+    return entityManager.createQuery(query, context).resultList
+}
+```
+
+`whereAnd`는 `where(and(...))`의 축약형입니다. 목록이 비어 있으면 쿼리에 아무런 조건도 추가되지 않습니다.

--- a/docs/ko/jpql-with-kotlin-jdsl/hibernate-reactive-supports.md
+++ b/docs/ko/jpql-with-kotlin-jdsl/hibernate-reactive-supports.md
@@ -1,0 +1,183 @@
+# Hibernate Reactive 지원
+
+Kotlin JDSL은 [Hibernate Reactive](https://hibernate.org/reactive/)를 사용하여 쿼리를 쉽게 실행할 수 있도록 `hibernate-reactive-support` 모듈을 제공합니다.
+
+이 모듈은 Hibernate Reactive의 `Session` 및 `StatelessSession` 객체에 대한 확장 함수를 제공하여, Kotlin JDSL 쿼리 객체를 직접 전달하여 리액티브 쿼리를 생성할 수 있게 해줍니다.
+
+## 쿼리 실행하기
+
+제공되는 주요 확장 함수는 다음과 같습니다:
+- `createQuery()`: `Session`과 `StatelessSession` 모두에서 `SELECT` 구문을 위해 사용됩니다. `StatelessSession`의 경우, `UPDATE`와 `DELETE` 구문에도 사용됩니다.
+- `createMutationQuery()`: 상태를 가지는(stateful) `Session`에서 `UPDATE`와 `DELETE` 구문을 위해 사용됩니다.
+
+이 함수들은 보통 `SessionFactory`로부터 얻는 `Session` 또는 `StatelessSession` 인스턴스에서 사용됩니다.
+
+### Mutiny
+
+#### Stateful Session (상태 기반 세션)
+상태를 가지는 `Mutiny.Session`에서는 `SELECT` 구문에 `createQuery`를, `UPDATE`/`DELETE` 구문에 `createMutationQuery`를 사용합니다.
+
+```kotlin
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createMutationQuery
+import io.smallrye.mutiny.Uni
+import org.hibernate.reactive.mutiny.Mutiny
+
+val sessionFactory: Mutiny.SessionFactory = ...
+val context = JpqlRenderContext()
+
+// 결과 목록 조회
+val selectQuery = jpql {
+    select(
+        entity(Book::class)
+    ).from(
+        entity(Book::class)
+    )
+}
+val books: Uni<List<Book>> = sessionFactory.withSession { session ->
+    session.createQuery(selectQuery, context).resultList
+}
+
+// Update 구문 실행
+val updateQuery = jpql {
+    update(
+        entity(Book::class)
+    ).set(
+        path(Book::price), BookPrice(10)
+    ).where(
+        path(Book::isbn).eq(Isbn("01"))
+    )
+}
+val updatedRows: Uni<Int> = sessionFactory.withTransaction { session, _ ->
+    session.createMutationQuery(updateQuery, context).executeUpdate()
+}
+```
+
+#### Stateless Session (상태 비저장 세션)
+`Mutiny.StatelessSession`에서는 모든 종류의 구문(`SELECT`, `UPDATE`, `DELETE`)에 `createQuery` 확장 함수가 사용됩니다.
+
+```kotlin
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+
+// Stateless 세션으로 delete 구문 실행
+val deleteQuery = jpql {
+    deleteFrom(
+        entity(Book::class)
+    ).where(
+        path(Book::isbn).eq(Isbn("01"))
+    )
+}
+val deletedRows: Uni<Int> = sessionFactory.withStatelessTransaction { session, _ ->
+    session.createQuery(deleteQuery, context).executeUpdate()
+}
+```
+
+### Stage
+
+`Stage.Session`과 `Stage.StatelessSession`의 사용 패턴은 Mutiny와 유사합니다.
+
+#### Stateful Session (상태 기반 세션)
+```kotlin
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createMutationQuery
+import java.util.concurrent.CompletionStage
+import org.hibernate.reactive.stage.Stage
+
+val sessionFactory: Stage.SessionFactory = ...
+val context = JpqlRenderContext()
+
+// 결과 목록 조회
+val selectQuery = jpql {
+    select(
+        entity(Book::class)
+    ).from(
+        entity(Book::class)
+    )
+}
+val books: CompletionStage<List<Book>> = sessionFactory.withSession { session ->
+    session.createQuery(selectQuery, context).resultList
+}
+
+// Delete 구문 실행
+val deleteQuery = jpql {
+    deleteFrom(
+        entity(Book::class)
+    ).where(
+        path(Book::isbn).eq(Isbn("01"))
+    )
+}
+val deletedRows: CompletionStage<Int> = sessionFactory.withTransaction { session, _ ->
+    session.createMutationQuery(deleteQuery, context).executeUpdate()
+}
+```
+
+#### Stateless Session (상태 비저장 세션)
+```kotlin
+import com.linecorp.kotlinjdsl.support.hibernate.reactive.extension.createQuery
+
+// Stateless 세션으로 delete 구문 실행
+val deleteQuery = jpql {
+    deleteFrom(
+        entity(Book::class)
+    ).where(
+        path(Book::isbn).eq(Isbn("01"))
+    )
+}
+val deletedRows: CompletionStage<Int> = sessionFactory.withStatelessTransaction { session, _ ->
+    session.createQuery(deleteQuery, context).executeUpdate()
+}
+```
+
+## Fetch 전략과 세션 범위에 대한 참고사항
+
+{% hint style="danger" %}
+활성화된 리액티브 세션 외부에서 지연 로딩된 연관 관계에 접근하면 `LazyInitializationException`이 발생합니다.
+{% endhint %}
+
+리액티브 세션의 범위는 일반적으로 `withSession`이나 `withTransaction`과 같은 메서드의 람다 블록으로 제한됩니다. 리액티브 스트림이 완료되고 블록 실행이 끝나면 세션은 닫힙니다.
+
+#### 안전한 방법: 세션 범위 내에서 지연 로딩된 연관 관계 접근하기
+세션 범위 **내에서** 접근하는 한, 지연 로딩된 연관 관계를 안전하게 사용할 수 있습니다.
+
+```kotlin
+val query = jpql {
+    select(
+        entity(Book::class)
+    ).from(
+        entity(Book::class)
+    )
+}
+
+val bookAuthorSizes: Uni<List<Int>> = sessionFactory.withSession { session ->
+    session.createQuery(query, context).resultList.onItem().transform { bookList ->
+        // 세션이 아직 활성 상태이므로 여기서 book.authors에 접근하는 것은 안전합니다.
+        bookList.map { it.authors.size }
+    }
+}
+```
+
+#### 필수적인 방법: 세션 범위 밖에서 사용하기 위해 `fetch join` 사용하기
+세션이 닫힌 **후에** (예: 리액티브 파이프라인의 다음 단계에서) 연관 관계에 접근해야 하는 경우, `fetch join`을 사용하여 반드시 즉시 로딩해야 합니다.
+
+```kotlin
+// fetch join을 사용하여 authors를 즉시 로딩합니다.
+val query = jpql {
+    select(
+        distinct(entity(Book::class))
+    ).from(
+        entity(Book::class),
+        fetchJoin(Book::authors) // authors 컬렉션을 즉시 fetch합니다.
+    )
+}
+
+val books: Uni<List<Book>> = sessionFactory.withSession { session ->
+    session.createQuery(query, context).resultList
+}
+
+// authors 컬렉션이 즉시 로딩되었으므로 이제 안전합니다.
+books.onItem().invoke { bookList ->
+    bookList.forEach { book ->
+        println(book.authors.size)
+    }
+}
+```


### PR DESCRIPTION
# Motivation

The documentation was missing a guide for the `hibernate-reactive-support` module. This PR introduces a new document explaining how to use Kotlin JDSL with Hibernate Reactive, including examples for both Mutiny and Stage APIs.

A crucial section on fetching strategies has been added to warn users about potential `LazyInitializationException` issues and guide them on using `fetch join` correctly when accessing associations outside the reactive session scope.

# Modifications

- Added `docs/en/jpql-with-kotlin-jdsl/hibernate-reactive-supports.md`
- Added `docs/ko/jpql-with-kotlin-jdsl/hibernate-reactive-supports.md`
- Updated `docs/en/SUMMARY.md` and `docs/ko/SUMMARY.md` to include the new document.

# Result

After this PR is merged, users will have a comprehensive guide to using Kotlin JDSL in a reactive environment with Hibernate Reactive, improving usability and helping to prevent common pitfalls.