### PR TITLE
docs: add FAQ on how to sort by DTO fields or aliases

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -19,4 +19,5 @@
 * [How can I see the generated query?](faq/how-can-i-see-the-generated-query.md)
 * [How can I use Kotlin value class?](faq/how-do-i-use-kotlin-value-class.md)
 * [What is the difference between Kotlin JDSL and jOOQ and QueryDSL?](faq/what-is-the-difference-between-kotlin-jdsl-and-jooq-and-querydsl.md)
+* [How to sort by DTO fields or aliases?](faq/how-to-sort-by-dto-fields-or-aliases.md)
 * [Why is there a support module that only has a nullable return type](faq/why-is-there-a-support-module-that-only-has-a-nullable-return-type.md)

--- a/docs/en/faq/how-to-sort-by-dto-fields-or-aliases.md
+++ b/docs/en/faq/how-to-sort-by-dto-fields-or-aliases.md
@@ -1,0 +1,39 @@
+# How to sort by DTO fields or aliases?
+
+You can sort the results of a query by a field in a DTO projection or by an alias you have defined in the `select` clause.
+
+To do this, you first need to create an alias for the expression in the `select` clause. Then, you can refer to this alias in the `orderBy` clause.
+
+Here is an example of sorting by an aliased column, which is projected into a DTO:
+
+```kotlin
+data class BookInfo(
+    val name: String,
+    val authorCount: Long
+)
+
+// 1. Define an alias for the expression.
+val authorCountAlias = expression(Long::class, "authorCount")
+
+val query = jpql {
+    selectNew<BookInfo>(
+        path(Book::name),
+        count(Book::authors).`as`(authorCountAlias) // 2. Use the alias in the select clause.
+    ).from(
+        entity(Book::class)
+    ).groupBy(
+        path(Book::name)
+    ).orderBy(
+        authorCountAlias.asc() // 3. Use the alias in the orderBy clause.
+    )
+}
+
+val bookInfos = entityManager.createQuery(query, context).resultList
+```
+
+In this example:
+1.  We create an `Expression` to serve as an alias named `authorCountAlias`.
+2.  In the `selectNew` clause, we use `as(authorCountAlias)` to associate the `count(Book::authors)` expression with our alias.
+3.  In the `orderBy` clause, we can now refer to `authorCountAlias` to sort the results.
+
+This pattern allows you to sort by any computed value or aggregate function that you include in your DTO.

--- a/docs/ko/SUMMARY.md
+++ b/docs/ko/SUMMARY.md
@@ -19,4 +19,5 @@
 * [어떻게 생성된 쿼리를 볼 수 있나요?](faq/how-can-i-see-the-generated-query.md)
 * [Kotlin value class 를 사용하려면 어떻게 해야할까요?](faq/how-do-i-use-kotlin-value-class.md)
 * [Kotlin JDSL과 jOOQ, QueryDSL의 차이점은 무엇인가요?](faq/what-is-the-difference-between-kotlin-jdsl-and-jooq-and-querydsl.md)
+* [DTO 필드나 별칭(alias)으로 정렬하려면 어떻게 하나요?](faq/how-to-sort-by-dto-fields-or-aliases.md)
 * [왜 Kotlin JDSL은 Nullable한 반환 타입을 허용하나요?](faq/why-is-there-a-support-module-that-only-has-a-nullable-return-type.md)

--- a/docs/ko/faq/how-to-sort-by-dto-fields-or-aliases.md
+++ b/docs/ko/faq/how-to-sort-by-dto-fields-or-aliases.md
@@ -1,0 +1,39 @@
+# DTO 필드나 별칭(alias)으로 정렬하려면 어떻게 하나요?
+
+DTO 프로젝션의 필드나 `select` 절에 정의한 별칭으로 쿼리 결과를 정렬할 수 있습니다.
+
+이렇게 하려면 먼저 `select` 절의 표현식에 대한 별칭을 만들어야 합니다. 그런 다음 `orderBy` 절에서 이 별칭을 참조할 수 있습니다.
+
+다음은 DTO로 프로젝션되는 별칭이 지정된 열로 정렬하는 예입니다.
+
+```kotlin
+data class BookInfo(
+    val name: String,
+    val authorCount: Long
+)
+
+// 1. 표현식에 대한 별칭을 정의합니다.
+val authorCountAlias = expression(Long::class, "authorCount")
+
+val query = jpql {
+    selectNew<BookInfo>(
+        path(Book::name),
+        count(Book::authors).`as`(authorCountAlias) // 2. select 절에서 별칭을 사용합니다.
+    ).from(
+        entity(Book::class)
+    ).groupBy(
+        path(Book::name)
+    ).orderBy(
+        authorCountAlias.asc() // 3. orderBy 절에서 별칭을 사용합니다.
+    )
+}
+
+val bookInfos = entityManager.createQuery(query, context).resultList
+```
+
+이 예제에서는 다음을 수행합니다.
+1.  `authorCountAlias`라는 별칭 역할을 할 `Expression`을 만듭니다.
+2.  `selectNew` 절에서 `as(authorCountAlias)`를 사용하여 `count(Book::authors)` 표현식을 별칭과 연결합니다.
+3.  `orderBy` 절에서 `authorCountAlias`를 참조하여 결과를 정렬할 수 있습니다.
+
+이 패턴을 사용하면 DTO에 포함된 계산된 값이나 집계 함수로 정렬할 수 있습니다.


### PR DESCRIPTION
# Motivation

The documentation did not explicitly cover how to sort query results by a computed or aggregated field in a DTO projection. This PR adds a new FAQ page to demonstrate how to use aliases in the `select` clause and refer to them in the `orderBy` clause.

# Modifications

- Added `docs/en/faq/how-to-sort-by-dto-fields-or-aliases.md`
- Added `docs/ko/faq/how-to-sort-by-dto-fields-or-aliases.md`
- Updated `docs/en/SUMMARY.md` and `docs/ko/SUMMARY.md` to include the new FAQ.

# Result

After this PR is merged, users will have a clear example of how to sort by aliased fields, making it easier to handle complex ordering requirements in their queries.