### PR TITLE
docs: add FAQ on how to work with advanced JPA mappings

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -19,4 +19,5 @@
 * [How can I see the generated query?](faq/how-can-i-see-the-generated-query.md)
 * [How can I use Kotlin value class?](faq/how-do-i-use-kotlin-value-class.md)
 * [What is the difference between Kotlin JDSL and jOOQ and QueryDSL?](faq/what-is-the-difference-between-kotlin-jdsl-and-jooq-and-querydsl.md)
+* [How to work with advanced JPA mappings?](faq/how-to-work-with-advanced-jpa-mappings.md)
 * [Why is there a support module that only has a nullable return type](faq/why-is-there-a-support-module-that-only-has-a-nullable-return-type.md)

--- a/docs/en/faq/how-to-work-with-advanced-jpa-mappings.md
+++ b/docs/en/faq/how-to-work-with-advanced-jpa-mappings.md
@@ -1,0 +1,121 @@
+# How to work with advanced JPA mappings?
+
+Kotlin JDSL is designed to work seamlessly with various JPA mapping strategies. Here are some examples of how to query entities with advanced mappings like composite keys, inheritance, and embedded IDs.
+
+## Composite Keys with `@IdClass`
+
+When an entity uses `@IdClass` for a composite primary key, you can query it by referencing the properties of the entity as usual.
+
+Consider the `BookAuthor` entity, which has a composite key consisting of `book` and `authorId`.
+
+```kotlin
+@Entity
+@IdClass(BookAuthor.BookAuthorId::class)
+class BookAuthor(
+    @Id
+    val authorId: Long,
+) {
+    @Id
+    @ManyToOne
+    lateinit var book: Book
+    // ...
+}
+```
+
+You can write a query that joins `BookAuthor` and refers to its properties, including those that are part of the composite key.
+
+```kotlin
+val query = jpql {
+    select(
+        path(Author::authorId),
+    ).from(
+        entity(Author::class),
+        join(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
+    )
+}
+```
+
+## Entity Inheritance
+
+Kotlin JDSL supports querying entities that use JPA inheritance. You can use `treat` to downcast to a specific subtype in your queries.
+
+For example, if `Employee` is a base class with `FullTimeEmployee` as a subclass:
+
+```kotlin
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+class Employee(
+    // ...
+)
+
+@Entity
+class FullTimeEmployee(
+    // ...
+    var annualSalary: EmployeeSalary,
+) : Employee(...)
+```
+
+You can write a query that specifically targets `FullTimeEmployee` and its properties.
+
+```kotlin
+val query = jpql {
+    update(
+        entity(FullTimeEmployee::class),
+    ).set(
+        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value),
+        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value).times(BigDecimal.valueOf(1.1)),
+    ).where(
+        path(FullTimeEmployee::employeeId).`in`(employeeIds),
+    )
+}
+```
+
+You can also use `type()` to filter by entity type in a `where` clause.
+
+```kotlin
+val query = jpql {
+    select(
+        path(Employee::employeeId),
+    ).from(
+        entity(Employee::class),
+    ).where(
+        type(entity(Employee::class)).eq(FullTimeEmployee::class)
+    )
+}
+```
+
+## Embedded IDs and Embeddable Types
+
+You can query entities that use `@EmbeddedId` or contain `@Embedded` objects by chaining path expressions.
+
+If a `Book` has an `@EmbeddedId` of type `Isbn`:
+
+```kotlin
+@Entity
+class Book(
+    @EmbeddedId
+    val isbn: Isbn,
+    // ...
+)
+
+@Embeddable
+data class Isbn(
+    val value: String,
+)
+```
+
+You can access the `value` of the `Isbn` using `path(Book::isbn)(Isbn::value)`.
+
+```kotlin
+val query = jpql {
+    select(
+        path(Book::isbn),
+    ).from(
+        entity(Book::class),
+    ).where(
+        path(Book::isbn)(Isbn::value).eq("01"),
+    )
+}
+```
+
+This approach works for both `@EmbeddedId` and regular `@Embedded` properties.

--- a/docs/ko/SUMMARY.md
+++ b/docs/ko/SUMMARY.md
@@ -19,4 +19,5 @@
 * [어떻게 생성된 쿼리를 볼 수 있나요?](faq/how-can-i-see-the-generated-query.md)
 * [Kotlin value class 를 사용하려면 어떻게 해야할까요?](faq/how-do-i-use-kotlin-value-class.md)
 * [Kotlin JDSL과 jOOQ, QueryDSL의 차이점은 무엇인가요?](faq/what-is-the-difference-between-kotlin-jdsl-and-jooq-and-querydsl.md)
+* [고급 JPA 매핑은 어떻게 처리하나요?](faq/how-to-work-with-advanced-jpa-mappings.md)
 * [왜 Kotlin JDSL은 Nullable한 반환 타입을 허용하나요?](faq/why-is-there-a-support-module-that-only-has-a-nullable-return-type.md)

--- a/docs/ko/faq/how-to-work-with-advanced-jpa-mappings.md
+++ b/docs/ko/faq/how-to-work-with-advanced-jpa-mappings.md
@@ -1,0 +1,121 @@
+# 고급 JPA 매핑은 어떻게 처리하나요?
+
+Kotlin JDSL은 다양한 JPA 매핑 전략과 원활하게 작동하도록 설계되었습니다. 다음은 복합 키, 상속, 임베디드 ID와 같은 고급 매핑이 적용된 엔티티를 쿼리하는 방법에 대한 몇 가지 예입니다.
+
+## `@IdClass`를 사용한 복합 키
+
+엔티티가 복합 기본 키에 `@IdClass`를 사용하는 경우, 평소와 같이 엔티티의 속성을 참조하여 쿼리할 수 있습니다.
+
+`book`과 `authorId`로 구성된 복합 키를 가진 `BookAuthor` 엔티티를 예로 들어 보겠습니다.
+
+```kotlin
+@Entity
+@IdClass(BookAuthor.BookAuthorId::class)
+class BookAuthor(
+    @Id
+    val authorId: Long,
+) {
+    @Id
+    @ManyToOne
+    lateinit var book: Book
+    // ...
+}
+```
+
+`BookAuthor`를 조인하고 복합 키의 일부인 속성을 포함하여 해당 속성을 참조하는 쿼리를 작성할 수 있습니다.
+
+```kotlin
+val query = jpql {
+    select(
+        path(Author::authorId),
+    ).from(
+        entity(Author::class),
+        join(BookAuthor::class).on(path(Author::authorId).equal(path(BookAuthor::authorId))),
+    )
+}
+```
+
+## 엔티티 상속
+
+Kotlin JDSL은 JPA 상속을 사용하는 엔티티 쿼리를 지원합니다. `treat`를 사용하여 쿼리에서 특정 하위 유형으로 다운캐스팅할 수 있습니다.
+
+예를 들어, `Employee`가 `FullTimeEmployee`를 하위 클래스로 갖는 기본 클래스인 경우:
+
+```kotlin
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+class Employee(
+    // ...
+)
+
+@Entity
+class FullTimeEmployee(
+    // ...
+    var annualSalary: EmployeeSalary,
+) : Employee(...)
+```
+
+`FullTimeEmployee`와 해당 속성을 구체적으로 대상으로 하는 쿼리를 작성할 수 있습니다.
+
+```kotlin
+val query = jpql {
+    update(
+        entity(FullTimeEmployee::class),
+    ).set(
+        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value),
+        path(FullTimeEmployee::annualSalary)(EmployeeSalary::value).times(BigDecimal.valueOf(1.1)),
+    ).where(
+        path(FullTimeEmployee::employeeId).`in`(employeeIds),
+    )
+}
+```
+
+`where` 절에서 엔티티 유형으로 필터링하기 위해 `type()`을 사용할 수도 있습니다.
+
+```kotlin
+val query = jpql {
+    select(
+        path(Employee::employeeId),
+    ).from(
+        entity(Employee::class),
+    ).where(
+        type(entity(Employee::class)).eq(FullTimeEmployee::class)
+    )
+}
+```
+
+## 임베디드 ID 및 임베디드 가능 유형
+
+경로 표현식을 연결하여 `@EmbeddedId`를 사용하거나 `@Embedded` 객체를 포함하는 엔티티를 쿼리할 수 있습니다.
+
+`Book`에 `Isbn` 유형의 `@EmbeddedId`가 있는 경우:
+
+```kotlin
+@Entity
+class Book(
+    @EmbeddedId
+    val isbn: Isbn,
+    // ...
+)
+
+@Embeddable
+data class Isbn(
+    val value: String,
+)
+```
+
+`path(Book::isbn)(Isbn::value)`를 사용하여 `Isbn`의 `value`에 액세스할 수 있습니다.
+
+```kotlin
+val query = jpql {
+    select(
+        path(Book::isbn),
+    ).from(
+        entity(Book::class),
+    ).where(
+        path(Book::isbn)(Isbn::value).eq("01"),
+    )
+}
+```
+
+이 접근 방식은 `@EmbeddedId`와 일반 `@Embedded` 속성 모두에 적용됩니다.


### PR DESCRIPTION
# Motivation

The documentation was missing examples for querying entities with advanced JPA mappings such as composite keys (`@IdClass`), inheritance (`@Inheritance`), and embedded IDs (`@EmbeddedId`). This PR adds a new FAQ page based on the existing hibernate examples to cover these scenarios.

# Modifications

- Added `docs/en/faq/how-to-work-with-advanced-jpa-mappings.md`
- Added `docs/ko/faq/how-to-work-with-advanced-jpa-mappings.md`
- Updated `docs/en/SUMMARY.md` and `docs/ko/SUMMARY.md` to include the new FAQ.

# Result

After this PR is merged, users will have a better understanding of how to use Kotlin JDSL with complex entity models, improving their ability to apply the library to real-world projects.