### PR TITLE
chore(build): suppress data-class copy-visibility warnings via compiler flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ allprojects {
     tasks.withType<KotlinCompile> {
         compilerOptions {
             freeCompilerArgs.add("-Xallow-kotlin-package")
+            freeCompilerArgs.add("-Xconsistent-data-class-copy-visibility")
         }
         jvmTargetValidationMode.set(JvmTargetValidationMode.ERROR)
     }


### PR DESCRIPTION
# Motivation

- After Kotlin 2.0 upgrade, data classes with internal/private constructors produce warnings
- This warning appears for 150+ files across the project, cluttering build output

# Modifications

- Add compiler flag to make copy() visibility consistent with constructor visibility
- No source files modified (cleaner than annotating 150+ data classes)

# Result

- ./gradlew compileKotlin completes without copy-visibility warnings
- Build behavior aligned with Kotlin 2.3 planned default

# Closes

- Follow-up to #1097
