### PR TITLE
fix(build): preserve existing git hooks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,32 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.nio.file.Files
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+fun resolveGitDirectory(gitMetadata: File): File? =
+    when {
+        gitMetadata.isDirectory -> gitMetadata
+        gitMetadata.isFile -> {
+            val worktreeGitDirectory = resolvePath(gitMetadata.readText().trim().removePrefix("gitdir: "), gitMetadata.parentFile)
+            val commonDirectory = File(worktreeGitDirectory, "commondir")
+
+            if (commonDirectory.isFile) {
+                resolvePath(commonDirectory.readText().trim(), worktreeGitDirectory)
+            } else {
+                worktreeGitDirectory
+            }
+        }
+        else -> null
+    }
+
+fun resolvePath(path: String, parent: File): File =
+    File(path).let {
+        if (it.isAbsolute) {
+            it
+        } else {
+            File(parent, path)
+        }
+    }
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -185,23 +211,20 @@ File("$projectDir/.githook").let { projectGitHookDir ->
         else -> "default"
     }
 
-    val gitHookDir = File("$projectDir/.git/hooks")
+    resolveGitDirectory(File(projectDir, ".git"))
+        ?.resolve("hooks")
+        ?.takeIf(File::isDirectory)
+        ?.let { gitHookDir ->
+            projectGitHookDir
+                .listFiles()
+                ?.filter {
+                    it.nameWithoutExtension.contains(suffix)
+                }?.forEach {
+                    val gitHook = File(gitHookDir, it.nameWithoutExtension.removeSuffix("-$suffix"))
 
-    gitHookDir
-        .listFiles()
-        ?.forEach {
-            it.deleteRecursively()
-        }
+                    Files.copy(it.toPath(), gitHook.toPath(), REPLACE_EXISTING)
 
-    projectGitHookDir
-        .listFiles()
-        ?.filter {
-            it.nameWithoutExtension.contains(suffix)
-        }?.forEach {
-            val gitHook = File(gitHookDir, it.nameWithoutExtension.removeSuffix("-$suffix"))
-
-            Files.copy(it.toPath(), gitHook.toPath())
-
-            gitHook.setExecutable(true)
+                    gitHook.setExecutable(true)
+                }
         }
 }


### PR DESCRIPTION
# Motivation

- During Gradle configuration, the hook installer recursively deletes every entry in `.git/hooks` before installing Kotlin JDSL's `pre-commit` hook. This removes hooks installed by users and other tools.
- The `.git/hooks` path does not resolve for linked Git worktrees, so hook installation fails when Gradle attempts to write the managed hook.

# Modifications

- **Safe hook installation**:
  - Resolve the common Git directory for both standard clones and linked Git worktrees.
  - Preserve every existing hook except the platform-specific Kotlin JDSL `pre-commit` hook managed by this build.
  - Replace that managed hook with `REPLACE_EXISTING`.

# Commit Convention Rule

- `fix(build)`: Preserve existing Git hooks while installing the managed pre-commit hook.

# Result

- Gradle configuration no longer deletes hooks that Kotlin JDSL does not manage.
- Hook installation succeeds for standard clones and linked Git worktrees.
- The platform-specific Kotlin JDSL `pre-commit` hook remains current.

--- korean

# Motivation

- Gradle 구성 과정에서 Kotlin JDSL의 `pre-commit` hook을 설치하기 전에 `.git/hooks`의 모든 항목을 재귀적으로 삭제하고 있었습니다. 이로 인해 사용자 또는 다른 도구가 설치한 hook이 삭제됩니다.
- Linked Git worktree에서는 `.git/hooks` 경로를 해석할 수 없어 Gradle이 관리 hook을 기록할 때 설치가 실패합니다.

# Modifications

- **안전한 hook 설치**:
  - 일반 clone과 linked Git worktree 모두에서 공통 Git 디렉터리를 해석하도록 변경했습니다.
  - 이 빌드가 관리하는 플랫폼별 Kotlin JDSL `pre-commit` hook 이외의 모든 기존 hook을 보존합니다.
  - 관리 대상 hook은 `REPLACE_EXISTING` 옵션으로 교체합니다.

# Commit Convention Rule

- `fix(build)`: 관리 대상 pre-commit hook 설치 시 기존 Git hook을 보존합니다.

# Result

- Gradle 구성은 Kotlin JDSL이 관리하지 않는 hook을 더 이상 삭제하지 않습니다.
- 일반 clone과 linked Git worktree에서 hook 설치가 모두 성공합니다.
- 플랫폼별 Kotlin JDSL `pre-commit` hook은 최신 상태로 유지됩니다.
