### PR TITLE
chore(build): suppress POM metadata warnings for test-fixtures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,8 @@ allprojects {
         publications {
             create<MavenPublication>("maven") {
                 from(components["java"])
+                suppressPomMetadataWarningsFor("testFixturesApiElements")
+                suppressPomMetadataWarningsFor("testFixturesRuntimeElements")
 
                 pom {
                     name.set(artifactId)


### PR DESCRIPTION
# Motivation

- After #1097 merge,  task emits warnings for every module using : "Maven publication 'maven' pom metadata warnings - Variant testFixturesApiElements cannot be mapped to Maven".
- This is expected behavior (Gradle variant capabilities don't map to Maven POM), but clutters build output.

# Modifications

- Add  and  to root  in 
- All modules automatically inherit this since publication config is in  block

# Result

- Type-safe project accessors is an incubating feature.
> Task :generatePomFileForMavenPublication
> Task :dsl:generatePomFileForMavenPublication
> Task :benchmark:generatePomFileForMavenPublication
> Task :eclipselink-example:generatePomFileForMavenPublication
> Task :example:generatePomFileForMavenPublication
> Task :eclipselink-support:generatePomFileForMavenPublication
> Task :eclipselink-javax-support:generatePomFileForMavenPublication
> Task :eclipselink-javax-example:generatePomFileForMavenPublication
> Task :hibernate-example:generatePomFileForMavenPublication
> Task :hibernate-javax-support:generatePomFileForMavenPublication
> Task :hibernate-javax-example:generatePomFileForMavenPublication
> Task :hibernate-reactive-support:generatePomFileForMavenPublication
> Task :hibernate-reactive-javax-support:generatePomFileForMavenPublication
> Task :jpql-dsl:generatePomFileForMavenPublication
> Task :hibernate-support:generatePomFileForMavenPublication
> Task :hibernate-reactive-javax-example:generatePomFileForMavenPublication
> Task :hibernate-reactive-example:generatePomFileForMavenPublication
> Task :jpql-query-model:generatePomFileForMavenPublication
> Task :query-model:generatePomFileForMavenPublication
> Task :render:generatePomFileForMavenPublication
> Task :jpql-render:generatePomFileForMavenPublication
> Task :spring-batch-javax-support:generatePomFileForMavenPublication
> Task :spring-batch-javax-example:generatePomFileForMavenPublication
> Task :spring-batch-support:generatePomFileForMavenPublication
> Task :spring-data-jpa-boot4-example:generatePomFileForMavenPublication
> Task :spring-batch-example:generatePomFileForMavenPublication
> Task :spring-batch6-support:generatePomFileForMavenPublication
> Task :spring-data-jpa-example:generatePomFileForMavenPublication
> Task :spring-batch6-example:generatePomFileForMavenPublication
> Task :spring-data-jpa-support:generatePomFileForMavenPublication
> Task :spring-data-jpa-javax-support:generatePomFileForMavenPublication
> Task :spring-data-jpa-javax-example:generatePomFileForMavenPublication
> Task :support:generatePomFileForMavenPublication
> Task :spring-data-jpa-boot4-support:generatePomFileForMavenPublication

BUILD SUCCESSFUL in 2s
34 actionable tasks: 34 executed
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html completes without warnings
- Publish metadata unchanged (test-fixtures info still present in  file for Gradle 6+ consumers)

# Closes

- Follow-up to #1097.