### PR TITLE
fix(ci): use files instead of file in codecov-action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./build/reports/kover/report.xml
+          files: ./build/reports/kover/report.xml,./support/spring-data-jpa-boot4/build/reports/kover/report.xml,./support/spring-batch6/build/reports/kover/report.xml
       - name: Cleanup Gradle Cache
         run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
# Motivation

`codecov-action@v6` uses `file` as input key, but the valid input is `files`. This causes the following annotation warning in GitHub Actions:

> Unexpected input(s) 'file', valid inputs are [...] 'files' [...]

Additionally, `support/spring-data-jpa-boot4` and `support/spring-batch6` are separate Gradle builds, so their Kover coverage reports were not being uploaded to Codecov at all. This leads to incomplete coverage data.

# Modifications

- **Updated:** `.github/workflows/test.yaml`  
  - Changed `file` to `files` in `codecov-action` inputs.
  - Added `support/spring-data-jpa-boot4/build/reports/kover/report.xml` and `support/spring-batch6/build/reports/kover/report.xml` to the uploaded files list.

# Commit Convention Rule

- `fix(ci)`: Fix invalid codecov-action input key and include missing coverage reports

# Result

- GitHub Actions annotation warning disappears.
- Coverage reports for the root project, `spring-data-jpa-boot4`, and `spring-batch6` are all uploaded to Codecov.
