### PR TITLE
ci: add support/spring-batch6 to publish workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,7 +37,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v5
+        uses: gradle/actions/wrapper-validation@v6
       - name: Lint Kotlin with Gradle
         run: |
           ./gradlew lintKotlin

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v5
+        uses: gradle/actions/wrapper-validation@v6
       - name: Build with Grade
         run: ./gradlew build
       - name: Publish to the Maven Central Repository

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,6 +31,7 @@ jobs:
         run: |
           ./gradlew --max-workers=1 publish closeAndReleaseStagingRepository
           ./gradlew -p support/spring-data-jpa-boot4 --max-workers=1 publish closeAndReleaseStagingRepository
+          ./gradlew -p support/spring-batch6 --max-workers=1 publish closeAndReleaseStagingRepository
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
           ./gradlew -p example/spring-data-jpa-boot4 test
           ./gradlew -p example/spring-batch6 test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./build/reports/kover/report.xml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v5
+        uses: gradle/actions/wrapper-validation@v6
       - name: CodeCoverage(with test) with Gradle
         run: |
           ./gradlew koverXmlReport

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -26,7 +26,7 @@ spring-batch5-test = { module = "org.springframework.batch:spring-batch-test", v
 spring-batch6-test = { module = "org.springframework.batch:spring-batch-test", version = "6.0.2" }
 
 # hibernate
-hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.2.6.Final" }
+hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.2.7.Final" }
 
 # hibernate-reactive
 hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "4.2.5.Final" }

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -29,7 +29,7 @@ spring-batch6-test = { module = "org.springframework.batch:spring-batch-test", v
 hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.2.6.Final" }
 
 # hibernate-reactive
-hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "4.2.5.Final" }
+hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "4.2.6.Final" }
 
 # eclipse-link
 eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "4.0.9" }

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -35,7 +35,7 @@ hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive
 eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "5.0.0" }
 
 # vertx
-vertx-jdbc-client = { module = "io.vertx:vertx-jdbc-client", version = "5.0.8" }
+vertx-jdbc-client = { module = "io.vertx:vertx-jdbc-client", version = "5.0.9" }
 vertx-jdbc-client4 = { module = "io.vertx:vertx-jdbc-client", version = "4.5.26" }
 agroal-pool = { module = "io.agroal:agroal-pool", version = "3.0.1" }
 

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -37,7 +37,7 @@ eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa",
 # vertx
 vertx-jdbc-client = { module = "io.vertx:vertx-jdbc-client", version = "5.0.8" }
 vertx-jdbc-client4 = { module = "io.vertx:vertx-jdbc-client", version = "4.5.26" }
-agroal-pool = { module = "io.agroal:agroal-pool", version = "3.0" }
+agroal-pool = { module = "io.agroal:agroal-pool", version = "3.0.1" }
 
 h2 = { module = "com.h2database:h2", version = "2.4.240" }
 

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 spring-boot3 = "3.5.13"
-spring-boot4 = "4.0.4"
+spring-boot4 = "4.0.5"
 
 [libraries]
 # log

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -35,7 +35,7 @@ hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive
 eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "5.0.0" }
 
 # vertx
-vertx-jdbc-client = { module = "io.vertx:vertx-jdbc-client", version = "5.0.9" }
+vertx-jdbc-client = { module = "io.vertx:vertx-jdbc-client", version = "5.0.10" }
 vertx-jdbc-client4 = { module = "io.vertx:vertx-jdbc-client", version = "4.5.26" }
 agroal-pool = { module = "io.agroal:agroal-pool", version = "3.0.1" }
 

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -22,7 +22,7 @@ spring-boot4-p6spy = { module = "com.github.gavlyukovskiy:p6spy-spring-boot-star
 spring-boot4-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot4" }
 
 # spring
-spring-batch5-test = { module = "org.springframework.batch:spring-batch-test", version = "5.2.4" }
+spring-batch5-test = { module = "org.springframework.batch:spring-batch-test", version = "5.2.5" }
 spring-batch6-test = { module = "org.springframework.batch:spring-batch-test", version = "6.0.2" }
 
 # hibernate

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -36,7 +36,7 @@ eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa",
 
 # vertx
 vertx-jdbc-client = { module = "io.vertx:vertx-jdbc-client", version = "5.0.8" }
-vertx-jdbc-client4 = { module = "io.vertx:vertx-jdbc-client", version = "4.5.25" }
+vertx-jdbc-client4 = { module = "io.vertx:vertx-jdbc-client", version = "4.5.26" }
 agroal-pool = { module = "io.agroal:agroal-pool", version = "3.0" }
 
 h2 = { module = "com.h2database:h2", version = "2.4.240" }

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 spring-boot3 = "3.5.11"
-spring-boot4 = "4.0.3"
+spring-boot4 = "4.0.4"
 
 [libraries]
 # log

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-spring-boot3 = "3.5.12"
+spring-boot3 = "3.5.13"
 spring-boot4 = "4.0.4"
 
 [libraries]

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -26,7 +26,7 @@ spring-batch5-test = { module = "org.springframework.batch:spring-batch-test", v
 spring-batch6-test = { module = "org.springframework.batch:spring-batch-test", version = "6.0.2" }
 
 # hibernate
-hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.2.5.Final" }
+hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.2.6.Final" }
 
 # hibernate-reactive
 hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "4.2.4.Final" }

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-spring-boot3 = "3.5.11"
+spring-boot3 = "3.5.12"
 spring-boot4 = "4.0.4"
 
 [libraries]

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -32,7 +32,7 @@ hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.3.0.Fi
 hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "4.3.0.Final" }
 
 # eclipse-link
-eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "4.0.9" }
+eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "5.0.0" }
 
 # vertx
 vertx-jdbc-client = { module = "io.vertx:vertx-jdbc-client", version = "5.0.8" }

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -29,7 +29,7 @@ spring-batch6-test = { module = "org.springframework.batch:spring-batch-test", v
 hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.3.0.Final" }
 
 # hibernate-reactive
-hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "4.2.6.Final" }
+hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "4.3.0.Final" }
 
 # eclipse-link
 eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "4.0.9" }

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -23,7 +23,7 @@ spring-boot4-test = { module = "org.springframework.boot:spring-boot-starter-tes
 
 # spring
 spring-batch5-test = { module = "org.springframework.batch:spring-batch-test", version = "5.2.5" }
-spring-batch6-test = { module = "org.springframework.batch:spring-batch-test", version = "6.0.2" }
+spring-batch6-test = { module = "org.springframework.batch:spring-batch-test", version = "6.0.3" }
 
 # hibernate
 hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.3.0.Final" }

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -26,7 +26,7 @@ spring-batch5-test = { module = "org.springframework.batch:spring-batch-test", v
 spring-batch6-test = { module = "org.springframework.batch:spring-batch-test", version = "6.0.2" }
 
 # hibernate
-hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.2.7.Final" }
+hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.3.0.Final" }
 
 # hibernate-reactive
 hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "4.2.6.Final" }

--- a/libs.example.versions.toml
+++ b/libs.example.versions.toml
@@ -29,7 +29,7 @@ spring-batch6-test = { module = "org.springframework.batch:spring-batch-test", v
 hibernate7-core = { module = "org.hibernate:hibernate-core", version = "7.2.6.Final" }
 
 # hibernate-reactive
-hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "4.2.4.Final" }
+hibernate-reactive4-core = { module = "org.hibernate.reactive:hibernate-reactive-core", version = "4.2.5.Final" }
 
 # eclipse-link
 eclipselink4 = { module = "org.eclipse.persistence:org.eclipse.persistence.jpa", version = "4.0.9" }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "jdsl-commitlint-node-package",
   "devDependencies": {
       "@commitlint/cli": "20.4.4",
-      "@commitlint/config-conventional": "20.4.4"
+      "@commitlint/config-conventional": "20.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jdsl-commitlint-node-package",
   "devDependencies": {
-      "@commitlint/cli": "20.4.3",
+      "@commitlint/cli": "20.4.4",
       "@commitlint/config-conventional": "20.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "jdsl-commitlint-node-package",
   "devDependencies": {
       "@commitlint/cli": "20.4.3",
-      "@commitlint/config-conventional": "20.4.2"
+      "@commitlint/config-conventional": "20.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jdsl-commitlint-node-package",
   "devDependencies": {
-      "@commitlint/cli": "20.4.2",
+      "@commitlint/cli": "20.4.3",
       "@commitlint/config-conventional": "20.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "jdsl-commitlint-node-package",
   "devDependencies": {
       "@commitlint/cli": "20.4.4",
-      "@commitlint/config-conventional": "20.4.3"
+      "@commitlint/config-conventional": "20.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jdsl-commitlint-node-package",
   "devDependencies": {
-      "@commitlint/cli": "20.4.4",
+      "@commitlint/cli": "20.5.0",
       "@commitlint/config-conventional": "20.5.0"
   }
 }


### PR DESCRIPTION
# Motivation

- The `support/spring-batch6` module was missing from the Maven Central publish workflow. This change ensures that the module is correctly published.

# Modifications

- Added the publish command for `support/spring-batch6` to `.github/workflows/publish.yaml`.

# Commit Convention Rule

- ci: Change CI configuration

# Result

- `support/spring-batch6` module will be published to Maven Central on release or push to develop.

# Closes

- None