### PR TITLE
feat: add findPage overload with custom count query

### DIFF
--- a/example/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/Issue1074Test.kt
+++ b/example/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/Issue1074Test.kt
@@ -1,0 +1,177 @@
+package com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.select
+
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.repository.book.BookRepository
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+class Issue1074Test : WithAssertions {
+    @Autowired
+    private lateinit var bookRepository: BookRepository
+
+    @Test
+    fun `findPage with explicit count query returns distinct totalElements for joined query with groupBy`() {
+        // given
+        val pageable = PageRequest.of(0, 10)
+
+        // when - main query joins authors and groups by ISBN (12 groups),
+        //        count query uses countDistinct to return the true group count.
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(path(Book::isbn))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    ).groupBy(path(Book::isbn))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    )
+            },
+        )
+
+        // then - 12 distinct books (auto count would return 15 joined rows)
+        assertThat(actual.totalElements).isEqualTo(12L)
+        assertThat(actual.content).hasSize(10)
+    }
+
+    @Test
+    fun `findPage with explicit count query honors where clause`() {
+        // given
+        val pageable = PageRequest.of(0, 10)
+
+        // when - filter to ISBNs 01..03 in both main and count query
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(path(Book::isbn))
+                    .from(entity(Book::class))
+                    .where(path(Book::isbn).`in`(Isbn("01"), Isbn("02"), Isbn("03")))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(entity(Book::class))
+                    .where(path(Book::isbn).`in`(Isbn("01"), Isbn("02"), Isbn("03")))
+            },
+        )
+
+        // then
+        assertThat(actual.totalElements).isEqualTo(3L)
+        assertThat(actual.content).hasSize(3)
+    }
+
+    @Test
+    fun `findPage with count query that uses groupBy falls back to row count`() {
+        // given
+        val pageable = PageRequest.of(0, 10)
+
+        // when - count query itself has groupBy -> resultList.size > 1,
+        //        impl should fall back to counts.count().toLong().
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(entity(Book::class))
+                    .from(entity(Book::class))
+            },
+            {
+                select(count(Book::isbn))
+                    .from(entity(Book::class))
+                    .groupBy(path(Book::isbn))
+            },
+        )
+
+        // then - 12 distinct ISBNs -> groupBy returns 12 rows -> counts.count() = 12
+        assertThat(actual.totalElements).isEqualTo(12L)
+        assertThat(actual.content).hasSize(10)
+    }
+
+    @Test
+    fun `findPage skips count query when content fits within page`() {
+        // Spring's PageableExecutionUtils skips the count supplier when
+        // pageable is on page 0 and content.size < pageSize.
+        // Prove the supplier isn't invoked by giving a count query that
+        // would return 0 (wrong total). If it ran, totalElements would
+        // be 0; instead Spring derives totalElements from content.size.
+        val pageable = PageRequest.of(0, 100)
+
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(path(Book::isbn))
+                    .from(entity(Book::class))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(entity(Book::class))
+                    .where(path(Book::isbn).eq(Isbn("99"))) // matches nothing
+            },
+        )
+
+        // content.size = 12, pageSize = 100 -> count query is NOT executed.
+        // totalElements = pageable.offset (0) + content.size (12) = 12.
+        assertThat(actual.totalElements).isEqualTo(12L)
+        assertThat(actual.content).hasSize(12)
+    }
+
+    @Test
+    fun `findPage with explicit count query paginates across pages`() {
+        // given
+        val firstPageable = PageRequest.of(0, 5)
+        val secondPageable = PageRequest.of(1, 5)
+
+        // when
+        val firstPage = bookRepository.findPage(
+            firstPageable,
+            {
+                select(path(Book::isbn))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    ).groupBy(path(Book::isbn))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    )
+            },
+        )
+        val secondPage = bookRepository.findPage(
+            secondPageable,
+            {
+                select(path(Book::isbn))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    ).groupBy(path(Book::isbn))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    )
+            },
+        )
+
+        // then - 12 total, 5 + 5 split across pages
+        assertThat(firstPage.totalElements).isEqualTo(12L)
+        assertThat(firstPage.content).hasSize(5)
+
+        assertThat(secondPage.totalElements).isEqualTo(12L)
+        assertThat(secondPage.content).hasSize(5)
+        assertThat(secondPage.content).isNotEqualTo(firstPage.content)
+    }
+}

--- a/example/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/Issue1074Test.kt
+++ b/example/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/Issue1074Test.kt
@@ -23,23 +23,24 @@ class Issue1074Test : WithAssertions {
 
         // when - main query joins authors and groups by ISBN (12 groups),
         //        count query uses countDistinct to return the true group count.
-        val actual = bookRepository.findPage(
-            pageable,
-            {
-                select(path(Book::isbn))
-                    .from(
-                        entity(Book::class),
-                        innerJoin(Book::authors),
-                    ).groupBy(path(Book::isbn))
-            },
-            {
-                select(countDistinct(path(Book::isbn)))
-                    .from(
-                        entity(Book::class),
-                        innerJoin(Book::authors),
-                    )
-            },
-        )
+        val actual =
+            bookRepository.findPage(
+                pageable,
+                {
+                    select(path(Book::isbn))
+                        .from(
+                            entity(Book::class),
+                            innerJoin(Book::authors),
+                        ).groupBy(path(Book::isbn))
+                },
+                {
+                    select(countDistinct(path(Book::isbn)))
+                        .from(
+                            entity(Book::class),
+                            innerJoin(Book::authors),
+                        )
+                },
+            )
 
         // then - 12 distinct books (auto count would return 15 joined rows)
         assertThat(actual.totalElements).isEqualTo(12L)
@@ -52,19 +53,20 @@ class Issue1074Test : WithAssertions {
         val pageable = PageRequest.of(0, 10)
 
         // when - filter to ISBNs 01..03 in both main and count query
-        val actual = bookRepository.findPage(
-            pageable,
-            {
-                select(path(Book::isbn))
-                    .from(entity(Book::class))
-                    .where(path(Book::isbn).`in`(Isbn("01"), Isbn("02"), Isbn("03")))
-            },
-            {
-                select(countDistinct(path(Book::isbn)))
-                    .from(entity(Book::class))
-                    .where(path(Book::isbn).`in`(Isbn("01"), Isbn("02"), Isbn("03")))
-            },
-        )
+        val actual =
+            bookRepository.findPage(
+                pageable,
+                {
+                    select(path(Book::isbn))
+                        .from(entity(Book::class))
+                        .where(path(Book::isbn).`in`(Isbn("01"), Isbn("02"), Isbn("03")))
+                },
+                {
+                    select(countDistinct(path(Book::isbn)))
+                        .from(entity(Book::class))
+                        .where(path(Book::isbn).`in`(Isbn("01"), Isbn("02"), Isbn("03")))
+                },
+            )
 
         // then
         assertThat(actual.totalElements).isEqualTo(3L)
@@ -78,18 +80,19 @@ class Issue1074Test : WithAssertions {
 
         // when - count query itself has groupBy -> resultList.size > 1,
         //        impl should fall back to counts.count().toLong().
-        val actual = bookRepository.findPage(
-            pageable,
-            {
-                select(entity(Book::class))
-                    .from(entity(Book::class))
-            },
-            {
-                select(count(Book::isbn))
-                    .from(entity(Book::class))
-                    .groupBy(path(Book::isbn))
-            },
-        )
+        val actual =
+            bookRepository.findPage(
+                pageable,
+                {
+                    select(entity(Book::class))
+                        .from(entity(Book::class))
+                },
+                {
+                    select(count(Book::isbn))
+                        .from(entity(Book::class))
+                        .groupBy(path(Book::isbn))
+                },
+            )
 
         // then - 12 distinct ISBNs -> groupBy returns 12 rows -> counts.count() = 12
         assertThat(actual.totalElements).isEqualTo(12L)
@@ -105,18 +108,19 @@ class Issue1074Test : WithAssertions {
         // be 0; instead Spring derives totalElements from content.size.
         val pageable = PageRequest.of(0, 100)
 
-        val actual = bookRepository.findPage(
-            pageable,
-            {
-                select(path(Book::isbn))
-                    .from(entity(Book::class))
-            },
-            {
-                select(countDistinct(path(Book::isbn)))
-                    .from(entity(Book::class))
-                    .where(path(Book::isbn).eq(Isbn("99"))) // matches nothing
-            },
-        )
+        val actual =
+            bookRepository.findPage(
+                pageable,
+                {
+                    select(path(Book::isbn))
+                        .from(entity(Book::class))
+                },
+                {
+                    select(countDistinct(path(Book::isbn)))
+                        .from(entity(Book::class))
+                        .where(path(Book::isbn).eq(Isbn("99"))) // matches nothing
+                },
+            )
 
         // content.size = 12, pageSize = 100 -> count query is NOT executed.
         // totalElements = pageable.offset (0) + content.size (12) = 12.
@@ -131,40 +135,42 @@ class Issue1074Test : WithAssertions {
         val secondPageable = PageRequest.of(1, 5)
 
         // when
-        val firstPage = bookRepository.findPage(
-            firstPageable,
-            {
-                select(path(Book::isbn))
-                    .from(
-                        entity(Book::class),
-                        innerJoin(Book::authors),
-                    ).groupBy(path(Book::isbn))
-            },
-            {
-                select(countDistinct(path(Book::isbn)))
-                    .from(
-                        entity(Book::class),
-                        innerJoin(Book::authors),
-                    )
-            },
-        )
-        val secondPage = bookRepository.findPage(
-            secondPageable,
-            {
-                select(path(Book::isbn))
-                    .from(
-                        entity(Book::class),
-                        innerJoin(Book::authors),
-                    ).groupBy(path(Book::isbn))
-            },
-            {
-                select(countDistinct(path(Book::isbn)))
-                    .from(
-                        entity(Book::class),
-                        innerJoin(Book::authors),
-                    )
-            },
-        )
+        val firstPage =
+            bookRepository.findPage(
+                firstPageable,
+                {
+                    select(path(Book::isbn))
+                        .from(
+                            entity(Book::class),
+                            innerJoin(Book::authors),
+                        ).groupBy(path(Book::isbn))
+                },
+                {
+                    select(countDistinct(path(Book::isbn)))
+                        .from(
+                            entity(Book::class),
+                            innerJoin(Book::authors),
+                        )
+                },
+            )
+        val secondPage =
+            bookRepository.findPage(
+                secondPageable,
+                {
+                    select(path(Book::isbn))
+                        .from(
+                            entity(Book::class),
+                            innerJoin(Book::authors),
+                        ).groupBy(path(Book::isbn))
+                },
+                {
+                    select(countDistinct(path(Book::isbn)))
+                        .from(
+                            entity(Book::class),
+                            innerJoin(Book::authors),
+                        )
+                },
+            )
 
         // then - 12 total, 5 + 5 split across pages
         assertThat(firstPage.totalElements).isEqualTo(12L)

--- a/example/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/javax/jpql/select/Issue1074Test.kt
+++ b/example/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/javax/jpql/select/Issue1074Test.kt
@@ -1,0 +1,177 @@
+package com.linecorp.kotlinjdsl.example.spring.data.jpa.javax.jpql.select
+
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.javax.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.javax.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.javax.jpql.repository.book.BookRepository
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+class Issue1074Test : WithAssertions {
+    @Autowired
+    private lateinit var bookRepository: BookRepository
+
+    @Test
+    fun `findPage with explicit count query returns distinct totalElements for joined query with groupBy`() {
+        // given
+        val pageable = PageRequest.of(0, 10)
+
+        // when - main query joins authors and groups by ISBN (12 groups),
+        //        count query uses countDistinct to return the true group count.
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(path(Book::isbn))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    ).groupBy(path(Book::isbn))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    )
+            },
+        )
+
+        // then - 12 distinct books (auto count would return 15 joined rows)
+        assertThat(actual.totalElements).isEqualTo(12L)
+        assertThat(actual.content).hasSize(10)
+    }
+
+    @Test
+    fun `findPage with explicit count query honors where clause`() {
+        // given
+        val pageable = PageRequest.of(0, 10)
+
+        // when - filter to ISBNs 01..03 in both main and count query
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(path(Book::isbn))
+                    .from(entity(Book::class))
+                    .where(path(Book::isbn).`in`(Isbn("01"), Isbn("02"), Isbn("03")))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(entity(Book::class))
+                    .where(path(Book::isbn).`in`(Isbn("01"), Isbn("02"), Isbn("03")))
+            },
+        )
+
+        // then
+        assertThat(actual.totalElements).isEqualTo(3L)
+        assertThat(actual.content).hasSize(3)
+    }
+
+    @Test
+    fun `findPage with count query that uses groupBy falls back to row count`() {
+        // given
+        val pageable = PageRequest.of(0, 10)
+
+        // when - count query itself has groupBy -> resultList.size > 1,
+        //        impl should fall back to counts.count().toLong().
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(entity(Book::class))
+                    .from(entity(Book::class))
+            },
+            {
+                select(count(Book::isbn))
+                    .from(entity(Book::class))
+                    .groupBy(path(Book::isbn))
+            },
+        )
+
+        // then - 12 distinct ISBNs -> groupBy returns 12 rows -> counts.count() = 12
+        assertThat(actual.totalElements).isEqualTo(12L)
+        assertThat(actual.content).hasSize(10)
+    }
+
+    @Test
+    fun `findPage skips count query when content fits within page`() {
+        // Spring's PageableExecutionUtils skips the count supplier when
+        // pageable is on page 0 and content.size < pageSize.
+        // Prove the supplier isn't invoked by giving a count query that
+        // would return 0 (wrong total). If it ran, totalElements would
+        // be 0; instead Spring derives totalElements from content.size.
+        val pageable = PageRequest.of(0, 100)
+
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(path(Book::isbn))
+                    .from(entity(Book::class))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(entity(Book::class))
+                    .where(path(Book::isbn).eq(Isbn("99"))) // matches nothing
+            },
+        )
+
+        // content.size = 12, pageSize = 100 -> count query is NOT executed.
+        // totalElements = pageable.offset (0) + content.size (12) = 12.
+        assertThat(actual.totalElements).isEqualTo(12L)
+        assertThat(actual.content).hasSize(12)
+    }
+
+    @Test
+    fun `findPage with explicit count query paginates across pages`() {
+        // given
+        val firstPageable = PageRequest.of(0, 5)
+        val secondPageable = PageRequest.of(1, 5)
+
+        // when
+        val firstPage = bookRepository.findPage(
+            firstPageable,
+            {
+                select(path(Book::isbn))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    ).groupBy(path(Book::isbn))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    )
+            },
+        )
+        val secondPage = bookRepository.findPage(
+            secondPageable,
+            {
+                select(path(Book::isbn))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    ).groupBy(path(Book::isbn))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    )
+            },
+        )
+
+        // then - 12 total, 5 + 5 split across pages
+        assertThat(firstPage.totalElements).isEqualTo(12L)
+        assertThat(firstPage.content).hasSize(5)
+
+        assertThat(secondPage.totalElements).isEqualTo(12L)
+        assertThat(secondPage.content).hasSize(5)
+        assertThat(secondPage.content).isNotEqualTo(firstPage.content)
+    }
+}

--- a/example/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/Issue1074Test.kt
+++ b/example/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/example/spring/data/jpa/jpql/select/Issue1074Test.kt
@@ -1,0 +1,177 @@
+package com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.select
+
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Isbn
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.repository.book.BookRepository
+import org.assertj.core.api.WithAssertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+class Issue1074Test : WithAssertions {
+    @Autowired
+    private lateinit var bookRepository: BookRepository
+
+    @Test
+    fun `findPage with explicit count query returns distinct totalElements for joined query with groupBy`() {
+        // given
+        val pageable = PageRequest.of(0, 10)
+
+        // when - main query joins authors and groups by ISBN (12 groups),
+        //        count query uses countDistinct to return the true group count.
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(path(Book::isbn))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    ).groupBy(path(Book::isbn))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    )
+            },
+        )
+
+        // then - 12 distinct books (auto count would return 15 joined rows)
+        assertThat(actual.totalElements).isEqualTo(12L)
+        assertThat(actual.content).hasSize(10)
+    }
+
+    @Test
+    fun `findPage with explicit count query honors where clause`() {
+        // given
+        val pageable = PageRequest.of(0, 10)
+
+        // when - filter to ISBNs 01..03 in both main and count query
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(path(Book::isbn))
+                    .from(entity(Book::class))
+                    .where(path(Book::isbn).`in`(Isbn("01"), Isbn("02"), Isbn("03")))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(entity(Book::class))
+                    .where(path(Book::isbn).`in`(Isbn("01"), Isbn("02"), Isbn("03")))
+            },
+        )
+
+        // then
+        assertThat(actual.totalElements).isEqualTo(3L)
+        assertThat(actual.content).hasSize(3)
+    }
+
+    @Test
+    fun `findPage with count query that uses groupBy falls back to row count`() {
+        // given
+        val pageable = PageRequest.of(0, 10)
+
+        // when - count query itself has groupBy -> resultList.size > 1,
+        //        impl should fall back to counts.count().toLong().
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(entity(Book::class))
+                    .from(entity(Book::class))
+            },
+            {
+                select(count(Book::isbn))
+                    .from(entity(Book::class))
+                    .groupBy(path(Book::isbn))
+            },
+        )
+
+        // then - 12 distinct ISBNs -> groupBy returns 12 rows -> counts.count() = 12
+        assertThat(actual.totalElements).isEqualTo(12L)
+        assertThat(actual.content).hasSize(10)
+    }
+
+    @Test
+    fun `findPage skips count query when content fits within page`() {
+        // Spring's PageableExecutionUtils skips the count supplier when
+        // pageable is on page 0 and content.size < pageSize.
+        // Prove the supplier isn't invoked by giving a count query that
+        // would return 0 (wrong total). If it ran, totalElements would
+        // be 0; instead Spring derives totalElements from content.size.
+        val pageable = PageRequest.of(0, 100)
+
+        val actual = bookRepository.findPage(
+            pageable,
+            {
+                select(path(Book::isbn))
+                    .from(entity(Book::class))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(entity(Book::class))
+                    .where(path(Book::isbn).eq(Isbn("99"))) // matches nothing
+            },
+        )
+
+        // content.size = 12, pageSize = 100 -> count query is NOT executed.
+        // totalElements = pageable.offset (0) + content.size (12) = 12.
+        assertThat(actual.totalElements).isEqualTo(12L)
+        assertThat(actual.content).hasSize(12)
+    }
+
+    @Test
+    fun `findPage with explicit count query paginates across pages`() {
+        // given
+        val firstPageable = PageRequest.of(0, 5)
+        val secondPageable = PageRequest.of(1, 5)
+
+        // when
+        val firstPage = bookRepository.findPage(
+            firstPageable,
+            {
+                select(path(Book::isbn))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    ).groupBy(path(Book::isbn))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    )
+            },
+        )
+        val secondPage = bookRepository.findPage(
+            secondPageable,
+            {
+                select(path(Book::isbn))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    ).groupBy(path(Book::isbn))
+            },
+            {
+                select(countDistinct(path(Book::isbn)))
+                    .from(
+                        entity(Book::class),
+                        innerJoin(Book::authors),
+                    )
+            },
+        )
+
+        // then - 12 total, 5 + 5 split across pages
+        assertThat(firstPage.totalElements).isEqualTo(12L)
+        assertThat(firstPage.content).hasSize(5)
+
+        assertThat(secondPage.totalElements).isEqualTo(12L)
+        assertThat(secondPage.content).hasSize(5)
+        assertThat(secondPage.content).isNotEqualTo(firstPage.content)
+    }
+}

--- a/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -39,6 +39,16 @@ internal object JpqlEntityManagerUtils {
         return createQuery(entityManager, rendered.query, rendered.params, returnType.java)
     }
 
+    fun createCountQuery(
+        entityManager: EntityManager,
+        query: JpqlQuery<*>,
+        context: RenderContext,
+    ): TypedQuery<Long> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(entityManager, rendered.query, rendered.params, Long::class.javaObjectType)
+    }
+
     fun createQuery(
         entityManager: EntityManager,
         query: JpqlQuery<*>,

--- a/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -39,6 +39,19 @@ internal object JpqlEntityManagerUtils {
         return createQuery(entityManager, rendered.query, rendered.params, returnType.java)
     }
 
+    /**
+     * Creates a [TypedQuery] for a count query with boxed [java.lang.Long] as the return type.
+     *
+     * This is separated from the general [createQuery] to work around a Hibernate 5 strictness issue:
+     * the primitive `long` vs. boxed `java.lang.Long` mismatch is rejected with
+     * `Type specified for TypedQuery [long] is incompatible with query return type [class java.lang.Long]`.
+     *
+     * Hibernate 6 is lenient about this mismatch today, but the same latent issue remains.
+     * Applied consistently across all three support modules (spring-data-jpa, spring-data-jpa-javax,
+     * spring-data-jpa-boot4) to remain safe when future Hibernate versions tighten type inference.
+     *
+     * This matches the convention already used by the auto-count path in `createEnhancedQuery`.
+     */
     fun createCountQuery(
         entityManager: EntityManager,
         query: JpqlQuery<*>,

--- a/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
@@ -107,6 +107,38 @@ interface KotlinJdslJpqlExecutor {
     ): Page<T>
 
     /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.8.2")
+    fun <T : Any> findPage(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: Jpql.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T>
+
+    /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.8.2")
+    fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T>
+
+    /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.8.2")
+    fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T>
+
+    /**
      * Returns the slice of the select query.
      */
     @SinceJdsl("3.0.0")

--- a/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -106,6 +106,35 @@ open class KotlinJdslJpqlExecutorImpl(
         return createPage(query, query.returnType, pageable)
     }
 
+    override fun <T : Any> findPage(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: Jpql.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T> {
+        return findPage(Jpql, pageable, init, countInit)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T> {
+        return findPage(dsl.newInstance(), pageable, init, countInit)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+        val countQuery: SelectQuery<Long> = jpql(dsl, countInit)
+
+        return createPage(query, query.returnType, countQuery, pageable)
+    }
+
     override fun <T : Any> findSlice(
         pageable: Pageable,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
@@ -325,6 +354,36 @@ open class KotlinJdslJpqlExecutorImpl(
 
             if (counts.size == 1) {
                 counts.first() as Long
+            } else {
+                counts.count().toLong()
+            }
+        }
+    }
+
+    private fun <T : Any> createPage(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        countQuery: JpqlQuery<*>,
+        pageable: Pageable,
+    ): Page<T> {
+        val enhancedQuery = createJpaEnhancedQuery(query, returnType, pageable.sort)
+
+        val sortedQuery = enhancedQuery.sortedQuery
+
+        if (pageable.isPaged) {
+            sortedQuery.firstResult = pageable.offset.toInt()
+            sortedQuery.maxResults = pageable.pageSize
+        }
+
+        val countJpaQuery = JpqlEntityManagerUtils
+            .createCountQuery(entityManager, countQuery, renderContext)
+            .apply { setMetadataForCount(this, metadata) }
+
+        return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
+            val counts = countJpaQuery.resultList
+
+            if (counts.size == 1) {
+                counts.first()
             } else {
                 counts.count().toLong()
             }

--- a/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -255,6 +255,11 @@ open class KotlinJdslJpqlExecutorImpl(
             setMetadata(this, metadata)
         }
 
+    private fun createJpaCountQuery(countQuery: JpqlQuery<*>): TypedQuery<Long> =
+        JpqlEntityManagerUtils
+            .createCountQuery(entityManager, countQuery, renderContext)
+            .apply { setMetadataForCount(this, metadata) }
+
     private fun <T : Any> createJpaEnhancedQuery(
         query: JpqlQuery<*>,
         returnType: KClass<T>,
@@ -371,10 +376,7 @@ open class KotlinJdslJpqlExecutorImpl(
             sortedQuery.maxResults = pageable.pageSize
         }
 
-        val countJpaQuery =
-            JpqlEntityManagerUtils
-                .createCountQuery(entityManager, countQuery, renderContext)
-                .apply { setMetadataForCount(this, metadata) }
+        val countJpaQuery = createJpaCountQuery(countQuery)
 
         return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
             val counts = countJpaQuery.resultList

--- a/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -110,18 +110,14 @@ open class KotlinJdslJpqlExecutorImpl(
         pageable: Pageable,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
         countInit: Jpql.() -> JpqlQueryable<SelectQuery<Long>>,
-    ): Page<T> {
-        return findPage(Jpql, pageable, init, countInit)
-    }
+    ): Page<T> = findPage(Jpql, pageable, init, countInit)
 
     override fun <T : Any, DSL : JpqlDsl> findPage(
         dsl: JpqlDsl.Constructor<DSL>,
         pageable: Pageable,
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
         countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
-    ): Page<T> {
-        return findPage(dsl.newInstance(), pageable, init, countInit)
-    }
+    ): Page<T> = findPage(dsl.newInstance(), pageable, init, countInit)
 
     override fun <T : Any, DSL : JpqlDsl> findPage(
         dsl: DSL,
@@ -375,9 +371,10 @@ open class KotlinJdslJpqlExecutorImpl(
             sortedQuery.maxResults = pageable.pageSize
         }
 
-        val countJpaQuery = JpqlEntityManagerUtils
-            .createCountQuery(entityManager, countQuery, renderContext)
-            .apply { setMetadataForCount(this, metadata) }
+        val countJpaQuery =
+            JpqlEntityManagerUtils
+                .createCountQuery(entityManager, countQuery, renderContext)
+                .apply { setMetadataForCount(this, metadata) }
 
         return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
             val counts = countJpaQuery.resultList

--- a/support/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtilsTest.kt
@@ -218,6 +218,35 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
+    fun `createCountQuery() uses boxed Long java type`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any<JpqlQuery<*>>(), any()) } returns rendered1
+        every { entityManager.createQuery(any<String>(), any<Class<Long>>()) } returns longTypedQuery1
+        every { longTypedQuery1.parameters } returns setOf(longTypedQueryParam1, longTypedQueryParam2)
+        every { longTypedQuery1.setParameter(any<String>(), any()) } returns longTypedQuery1
+        every { longTypedQueryParam1.name } returns renderedParam1.first
+        every { longTypedQueryParam2.name } returns renderedParam2.first
+
+        // when
+        val actual = JpqlEntityManagerUtils.createCountQuery(entityManager, query1, context)
+
+        // then
+        assertThat(actual).isEqualTo(longTypedQuery1)
+
+        verifySequence {
+            renderer.render(query1, context)
+            entityManager.createQuery(rendered1.query, Long::class.javaObjectType)
+            longTypedQuery1.parameters
+            longTypedQueryParam1.name
+            longTypedQueryParam2.name
+            longTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
+            longTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
     fun `createEnhancedQuery() with JpqlSelectQuery`() {
         // given
         val selectQuery1: JpqlSelectQuery<Any> = mockk()

--- a/support/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImplTest.kt
+++ b/support/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImplTest.kt
@@ -78,6 +78,15 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     private lateinit var createDeleteQuery3: MyJpqlObject.() -> JpqlQueryable<DeleteQuery<String>>
 
     @MockK
+    private lateinit var createCountSelectQuery1: Jpql.() -> JpqlQueryable<SelectQuery<Long>>
+
+    @MockK
+    private lateinit var createCountSelectQuery2: MyJpql.() -> JpqlQueryable<SelectQuery<Long>>
+
+    @MockK
+    private lateinit var createCountSelectQuery3: MyJpqlObject.() -> JpqlQueryable<SelectQuery<Long>>
+
+    @MockK
     private lateinit var selectQuery1: SelectQuery<String>
 
     @MockK
@@ -103,6 +112,15 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
 
     @MockK
     private lateinit var deleteQuery3: DeleteQuery<String>
+
+    @MockK
+    private lateinit var countSelectQuery1: SelectQuery<Long>
+
+    @MockK
+    private lateinit var countSelectQuery2: SelectQuery<Long>
+
+    @MockK
+    private lateinit var countSelectQuery3: SelectQuery<Long>
 
     @MockK
     private lateinit var stringTypedQuery1: TypedQuery<String>
@@ -235,6 +253,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         every { createDeleteQuery1.invoke(any()) } returns deleteQuery1
         every { createDeleteQuery2.invoke(any()) } returns deleteQuery2
         every { createDeleteQuery3.invoke(any()) } returns deleteQuery3
+        every { createCountSelectQuery1.invoke(any()) } returns countSelectQuery1
+        every { createCountSelectQuery2.invoke(any()) } returns countSelectQuery2
+        every { createCountSelectQuery3.invoke(any()) } returns countSelectQuery3
         every { selectQuery1.toQuery() } returns selectQuery1
         every { selectQuery2.toQuery() } returns selectQuery2
         every { selectQuery3.toQuery() } returns selectQuery3
@@ -244,6 +265,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         every { deleteQuery1.toQuery() } returns deleteQuery1
         every { deleteQuery2.toQuery() } returns deleteQuery2
         every { deleteQuery3.toQuery() } returns deleteQuery3
+        every { countSelectQuery1.toQuery() } returns countSelectQuery1
+        every { countSelectQuery2.toQuery() } returns countSelectQuery2
+        every { countSelectQuery3.toQuery() } returns countSelectQuery3
 
         excludeRecords { createSelectQuery1.invoke(any()) }
         excludeRecords { createSelectQuery2.invoke(any()) }
@@ -254,6 +278,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         excludeRecords { createDeleteQuery1.invoke(any()) }
         excludeRecords { createDeleteQuery2.invoke(any()) }
         excludeRecords { createDeleteQuery3.invoke(any()) }
+        excludeRecords { createCountSelectQuery1.invoke(any()) }
+        excludeRecords { createCountSelectQuery2.invoke(any()) }
+        excludeRecords { createCountSelectQuery3.invoke(any()) }
         excludeRecords { selectQuery1.toQuery() }
         excludeRecords { selectQuery2.toQuery() }
         excludeRecords { selectQuery3.toQuery() }
@@ -263,6 +290,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         excludeRecords { deleteQuery1.toQuery() }
         excludeRecords { deleteQuery2.toQuery() }
         excludeRecords { deleteQuery3.toQuery() }
+        excludeRecords { countSelectQuery1.toQuery() }
+        excludeRecords { countSelectQuery2.toQuery() }
+        excludeRecords { countSelectQuery3.toQuery() }
     }
 
     @Test
@@ -666,6 +696,174 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             longTypedQuery3.setHint(queryHintForCount1.first, queryHintForCount1.second)
             longTypedQuery3.setHint(queryHintForCount2.first, queryHintForCount2.second)
             longTypedQuery3.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            longTypedQuery3.resultList
+        }
+    }
+
+    @Test
+    fun `findPage() with count query`() {
+        // given
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery1
+        every {
+            JpqlEntityManagerUtils.createCountQuery(any(), any<SelectQuery<Long>>(), any())
+        } returns longTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultList } returns list1
+        every { longTypedQuery1.setHint(any(), any()) } returns longTypedQuery1
+        every { longTypedQuery1.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
+
+            page1
+        }
+
+        // when
+        val actual = sut.findPage(pageable1, createSelectQuery1, createCountSelectQuery1)
+
+        // then
+        assertThat(actual).isEqualTo(page1)
+
+        verifySequence {
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery1, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.firstResult = pageable1.offset.toInt()
+            stringTypedQuery1.maxResults = pageable1.pageSize
+            JpqlEntityManagerUtils.createCountQuery(entityManager, countSelectQuery1, renderContext)
+            metadata.queryHintsForCount
+            longTypedQuery1.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery1.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery1.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            stringTypedQuery1.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
+            longTypedQuery1.resultList
+        }
+    }
+
+    @Test
+    fun `findPage() with count query with a dsl`() {
+        // given
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery2
+        every {
+            JpqlEntityManagerUtils.createCountQuery(any(), any<SelectQuery<Long>>(), any())
+        } returns longTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultList } returns list1
+        every { longTypedQuery2.setHint(any(), any()) } returns longTypedQuery2
+        every { longTypedQuery2.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
+
+            page1
+        }
+
+        // when
+        val actual = sut.findPage(MyJpql, pageable1, createSelectQuery2, createCountSelectQuery2)
+
+        // then
+        assertThat(actual).isEqualTo(page1)
+
+        verifySequence {
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery2, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.firstResult = pageable1.offset.toInt()
+            stringTypedQuery2.maxResults = pageable1.pageSize
+            JpqlEntityManagerUtils.createCountQuery(entityManager, countSelectQuery2, renderContext)
+            metadata.queryHintsForCount
+            longTypedQuery2.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery2.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery2.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            stringTypedQuery2.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
+            longTypedQuery2.resultList
+        }
+    }
+
+    @Test
+    fun `findPage() with count query with a dsl object`() {
+        // given
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery3
+        every {
+            JpqlEntityManagerUtils.createCountQuery(any(), any<SelectQuery<Long>>(), any())
+        } returns longTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultList } returns list1
+        every { longTypedQuery3.setHint(any(), any()) } returns longTypedQuery3
+        every { longTypedQuery3.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
+
+            page1
+        }
+
+        // when
+        val actual = sut.findPage(MyJpqlObject, pageable1, createSelectQuery3, createCountSelectQuery3)
+
+        // then
+        assertThat(actual).isEqualTo(page1)
+
+        verifySequence {
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery3, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.firstResult = pageable1.offset.toInt()
+            stringTypedQuery3.maxResults = pageable1.pageSize
+            JpqlEntityManagerUtils.createCountQuery(entityManager, countSelectQuery3, renderContext)
+            metadata.queryHintsForCount
+            longTypedQuery3.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery3.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery3.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            stringTypedQuery3.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
             longTypedQuery3.resultList
         }
     }

--- a/support/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImplTest.kt
+++ b/support/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImplTest.kt
@@ -706,7 +706,11 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         every { selectQuery1.returnType } returns String::class
         every {
             JpqlEntityManagerUtils.createEnhancedQuery(
-                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+                any(),
+                any<SelectQuery<String>>(),
+                any<KClass<*>>(),
+                any(),
+                any(),
             )
         } returns enhancedTypedQuery1
         every {
@@ -762,7 +766,11 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         every { selectQuery2.returnType } returns String::class
         every {
             JpqlEntityManagerUtils.createEnhancedQuery(
-                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+                any(),
+                any<SelectQuery<String>>(),
+                any<KClass<*>>(),
+                any(),
+                any(),
             )
         } returns enhancedTypedQuery2
         every {
@@ -818,7 +826,11 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         every { selectQuery3.returnType } returns String::class
         every {
             JpqlEntityManagerUtils.createEnhancedQuery(
-                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+                any(),
+                any<SelectQuery<String>>(),
+                any<KClass<*>>(),
+                any(),
+                any(),
             )
         } returns enhancedTypedQuery3
         every {

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -26,6 +26,18 @@ internal object JpqlEntityManagerUtils {
         return createQuery(entityManager, rendered.query, rendered.params, returnType.java)
     }
 
+    fun createCountQuery(
+        entityManager: EntityManager,
+        query: JpqlQuery<*>,
+        context: RenderContext,
+    ): TypedQuery<Long> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return entityManager.createQuery(rendered.query, Long::class.javaObjectType).apply {
+            setParams(this, rendered.params)
+        }
+    }
+
     fun <T : Any> createQuery(
         entityManager: EntityManager,
         query: JpqlQuery<*>,

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtils.kt
@@ -26,6 +26,19 @@ internal object JpqlEntityManagerUtils {
         return createQuery(entityManager, rendered.query, rendered.params, returnType.java)
     }
 
+    /**
+     * Creates a [TypedQuery] for a count query with boxed [java.lang.Long] as the return type.
+     *
+     * This is separated from the general [createQuery] to work around a Hibernate 5 strictness issue:
+     * the primitive `long` vs. boxed `java.lang.Long` mismatch is rejected with
+     * `Type specified for TypedQuery [long] is incompatible with query return type [class java.lang.Long]`.
+     *
+     * Hibernate 6 is lenient about this mismatch today, but the same latent issue remains.
+     * Applied consistently across all three support modules (spring-data-jpa, spring-data-jpa-javax,
+     * spring-data-jpa-boot4) to remain safe when future Hibernate versions tighten type inference.
+     *
+     * This matches the convention already used by the auto-count path in `createEnhancedQuery`.
+     */
     fun createCountQuery(
         entityManager: EntityManager,
         query: JpqlQuery<*>,

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutor.kt
@@ -107,6 +107,38 @@ interface KotlinJdslJpqlExecutor {
     ): Page<T?>
 
     /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.8.2")
+    fun <T : Any> findPage(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: Jpql.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?>
+
+    /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.8.2")
+    fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?>
+
+    /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.8.2")
+    fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?>
+
+    /**
      * Returns the slice of the select query.
      */
     @SinceJdsl("3.0.0")

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -297,6 +297,14 @@ open class KotlinJdslJpqlExecutorImpl(
         }
     }
 
+    private fun createJpaCountQuery(
+        countQuery: JpqlQuery<*>,
+    ): TypedQuery<Long> {
+        return JpqlEntityManagerUtils
+            .createCountQuery(entityManager, countQuery, renderContext)
+            .apply { setMetadataForCount(this, metadata) }
+    }
+
     private fun <T : Any> createJpaEnhancedQuery(
         query: JpqlQuery<*>,
         returnType: KClass<T>,
@@ -400,9 +408,7 @@ open class KotlinJdslJpqlExecutorImpl(
             sortedQuery.maxResults = pageable.pageSize
         }
 
-        val countJpaQuery = JpqlEntityManagerUtils
-            .createCountQuery(entityManager, countQuery, renderContext)
-            .apply { setMetadataForCount(this, metadata) }
+        val countJpaQuery = createJpaCountQuery(countQuery)
 
         return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
             val counts = countJpaQuery.resultList

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -116,6 +116,35 @@ open class KotlinJdslJpqlExecutorImpl(
         return createPage(query, query.returnType, pageable)
     }
 
+    override fun <T : Any> findPage(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: Jpql.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> {
+        return findPage(Jpql, pageable, init, countInit)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> {
+        return findPage(dsl.newInstance(), pageable, init, countInit)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+        val countQuery: SelectQuery<Long> = jpql(dsl, countInit)
+
+        return createPage(query, query.returnType, countQuery, pageable)
+    }
+
     override fun <T : Any> findSlice(
         pageable: Pageable,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
@@ -347,6 +376,36 @@ open class KotlinJdslJpqlExecutorImpl(
 
         return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
             val counts = enhancedQuery.countQuery.resultList
+
+            if (counts.size == 1) {
+                counts.first()
+            } else {
+                counts.count().toLong()
+            }
+        }
+    }
+
+    private fun <T : Any> createPage(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        countQuery: JpqlQuery<*>,
+        pageable: Pageable,
+    ): Page<T?> {
+        val enhancedQuery = createJpaEnhancedQuery(query, returnType, pageable.sort)
+
+        val sortedQuery = enhancedQuery.sortedQuery
+
+        if (pageable.isPaged) {
+            sortedQuery.firstResult = pageable.offset.toInt()
+            sortedQuery.maxResults = pageable.pageSize
+        }
+
+        val countJpaQuery = JpqlEntityManagerUtils
+            .createCountQuery(entityManager, countQuery, renderContext)
+            .apply { setMetadataForCount(this, metadata) }
+
+        return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
+            val counts = countJpaQuery.resultList
 
             if (counts.size == 1) {
                 counts.first()

--- a/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorProxy.kt
+++ b/support/spring-data-jpa-javax/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorProxy.kt
@@ -83,6 +83,26 @@ open class KotlinJdslJpqlExecutorProxy(
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): Page<T?> = getDelegate().findPage(dsl, pageable, init)
 
+    override fun <T : Any> findPage(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: Jpql.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> = getDelegate().findPage(pageable, init, countInit)
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> = getDelegate().findPage(dsl, pageable, init, countInit)
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> = getDelegate().findPage(dsl, pageable, init, countInit)
+
     override fun <T : Any> findSlice(
         pageable: Pageable,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,

--- a/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/JpqlEntityManagerUtilsTest.kt
@@ -213,6 +213,35 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
+    fun `createCountQuery() uses boxed Long java type`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any<JpqlQuery<*>>(), any()) } returns rendered1
+        every { entityManager.createQuery(any<String>(), any<Class<Long>>()) } returns longTypedQuery1
+        every { longTypedQuery1.parameters } returns setOf(longTypedQueryParam1, longTypedQueryParam2)
+        every { longTypedQuery1.setParameter(any<String>(), any()) } returns longTypedQuery1
+        every { longTypedQueryParam1.name } returns renderedParam1.first
+        every { longTypedQueryParam2.name } returns renderedParam2.first
+
+        // when
+        val actual = JpqlEntityManagerUtils.createCountQuery(entityManager, query1, context)
+
+        // then
+        assertThat(actual).isEqualTo(longTypedQuery1)
+
+        verifySequence {
+            renderer.render(query1, context)
+            entityManager.createQuery(rendered1.query, Long::class.javaObjectType)
+            longTypedQuery1.parameters
+            longTypedQueryParam1.name
+            longTypedQueryParam2.name
+            longTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
+            longTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
     fun `createEnhancedQuery() with JpqlSelectQuery`() {
         // given
         val selectQuery1: JpqlSelectQuery<Any> = mockk()

--- a/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImplTest.kt
+++ b/support/spring-data-jpa-javax/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/javax/repository/KotlinJdslJpqlExecutorImplTest.kt
@@ -78,6 +78,15 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     private lateinit var createDeleteQuery3: MyJpqlObject.() -> JpqlQueryable<DeleteQuery<String>>
 
     @MockK
+    private lateinit var createCountSelectQuery1: Jpql.() -> JpqlQueryable<SelectQuery<Long>>
+
+    @MockK
+    private lateinit var createCountSelectQuery2: MyJpql.() -> JpqlQueryable<SelectQuery<Long>>
+
+    @MockK
+    private lateinit var createCountSelectQuery3: MyJpqlObject.() -> JpqlQueryable<SelectQuery<Long>>
+
+    @MockK
     private lateinit var selectQuery1: SelectQuery<String>
 
     @MockK
@@ -103,6 +112,15 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
 
     @MockK
     private lateinit var deleteQuery3: DeleteQuery<String>
+
+    @MockK
+    private lateinit var countSelectQuery1: SelectQuery<Long>
+
+    @MockK
+    private lateinit var countSelectQuery2: SelectQuery<Long>
+
+    @MockK
+    private lateinit var countSelectQuery3: SelectQuery<Long>
 
     @MockK
     private lateinit var stringTypedQuery1: TypedQuery<String>
@@ -235,6 +253,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         every { createDeleteQuery1.invoke(any()) } returns deleteQuery1
         every { createDeleteQuery2.invoke(any()) } returns deleteQuery2
         every { createDeleteQuery3.invoke(any()) } returns deleteQuery3
+        every { createCountSelectQuery1.invoke(any()) } returns countSelectQuery1
+        every { createCountSelectQuery2.invoke(any()) } returns countSelectQuery2
+        every { createCountSelectQuery3.invoke(any()) } returns countSelectQuery3
         every { selectQuery1.toQuery() } returns selectQuery1
         every { selectQuery2.toQuery() } returns selectQuery2
         every { selectQuery3.toQuery() } returns selectQuery3
@@ -244,6 +265,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         every { deleteQuery1.toQuery() } returns deleteQuery1
         every { deleteQuery2.toQuery() } returns deleteQuery2
         every { deleteQuery3.toQuery() } returns deleteQuery3
+        every { countSelectQuery1.toQuery() } returns countSelectQuery1
+        every { countSelectQuery2.toQuery() } returns countSelectQuery2
+        every { countSelectQuery3.toQuery() } returns countSelectQuery3
 
         excludeRecords { createSelectQuery1.invoke(any()) }
         excludeRecords { createSelectQuery2.invoke(any()) }
@@ -254,6 +278,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         excludeRecords { createDeleteQuery1.invoke(any()) }
         excludeRecords { createDeleteQuery2.invoke(any()) }
         excludeRecords { createDeleteQuery3.invoke(any()) }
+        excludeRecords { createCountSelectQuery1.invoke(any()) }
+        excludeRecords { createCountSelectQuery2.invoke(any()) }
+        excludeRecords { createCountSelectQuery3.invoke(any()) }
         excludeRecords { selectQuery1.toQuery() }
         excludeRecords { selectQuery2.toQuery() }
         excludeRecords { selectQuery3.toQuery() }
@@ -263,6 +290,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         excludeRecords { deleteQuery1.toQuery() }
         excludeRecords { deleteQuery2.toQuery() }
         excludeRecords { deleteQuery3.toQuery() }
+        excludeRecords { countSelectQuery1.toQuery() }
+        excludeRecords { countSelectQuery2.toQuery() }
+        excludeRecords { countSelectQuery3.toQuery() }
     }
 
     @Test
@@ -642,6 +672,174 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             longTypedQuery3.setHint(queryHintForCount1.first, queryHintForCount1.second)
             longTypedQuery3.setHint(queryHintForCount2.first, queryHintForCount2.second)
             longTypedQuery3.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            longTypedQuery3.resultList
+        }
+    }
+
+    @Test
+    fun `findPage() with count query`() {
+        // given
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery1
+        every {
+            JpqlEntityManagerUtils.createCountQuery(any(), any<SelectQuery<Long>>(), any())
+        } returns longTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultList } returns list1
+        every { longTypedQuery1.setHint(any(), any()) } returns longTypedQuery1
+        every { longTypedQuery1.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
+
+            page1
+        }
+
+        // when
+        val actual = sut.findPage(pageable1, createSelectQuery1, createCountSelectQuery1)
+
+        // then
+        assertThat(actual).isEqualTo(page1)
+
+        verifySequence {
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery1, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.firstResult = pageable1.offset.toInt()
+            stringTypedQuery1.maxResults = pageable1.pageSize
+            JpqlEntityManagerUtils.createCountQuery(entityManager, countSelectQuery1, renderContext)
+            metadata.queryHintsForCount
+            longTypedQuery1.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery1.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery1.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            stringTypedQuery1.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
+            longTypedQuery1.resultList
+        }
+    }
+
+    @Test
+    fun `findPage() with count query with a dsl`() {
+        // given
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery2
+        every {
+            JpqlEntityManagerUtils.createCountQuery(any(), any<SelectQuery<Long>>(), any())
+        } returns longTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultList } returns list1
+        every { longTypedQuery2.setHint(any(), any()) } returns longTypedQuery2
+        every { longTypedQuery2.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
+
+            page1
+        }
+
+        // when
+        val actual = sut.findPage(MyJpql, pageable1, createSelectQuery2, createCountSelectQuery2)
+
+        // then
+        assertThat(actual).isEqualTo(page1)
+
+        verifySequence {
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery2, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.firstResult = pageable1.offset.toInt()
+            stringTypedQuery2.maxResults = pageable1.pageSize
+            JpqlEntityManagerUtils.createCountQuery(entityManager, countSelectQuery2, renderContext)
+            metadata.queryHintsForCount
+            longTypedQuery2.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery2.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery2.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            stringTypedQuery2.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
+            longTypedQuery2.resultList
+        }
+    }
+
+    @Test
+    fun `findPage() with count query with a dsl object`() {
+        // given
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery3
+        every {
+            JpqlEntityManagerUtils.createCountQuery(any(), any<SelectQuery<Long>>(), any())
+        } returns longTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultList } returns list1
+        every { longTypedQuery3.setHint(any(), any()) } returns longTypedQuery3
+        every { longTypedQuery3.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
+
+            page1
+        }
+
+        // when
+        val actual = sut.findPage(MyJpqlObject, pageable1, createSelectQuery3, createCountSelectQuery3)
+
+        // then
+        assertThat(actual).isEqualTo(page1)
+
+        verifySequence {
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery3, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.firstResult = pageable1.offset.toInt()
+            stringTypedQuery3.maxResults = pageable1.pageSize
+            JpqlEntityManagerUtils.createCountQuery(entityManager, countSelectQuery3, renderContext)
+            metadata.queryHintsForCount
+            longTypedQuery3.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery3.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery3.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            stringTypedQuery3.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
             longTypedQuery3.resultList
         }
     }

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -38,6 +38,16 @@ internal object JpqlEntityManagerUtils {
         return createQuery(entityManager, rendered.query, rendered.params, returnType.java)
     }
 
+    fun createCountQuery(
+        entityManager: EntityManager,
+        query: JpqlQuery<*>,
+        context: RenderContext,
+    ): TypedQuery<Long> {
+        val rendered = JpqlRendererHolder.get().render(query, context)
+
+        return createQuery(entityManager, rendered.query, rendered.params, Long::class.javaObjectType)
+    }
+
     fun createQuery(
         entityManager: EntityManager,
         query: JpqlQuery<*>,

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtils.kt
@@ -38,6 +38,19 @@ internal object JpqlEntityManagerUtils {
         return createQuery(entityManager, rendered.query, rendered.params, returnType.java)
     }
 
+    /**
+     * Creates a [TypedQuery] for a count query with boxed [java.lang.Long] as the return type.
+     *
+     * This is separated from the general [createQuery] to work around a Hibernate 5 strictness issue:
+     * the primitive `long` vs. boxed `java.lang.Long` mismatch is rejected with
+     * `Type specified for TypedQuery [long] is incompatible with query return type [class java.lang.Long]`.
+     *
+     * Hibernate 6 is lenient about this mismatch today, but the same latent issue remains.
+     * Applied consistently across all three support modules (spring-data-jpa, spring-data-jpa-javax,
+     * spring-data-jpa-boot4) to remain safe when future Hibernate versions tighten type inference.
+     *
+     * This matches the convention already used by the auto-count path in `createEnhancedQuery`.
+     */
     fun createCountQuery(
         entityManager: EntityManager,
         query: JpqlQuery<*>,

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutor.kt
@@ -107,6 +107,38 @@ interface KotlinJdslJpqlExecutor {
     ): Page<T?>
 
     /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.8.2")
+    fun <T : Any> findPage(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: Jpql.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?>
+
+    /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.8.2")
+    fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?>
+
+    /**
+     * Returns the page of the select query.
+     */
+    @SinceJdsl("3.8.2")
+    fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?>
+
+    /**
      * Returns the slice of the select query.
      */
     @SinceJdsl("3.0.0")

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -118,6 +118,35 @@ open class KotlinJdslJpqlExecutorImpl(
         return createPage(query, query.returnType, pageable)
     }
 
+    override fun <T : Any> findPage(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: Jpql.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> {
+        return findPage(Jpql, pageable, init, countInit)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> {
+        return findPage(dsl.newInstance(), pageable, init, countInit)
+    }
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> {
+        val query: SelectQuery<T> = jpql(dsl, init)
+        val countQuery: SelectQuery<Long> = jpql(dsl, countInit)
+
+        return createPage(query, query.returnType, countQuery, pageable)
+    }
+
     override fun <T : Any> findSlice(
         pageable: Pageable,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
@@ -349,6 +378,36 @@ open class KotlinJdslJpqlExecutorImpl(
 
         return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
             val counts = enhancedQuery.countQuery.resultList
+
+            if (counts.size == 1) {
+                counts.first()
+            } else {
+                counts.count().toLong()
+            }
+        }
+    }
+
+    private fun <T : Any> createPage(
+        query: JpqlQuery<*>,
+        returnType: KClass<T>,
+        countQuery: JpqlQuery<*>,
+        pageable: Pageable,
+    ): Page<T?> {
+        val enhancedQuery = createJpaEnhancedQuery(query, returnType, pageable.sort)
+
+        val sortedQuery = enhancedQuery.sortedQuery
+
+        if (pageable.isPaged) {
+            sortedQuery.firstResult = pageable.offset.toInt()
+            sortedQuery.maxResults = pageable.pageSize
+        }
+
+        val countJpaQuery = JpqlEntityManagerUtils
+            .createCountQuery(entityManager, countQuery, renderContext)
+            .apply { setMetadataForCount(this, metadata) }
+
+        return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
+            val counts = countJpaQuery.resultList
 
             if (counts.size == 1) {
                 counts.first()

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImpl.kt
@@ -299,6 +299,14 @@ open class KotlinJdslJpqlExecutorImpl(
         }
     }
 
+    private fun createJpaCountQuery(
+        countQuery: JpqlQuery<*>,
+    ): TypedQuery<Long> {
+        return JpqlEntityManagerUtils
+            .createCountQuery(entityManager, countQuery, renderContext)
+            .apply { setMetadataForCount(this, metadata) }
+    }
+
     private fun <T : Any> createJpaEnhancedQuery(
         query: JpqlQuery<*>,
         returnType: KClass<T>,
@@ -402,9 +410,7 @@ open class KotlinJdslJpqlExecutorImpl(
             sortedQuery.maxResults = pageable.pageSize
         }
 
-        val countJpaQuery = JpqlEntityManagerUtils
-            .createCountQuery(entityManager, countQuery, renderContext)
-            .apply { setMetadataForCount(this, metadata) }
+        val countJpaQuery = createJpaCountQuery(countQuery)
 
         return PageableExecutionUtilsAdaptor.getPage(sortedQuery.resultList, pageable) {
             val counts = countJpaQuery.resultList

--- a/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorProxy.kt
+++ b/support/spring-data-jpa/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorProxy.kt
@@ -83,6 +83,26 @@ open class KotlinJdslJpqlExecutorProxy(
         init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
     ): Page<T?> = getDelegate().findPage(dsl, pageable, init)
 
+    override fun <T : Any> findPage(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: Jpql.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> = getDelegate().findPage(pageable, init, countInit)
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> = getDelegate().findPage(dsl, pageable, init, countInit)
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T?> = getDelegate().findPage(dsl, pageable, init, countInit)
+
     override fun <T : Any> findSlice(
         pageable: Pageable,
         init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,

--- a/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtilsTest.kt
+++ b/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/JpqlEntityManagerUtilsTest.kt
@@ -213,6 +213,35 @@ class JpqlEntityManagerUtilsTest : WithAssertions {
     }
 
     @Test
+    fun `createCountQuery() uses boxed Long java type`() {
+        // given
+        val rendered1 = JpqlRendered(renderedQuery1, JpqlRenderedParams(mapOf(renderedParam1, renderedParam2)))
+
+        every { renderer.render(any<JpqlQuery<*>>(), any()) } returns rendered1
+        every { entityManager.createQuery(any<String>(), any<Class<Long>>()) } returns longTypedQuery1
+        every { longTypedQuery1.parameters } returns setOf(longTypedQueryParam1, longTypedQueryParam2)
+        every { longTypedQuery1.setParameter(any<String>(), any()) } returns longTypedQuery1
+        every { longTypedQueryParam1.name } returns renderedParam1.first
+        every { longTypedQueryParam2.name } returns renderedParam2.first
+
+        // when
+        val actual = JpqlEntityManagerUtils.createCountQuery(entityManager, query1, context)
+
+        // then
+        assertThat(actual).isEqualTo(longTypedQuery1)
+
+        verifySequence {
+            renderer.render(query1, context)
+            entityManager.createQuery(rendered1.query, Long::class.javaObjectType)
+            longTypedQuery1.parameters
+            longTypedQueryParam1.name
+            longTypedQueryParam2.name
+            longTypedQuery1.setParameter(renderedParam1.first, renderedParam1.second)
+            longTypedQuery1.setParameter(renderedParam2.first, renderedParam2.second)
+        }
+    }
+
+    @Test
     fun `createEnhancedQuery() with JpqlSelectQuery`() {
         // given
         val selectQuery1: JpqlSelectQuery<Any> = mockk()

--- a/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImplTest.kt
+++ b/support/spring-data-jpa/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorImplTest.kt
@@ -78,6 +78,15 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
     private lateinit var createDeleteQuery3: MyJpqlObject.() -> JpqlQueryable<DeleteQuery<String>>
 
     @MockK
+    private lateinit var createCountSelectQuery1: Jpql.() -> JpqlQueryable<SelectQuery<Long>>
+
+    @MockK
+    private lateinit var createCountSelectQuery2: MyJpql.() -> JpqlQueryable<SelectQuery<Long>>
+
+    @MockK
+    private lateinit var createCountSelectQuery3: MyJpqlObject.() -> JpqlQueryable<SelectQuery<Long>>
+
+    @MockK
     private lateinit var selectQuery1: SelectQuery<String>
 
     @MockK
@@ -103,6 +112,15 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
 
     @MockK
     private lateinit var deleteQuery3: DeleteQuery<String>
+
+    @MockK
+    private lateinit var countSelectQuery1: SelectQuery<Long>
+
+    @MockK
+    private lateinit var countSelectQuery2: SelectQuery<Long>
+
+    @MockK
+    private lateinit var countSelectQuery3: SelectQuery<Long>
 
     @MockK
     private lateinit var stringTypedQuery1: TypedQuery<String>
@@ -235,6 +253,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         every { createDeleteQuery1.invoke(any()) } returns deleteQuery1
         every { createDeleteQuery2.invoke(any()) } returns deleteQuery2
         every { createDeleteQuery3.invoke(any()) } returns deleteQuery3
+        every { createCountSelectQuery1.invoke(any()) } returns countSelectQuery1
+        every { createCountSelectQuery2.invoke(any()) } returns countSelectQuery2
+        every { createCountSelectQuery3.invoke(any()) } returns countSelectQuery3
         every { selectQuery1.toQuery() } returns selectQuery1
         every { selectQuery2.toQuery() } returns selectQuery2
         every { selectQuery3.toQuery() } returns selectQuery3
@@ -244,6 +265,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         every { deleteQuery1.toQuery() } returns deleteQuery1
         every { deleteQuery2.toQuery() } returns deleteQuery2
         every { deleteQuery3.toQuery() } returns deleteQuery3
+        every { countSelectQuery1.toQuery() } returns countSelectQuery1
+        every { countSelectQuery2.toQuery() } returns countSelectQuery2
+        every { countSelectQuery3.toQuery() } returns countSelectQuery3
 
         excludeRecords { createSelectQuery1.invoke(any()) }
         excludeRecords { createSelectQuery2.invoke(any()) }
@@ -254,6 +278,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         excludeRecords { createDeleteQuery1.invoke(any()) }
         excludeRecords { createDeleteQuery2.invoke(any()) }
         excludeRecords { createDeleteQuery3.invoke(any()) }
+        excludeRecords { createCountSelectQuery1.invoke(any()) }
+        excludeRecords { createCountSelectQuery2.invoke(any()) }
+        excludeRecords { createCountSelectQuery3.invoke(any()) }
         excludeRecords { selectQuery1.toQuery() }
         excludeRecords { selectQuery2.toQuery() }
         excludeRecords { selectQuery3.toQuery() }
@@ -263,6 +290,9 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
         excludeRecords { deleteQuery1.toQuery() }
         excludeRecords { deleteQuery2.toQuery() }
         excludeRecords { deleteQuery3.toQuery() }
+        excludeRecords { countSelectQuery1.toQuery() }
+        excludeRecords { countSelectQuery2.toQuery() }
+        excludeRecords { countSelectQuery3.toQuery() }
     }
 
     @Test
@@ -642,6 +672,174 @@ class KotlinJdslJpqlExecutorImplTest : WithAssertions {
             longTypedQuery3.setHint(queryHintForCount1.first, queryHintForCount1.second)
             longTypedQuery3.setHint(queryHintForCount2.first, queryHintForCount2.second)
             longTypedQuery3.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            longTypedQuery3.resultList
+        }
+    }
+
+    @Test
+    fun `findPage() with count query`() {
+        // given
+        every { selectQuery1.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery1
+        every {
+            JpqlEntityManagerUtils.createCountQuery(any(), any<SelectQuery<Long>>(), any())
+        } returns longTypedQuery1
+        every { stringTypedQuery1.setLockMode(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setHint(any(), any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setFirstResult(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.setMaxResults(any()) } returns stringTypedQuery1
+        every { stringTypedQuery1.resultList } returns list1
+        every { longTypedQuery1.setHint(any(), any()) } returns longTypedQuery1
+        every { longTypedQuery1.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
+
+            page1
+        }
+
+        // when
+        val actual = sut.findPage(pageable1, createSelectQuery1, createCountSelectQuery1)
+
+        // then
+        assertThat(actual).isEqualTo(page1)
+
+        verifySequence {
+            selectQuery1.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery1, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery1.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery1.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery1.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery1.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery1.firstResult = pageable1.offset.toInt()
+            stringTypedQuery1.maxResults = pageable1.pageSize
+            JpqlEntityManagerUtils.createCountQuery(entityManager, countSelectQuery1, renderContext)
+            metadata.queryHintsForCount
+            longTypedQuery1.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery1.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery1.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            stringTypedQuery1.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
+            longTypedQuery1.resultList
+        }
+    }
+
+    @Test
+    fun `findPage() with count query with a dsl`() {
+        // given
+        every { selectQuery2.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery2
+        every {
+            JpqlEntityManagerUtils.createCountQuery(any(), any<SelectQuery<Long>>(), any())
+        } returns longTypedQuery2
+        every { stringTypedQuery2.setLockMode(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setHint(any(), any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setFirstResult(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.setMaxResults(any()) } returns stringTypedQuery2
+        every { stringTypedQuery2.resultList } returns list1
+        every { longTypedQuery2.setHint(any(), any()) } returns longTypedQuery2
+        every { longTypedQuery2.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
+
+            page1
+        }
+
+        // when
+        val actual = sut.findPage(MyJpql, pageable1, createSelectQuery2, createCountSelectQuery2)
+
+        // then
+        assertThat(actual).isEqualTo(page1)
+
+        verifySequence {
+            selectQuery2.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery2, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery2.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery2.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery2.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery2.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery2.firstResult = pageable1.offset.toInt()
+            stringTypedQuery2.maxResults = pageable1.pageSize
+            JpqlEntityManagerUtils.createCountQuery(entityManager, countSelectQuery2, renderContext)
+            metadata.queryHintsForCount
+            longTypedQuery2.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery2.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery2.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            stringTypedQuery2.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
+            longTypedQuery2.resultList
+        }
+    }
+
+    @Test
+    fun `findPage() with count query with a dsl object`() {
+        // given
+        every { selectQuery3.returnType } returns String::class
+        every {
+            JpqlEntityManagerUtils.createEnhancedQuery(
+                any(), any<SelectQuery<String>>(), any<KClass<*>>(), any(), any(),
+            )
+        } returns enhancedTypedQuery3
+        every {
+            JpqlEntityManagerUtils.createCountQuery(any(), any<SelectQuery<Long>>(), any())
+        } returns longTypedQuery3
+        every { stringTypedQuery3.setLockMode(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setHint(any(), any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setFirstResult(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.setMaxResults(any()) } returns stringTypedQuery3
+        every { stringTypedQuery3.resultList } returns list1
+        every { longTypedQuery3.setHint(any(), any()) } returns longTypedQuery3
+        every { longTypedQuery3.resultList } returns counts1
+        every { metadata.lockModeType } returns lockModeType1
+        every { metadata.queryHints } returns queryHints1
+        every { metadata.queryHintsForCount } returns queryHintsForCount1
+        every { PageableExecutionUtilsAdaptor.getPage<String>(any(), any(), any()) } answers {
+            lastArg<LongSupplier>().asLong
+
+            page1
+        }
+
+        // when
+        val actual = sut.findPage(MyJpqlObject, pageable1, createSelectQuery3, createCountSelectQuery3)
+
+        // then
+        assertThat(actual).isEqualTo(page1)
+
+        verifySequence {
+            selectQuery3.returnType
+            JpqlEntityManagerUtils.createEnhancedQuery(entityManager, selectQuery3, String::class, sort1, renderContext)
+            metadata.lockModeType
+            stringTypedQuery3.setLockMode(lockModeType1)
+            metadata.queryHints
+            stringTypedQuery3.setHint(queryHint1.first, queryHint1.second)
+            stringTypedQuery3.setHint(queryHint2.first, queryHint2.second)
+            stringTypedQuery3.setHint(queryHint3.first, queryHint3.second)
+            stringTypedQuery3.firstResult = pageable1.offset.toInt()
+            stringTypedQuery3.maxResults = pageable1.pageSize
+            JpqlEntityManagerUtils.createCountQuery(entityManager, countSelectQuery3, renderContext)
+            metadata.queryHintsForCount
+            longTypedQuery3.setHint(queryHintForCount1.first, queryHintForCount1.second)
+            longTypedQuery3.setHint(queryHintForCount2.first, queryHintForCount2.second)
+            longTypedQuery3.setHint(queryHintForCount3.first, queryHintForCount3.second)
+            stringTypedQuery3.resultList
+            PageableExecutionUtilsAdaptor.getPage(list1, pageable1, any())
             longTypedQuery3.resultList
         }
     }


### PR DESCRIPTION
# Motivation

The FAQ [`how-to-handle-count-query-in-spring-data-jpa-pageable`](https://github.com/line/kotlin-jdsl/blob/main/docs/en/faq/how-to-handle-count-query-in-spring-data-jpa-pageable.md) says you can provide an explicit count query to `findPage`, but that API didn't actually exist.

This PR implements it.

# Modifications

- Add `findPage` overloads:
    - Three `countInit` parameter overloads on the `KotlinJdslJpqlExecutor` interface (default `Jpql` / `JpqlDsl.Constructor<DSL>` / `DSL` instance)
    - Override in `KotlinJdslJpqlExecutorImpl` with a new private `createPage` helper
    - Delegating overrides in `KotlinJdslJpqlExecutorProxy` (jakarta / javax)
- Add a dedicated count query helper `JpqlEntityManagerUtils.createCountQuery`:
    - The existing shared `createQuery(..., KClass)` resolves `returnType.java` to `Long::class.java`, which maps to the primitive `long.class`.
    - The javax module uses Hibernate 5.x, which strictly rejects the primitive `long` vs. boxed `java.lang.Long` mismatch: `Type specified for TypedQuery [long] is incompatible with query return type [class java.lang.Long]`.
    - The new helper passes `Long::class.javaObjectType` to `entityManager.createQuery`, forcing `TypedQuery<Long>` to always be boxed as `java.lang.Long`. This matches the convention already used by the auto-count path in `createEnhancedQuery`.
    - jakarta / boot4 currently work without issues because Hibernate 6 is lenient about the primitive vs. boxed mismatch, but they carry the same latent bug. Applied proactively across all three modules so nothing breaks when a future Hibernate version tightens type inference.
- Allow `groupBy` in count queries:
    - When `resultList.size != 1`, fall back to the row count as the total (matches the existing auto-count behavior)
- Applied consistently across all three modules: `spring-data-jpa`, `spring-data-jpa-javax`, and `spring-data-jpa-boot4`
- Verification:
    - Three mockk tests added to `KotlinJdslJpqlExecutorImplTest` in each module
    - `createCountQuery` tests added to `JpqlEntityManagerUtilsTest` in each module
    - New `Issue1074Test` covering: groupBy + countDistinct, where-clause consistency, groupBy inside the count query, pagination across multiple pages, and count skipping when content < pageSize

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- The FAQ example is now usable as working code.
- Consistent behavior across all three support modules.

# Closes

#1074

--- korean

# Motivation

[FAQ 문서](https://github.com/line/kotlin-jdsl/blob/main/docs/ko/faq/how-to-handle-count-query-in-spring-data-jpa-pageable.md) 에는 `findPage` 에 count 쿼리를 명시적으로 지정할 수 있다고 나와 있지만 실제로는 해당
API 가 없었습니다.

이 PR 에서 추가했습니다.

# Modifications

- `findPage` 오버로드 추가:
    - `KotlinJdslJpqlExecutor` 인터페이스에 `countInit` 파라미터 오버로드 3개 (`Jpql` 기본 /
      `JpqlDsl.Constructor<DSL>` / `DSL` 인스턴스)
    - `KotlinJdslJpqlExecutorImpl` override + `createPage` private helper 추가
    - `KotlinJdslJpqlExecutorProxy` delegating override 추가 (jakarta / javax)
- count 쿼리 전용 헬퍼 `JpqlEntityManagerUtils.createCountQuery` 추가:
    - 기존 공용 `createQuery(..., KClass)` 는 `returnType.java` 를 통해 `Long::class.java` → primitive
      `long.class` 로 해석함.
    - javax 모듈은 Hibernate 5.x 를 사용하며 primitive `long` 과 boxed `java.lang.Long` 불일치를 엄격하게
      거부: `Type specified for TypedQuery [long] is incompatible with query return type [class java.lang.Long]`.
    - 새 헬퍼는 `Long::class.javaObjectType` 을 `entityManager.createQuery` 에 전달해 `TypedQuery<Long>` 이
      항상 boxed `java.lang.Long` 으로 박히도록 강제함. 이는 기존 `createEnhancedQuery` 의 auto-count 경로가 이미
      사용하던 컨벤션과 동일.
    - jakarta / boot4 는 Hibernate 6 이 primitive/boxed 불일치를 관대하게 처리해서 현재는 문제 없지만, 동일한
      잠재 버그를 품고 있음. 향후 Hibernate 버전이 타입 추론을 엄격화할 때 깨지지 않도록 세 모듈 모두에 선제
      적용.
- count 쿼리 내 `groupBy` 허용:
    - `resultList.size != 1` 이면 row 수를 총합으로 폴백 (기존 auto-count 경로와 동일)
- 세 모듈 일관 적용: `spring-data-jpa`, `spring-data-jpa-javax`, `spring-data-jpa-boot4`
- 검증:
    - 모듈별 `KotlinJdslJpqlExecutorImplTest` mockk 테스트 3개씩 추가
    - 모듈별 `JpqlEntityManagerUtilsTest` `createCountQuery` 테스트 추가
    - `Issue1074Test` 신규: groupBy + countDistinct / where 정합성 / count 쿼리 내 groupBy / 페이지 분할 /
      content < pageSize 시 count skip 검증

# Commit Convention Rule

- Please commit your modification based by [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/):

| Commit type | Description                                                                     |
|-------------|---------------------------------------------------------------------------------|
| feat        | New Feature                                                                     |
| fix         | Fix bug                                                                         |
| docs        | Documentation only changed                                                      |
| ci          | Change CI configuration                                                         |
| refactor    | Not a bug fix or add feature, just refactoring code                             |
| test        | Add Test case or fix wrong test case                                            |
| style       | Only change the code style(ex. white-space, formatting)                         |
| chore       | It refers to minor tasks such as library version upgrade, typo correction, etc. |

- If you want to add some more `commit type` please describe it on the **Pull Request**

# Result

- FAQ 예시를 실제 동작하는 코드로 사용할 수 있습니다.
- 세 지원 모듈 모두에서 동일하게 동작합니다.

# Closes

#1074
