### PR TITLE
fix: support spring-data-jpa-boot4 proxy bean for Spring Boot 4 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ package-lock.json
 
 ### OS generated files ###
 .DS_Store
+.omc/

--- a/example/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorProxyTest.kt
+++ b/example/spring-data-jpa-boot4/src/test/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorProxyTest.kt
@@ -1,0 +1,63 @@
+package com.linecorp.kotlinjdsl.support.spring.data.jpa.repository
+
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.Application
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.author.Author
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.entity.book.Book
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.repository.author.AuthorRepository
+import com.linecorp.kotlinjdsl.example.spring.data.jpa.jpql.repository.book.BookRepository
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest(classes = [Application::class])
+@Transactional
+class KotlinJdslJpqlExecutorProxyTest {
+    @Autowired
+    private lateinit var bookRepository: BookRepository
+
+    @Autowired
+    private lateinit var authorRepository: AuthorRepository
+
+    @Test
+    fun `test proxy executor works`() {
+        bookRepository.findAll {
+            select(
+                path(Book::isbn),
+            ).from(
+                entity(Book::class),
+            )
+        }
+    }
+
+    @Test
+    fun `test proxy with pagination`() {
+        val pageable = PageRequest.of(0, 10)
+        bookRepository.findPage(pageable) {
+            select(
+                path(Book::isbn),
+            ).from(
+                entity(Book::class),
+            )
+        }
+    }
+
+    @Test
+    fun `test multiple proxies in single test`() {
+        bookRepository.findAll {
+            select(
+                path(Book::isbn),
+            ).from(
+                entity(Book::class),
+            )
+        }
+        authorRepository.findAll {
+            select(
+                path(Author::authorId),
+            ).from(
+                entity(Author::class),
+            )
+        }
+    }
+}

--- a/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/autoconfigure/KotlinJdslJpaRepositoryFactoryBeanPostProcessor.kt
+++ b/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/autoconfigure/KotlinJdslJpaRepositoryFactoryBeanPostProcessor.kt
@@ -2,6 +2,7 @@ package com.linecorp.kotlinjdsl.support.spring.data.jpa.autoconfigure
 
 import com.linecorp.kotlinjdsl.SinceJdsl
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutorProxy
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.BeanFactoryAware
 import org.springframework.beans.factory.config.BeanPostProcessor
@@ -11,10 +12,10 @@ import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean
 open class KotlinJdslJpaRepositoryFactoryBeanPostProcessor :
     BeanPostProcessor,
     BeanFactoryAware {
-    private lateinit var kotlinJdslJpqlExecutor: KotlinJdslJpqlExecutor
+    private lateinit var beanFactory: BeanFactory
 
     override fun setBeanFactory(beanFactory: BeanFactory) {
-        kotlinJdslJpqlExecutor = beanFactory.getBean("kotlinJdslJpqlExecutor", KotlinJdslJpqlExecutor::class.java)
+        this.beanFactory = beanFactory
     }
 
     override fun postProcessBeforeInitialization(
@@ -22,7 +23,7 @@ open class KotlinJdslJpaRepositoryFactoryBeanPostProcessor :
         beanName: String,
     ): Any? {
         if (bean is JpaRepositoryFactoryBean<*, *, *> && bean.hasJdsl()) {
-            bean.setCustomImplementation(kotlinJdslJpqlExecutor)
+            bean.setCustomImplementation(KotlinJdslJpqlExecutorProxy(beanFactory))
         }
 
         return super.postProcessAfterInitialization(bean, beanName)

--- a/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorProxy.kt
+++ b/support/spring-data-jpa-boot4/src/main/kotlin/com/linecorp/kotlinjdsl/support/spring/data/jpa/repository/KotlinJdslJpqlExecutorProxy.kt
@@ -1,0 +1,183 @@
+package com.linecorp.kotlinjdsl.support.spring.data.jpa.repository
+
+import com.linecorp.kotlinjdsl.SinceJdsl
+import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
+import com.linecorp.kotlinjdsl.dsl.jpql.JpqlDsl
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.delete.DeleteQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.repository.NoRepositoryBean
+import java.util.stream.Stream
+
+@NoRepositoryBean
+@SinceJdsl("3.9.0")
+open class KotlinJdslJpqlExecutorProxy(
+    private val beanFactory: BeanFactory,
+) : KotlinJdslJpqlExecutor {
+    private var delegate: KotlinJdslJpqlExecutor? = null
+
+    private fun getDelegate(): KotlinJdslJpqlExecutor {
+        if (delegate == null) {
+            delegate = beanFactory.getBean("kotlinJdslJpqlExecutor", KotlinJdslJpqlExecutor::class.java)
+        }
+
+        return delegate!!
+    }
+
+    override fun <T : Any> findAll(
+        offset: Int?,
+        limit: Int?,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?> = getDelegate().findAll(offset, limit, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: JpqlDsl.Constructor<DSL>,
+        offset: Int?,
+        limit: Int?,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?> = getDelegate().findAll(dsl, offset, limit, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: DSL,
+        offset: Int?,
+        limit: Int?,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?> = getDelegate().findAll(dsl, offset, limit, init)
+
+    override fun <T : Any> findAll(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?> = getDelegate().findAll(pageable, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?> = getDelegate().findAll(dsl, pageable, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findAll(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): List<T?> = getDelegate().findAll(dsl, pageable, init)
+
+    override fun <T : Any> findPage(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Page<T> = getDelegate().findPage(pageable, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Page<T> = getDelegate().findPage(dsl, pageable, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Page<T> = getDelegate().findPage(dsl, pageable, init)
+
+    override fun <T : Any> findPage(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: Jpql.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T> = getDelegate().findPage(pageable, init, countInit)
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T> = getDelegate().findPage(dsl, pageable, init, countInit)
+
+    override fun <T : Any, DSL : JpqlDsl> findPage(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+        countInit: DSL.() -> JpqlQueryable<SelectQuery<Long>>,
+    ): Page<T> = getDelegate().findPage(dsl, pageable, init, countInit)
+
+    override fun <T : Any> findSlice(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Slice<T> = getDelegate().findSlice(pageable, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findSlice(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Slice<T> = getDelegate().findSlice(dsl, pageable, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findSlice(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Slice<T> = getDelegate().findSlice(dsl, pageable, init)
+
+    override fun <T : Any> findStream(
+        offset: Int?,
+        limit: Int?,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T> = getDelegate().findStream(offset, limit, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: JpqlDsl.Constructor<DSL>,
+        offset: Int?,
+        limit: Int?,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T> = getDelegate().findStream(dsl, offset, limit, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: DSL,
+        offset: Int?,
+        limit: Int?,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T> = getDelegate().findStream(dsl, offset, limit, init)
+
+    override fun <T : Any> findStream(
+        pageable: Pageable,
+        init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T> = getDelegate().findStream(pageable, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: JpqlDsl.Constructor<DSL>,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T> = getDelegate().findStream(dsl, pageable, init)
+
+    override fun <T : Any, DSL : JpqlDsl> findStream(
+        dsl: DSL,
+        pageable: Pageable,
+        init: DSL.() -> JpqlQueryable<SelectQuery<T>>,
+    ): Stream<T> = getDelegate().findStream(dsl, pageable, init)
+
+    override fun <T : Any> update(init: Jpql.() -> JpqlQueryable<UpdateQuery<T>>): Int = getDelegate().update(init)
+
+    override fun <T : Any, DSL : JpqlDsl> update(
+        dsl: JpqlDsl.Constructor<DSL>,
+        init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
+    ): Int = getDelegate().update(dsl, init)
+
+    override fun <T : Any, DSL : JpqlDsl> update(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<UpdateQuery<T>>,
+    ): Int = getDelegate().update(dsl, init)
+
+    override fun <T : Any> delete(init: Jpql.() -> JpqlQueryable<DeleteQuery<T>>): Int = getDelegate().delete(init)
+
+    override fun <T : Any, DSL : JpqlDsl> delete(
+        dsl: JpqlDsl.Constructor<DSL>,
+        init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
+    ): Int = getDelegate().delete(dsl, init)
+
+    override fun <T : Any, DSL : JpqlDsl> delete(
+        dsl: DSL,
+        init: DSL.() -> JpqlQueryable<DeleteQuery<T>>,
+    ): Int = getDelegate().delete(dsl, init)
+}


### PR DESCRIPTION
# Motivation

In Spring Data JPA Boot 4 module (`support/spring-data-jpa-boot4`), when using Hibernate 7.3.3+ with Spring Boot 4, the `KotlinJdslJpqlExecutor` bean can cause circular dependency issues because `KotlinJdslJpaRepositoryFactoryBeanPostProcessor` eagerly resolves it during bean post-processing.

Additionally, under Kotlin 2.2 with `-Xjsr305=strict`, the `Page<T?>`, `Slice<T?>`, and `Stream<T?>` return types used in the original proxy implementation are rejected as "not within its bounds" because Spring Data's `@NonNullApi` enforces non-nullable type arguments.

This PR fixes #1087.

# Modifications

- **New file:** `KotlinJdslJpqlExecutorProxy.kt`  
  - Lazily resolves `kotlinJdslJpqlExecutor` via `BeanFactory` instead of eagerly injecting it.  
  - Return types adjusted to `Page<T>`, `Slice<T>`, `Stream<T>` (non-nullable) to match the Boot 4 interface.

- **Updated:** `KotlinJdslJpaRepositoryFactoryBeanPostProcessor.kt`  
  - Changed to inject `KotlinJdslJpqlExecutorProxy` instead of directly injecting the executor bean.

- **New test:** `KotlinJdslJpqlExecutorProxyTest.kt` in `example/spring-data-jpa-boot4`  
  - Integration test using `@SpringBootTest(classes = [Application::class])` that verifies proxy functionality with multiple repositories in a single test context.

# Commit Convention Rule

- `fix`: Fix bug (circular dependency and strict null-safety compatibility)

# Result

- Spring Data JPA Boot 4 users no longer encounter circular dependency issues on startup.
- `Page<T>`, `Slice<T>`, `Stream<T>` return types compile cleanly under `-Xjsr305=strict`.
- Verified with integration tests on JDK 21.

# Closes

- #1087
