### PR TITLE
fix: specified boot4 dependency module versions

### DIFF
--- a/support/spring-data-jpa-boot4/build.gradle.kts
+++ b/support/spring-data-jpa-boot4/build.gradle.kts
@@ -26,10 +26,10 @@ kotlin {
 
 dependencies {
     // Core Dependencies (from included build)
-    implementation("com.linecorp.kotlin-jdsl:kotlin-jdsl")
-    implementation("com.linecorp.kotlin-jdsl:jpql-dsl")
-    implementation("com.linecorp.kotlin-jdsl:jpql-query-model")
-    implementation("com.linecorp.kotlin-jdsl:jpql-render")
+    implementation("com.linecorp.kotlin-jdsl:kotlin-jdsl:${project.version}")
+    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:${project.version}")
+    implementation("com.linecorp.kotlin-jdsl:jpql-query-model:${project.version}")
+    implementation("com.linecorp.kotlin-jdsl:jpql-render:${project.version}")
 
     // Spring Boot & JPA
     compileOnly(rootLibs.spring.boot4.starter.data.jpa)


### PR DESCRIPTION
# Motivation

Fixed an issue where the `closeSonatypeStagingRepository` task failed during the release process.
The error occurred because dependency version information for `kotlin-jdsl` modules was missing in the generated POM for the
`spring-data-jpa-boot4-support` module. This is required for successful publication to Maven Central.

# Modifications

- Updated `support/spring-data-jpa-boot4/build.gradle.kts` to explicitly specify `${project.version}` for the following
dependencies:
    - `com.linecorp.kotlin-jdsl:kotlin-jdsl`
    - `com.linecorp.kotlin-jdsl:jpql-dsl`
    - `com.linecorp.kotlin-jdsl:jpql-query-model`
    - `com.linecorp.kotlin-jdsl:jpql-render`

Please refer to this screenshot.
<img width="1196" height="230" alt="image" src="https://github.com/user-attachments/assets/8329620e-b7fe-42fd-bdb6-c11fb200839f" />

# Commit Convention Rule

- [x] fix: Fix bug

# Result

The `spring-data-jpa-boot4-support` artifact will now be generated with a valid POM containing correct version numbers for dependencies, resolving the publication failure.

# Closes

- #1008 

--- korean

# Motivation

릴리스 프로세스 중 `closeSonatypeStagingRepository` 태스크가 실패하는 문제를 수정했습니다.
`spring-data-jpa-boot4-support` 모듈의 생성된 POM 파일에서 `kotlin-jdsl` 관련 모듈들의 의존성 버전 정보가 누락되어 Maven
Central 배포가 거부되는 현상이 발생했습니다.

# Modifications

- `support/spring-data-jpa-boot4/build.gradle.kts` 파일을 수정하여 다음 의존성들에 대해 `${project.version}`을 명시적으로
지정했습니다:
    - `com.linecorp.kotlin-jdsl:kotlin-jdsl`
    - `com.linecorp.kotlin-jdsl:jpql-dsl`
    - `com.linecorp.kotlin-jdsl:jpql-query-model`
    - `com.linecorp.kotlin-jdsl:jpql-render`

이 스크린샷을 참고해주세요.
<img width="1196" height="230" alt="image" src="https://github.com/user-attachments/assets/8329620e-b7fe-42fd-bdb6-c11fb200839f" />

# Commit Convention Rule

- [x] fix: Fix bug

# Result

`spring-data-jpa-boot4-support` 아티팩트가 올바른 의존성 버전이 포함된 유효한 POM과 함께 생성되어, 배포 실패 문제가 해결됩니다.

# Closes

- #1008  