### PR TITLE
ci: add support/spring-batch6 to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,6 +31,7 @@ jobs:
         run: |
           ./gradlew --max-workers=1 publish closeAndReleaseStagingRepository
           ./gradlew -p support/spring-data-jpa-boot4 --max-workers=1 publish closeAndReleaseStagingRepository
+          ./gradlew -p support/spring-batch6 --max-workers=1 publish closeAndReleaseStagingRepository
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION
# Motivation

- The `support/spring-batch6` module was missing from the Maven Central publish workflow. This change ensures that the module is correctly published.

# Modifications

- Added the publish command for `support/spring-batch6` to `.github/workflows/publish.yaml`.

# Commit Convention Rule

- ci: Change CI configuration

# Result

- `support/spring-batch6` module will be published to Maven Central on release.

# Closes

- None