### PR TITLE
fix(build): preserve existing git hooks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,32 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.nio.file.Files
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+fun resolveGitDirectory(gitMetadata: File): File? =
+    when {
+        gitMetadata.isDirectory -> gitMetadata
+        gitMetadata.isFile -> {
+            val worktreeGitDirectory = resolvePath(gitMetadata.readText().trim().removePrefix("gitdir: "), gitMetadata.parentFile)
+            val commonDirectory = File(worktreeGitDirectory, "commondir")
+
+            if (commonDirectory.isFile) {
+                resolvePath(commonDirectory.readText().trim(), worktreeGitDirectory)
+            } else {
+                worktreeGitDirectory
+            }
+        }
+        else -> null
+    }
+
+fun resolvePath(path: String, parent: File): File =
+    File(path).let {
+        if (it.isAbsolute) {
+            it
+        } else {
+            File(parent, path)
+        }
+    }
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -185,23 +211,20 @@ File("$projectDir/.githook").let { projectGitHookDir ->
         else -> "default"
     }
 
-    val gitHookDir = File("$projectDir/.git/hooks")
+    resolveGitDirectory(File(projectDir, ".git"))
+        ?.resolve("hooks")
+        ?.takeIf(File::isDirectory)
+        ?.let { gitHookDir ->
+            projectGitHookDir
+                .listFiles()
+                ?.filter {
+                    it.nameWithoutExtension.contains(suffix)
+                }?.forEach {
+                    val gitHook = File(gitHookDir, it.nameWithoutExtension.removeSuffix("-$suffix"))
 
-    gitHookDir
-        .listFiles()
-        ?.forEach {
-            it.deleteRecursively()
-        }
+                    Files.copy(it.toPath(), gitHook.toPath(), REPLACE_EXISTING)
 
-    projectGitHookDir
-        .listFiles()
-        ?.filter {
-            it.nameWithoutExtension.contains(suffix)
-        }?.forEach {
-            val gitHook = File(gitHookDir, it.nameWithoutExtension.removeSuffix("-$suffix"))
-
-            Files.copy(it.toPath(), gitHook.toPath())
-
-            gitHook.setExecutable(true)
+                    gitHook.setExecutable(true)
+                }
         }
 }


### PR DESCRIPTION
# Motivation

During Gradle configuration, the existing hook installer recursively deletes every entry in `.git/hooks` before installing Kotlin JDSL's `pre-commit` hook. This removes hooks installed by users and other tools.

The original `.git/hooks` path also does not resolve when the repository is used as a linked Git worktree, causing Gradle configuration to fail once the installer writes the hook.

# Modifications

- **Updated:** `build.gradle.kts`  
  - Resolve the common Git directory from either a standard `.git` directory or a linked-worktree `.git` file.
  - Preserve all existing hooks and replace only the platform-specific Kotlin JDSL `pre-commit` hook.
  - Use `REPLACE_EXISTING` when updating that managed hook.

# Commit Convention Rule

- `fix(build)`: Preserve existing Git hooks while installing the managed pre-commit hook.

# Result

- Gradle configuration no longer deletes hooks that Kotlin JDSL does not manage.
- Hook installation works for both standard clones and linked Git worktrees.
- The platform-specific Kotlin JDSL `pre-commit` hook remains updated on each Gradle configuration.
