### PR TITLE
fix(build): replace deprecated Gradle property delegates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,11 +75,11 @@ allprojects {
         withJavadocJar()
     }
 
-    signing {
-        val signingKeyId: String? by project
-        val signingKey: String? by project
-        val signingPassword: String? by project
+    val signingKeyId = providers.gradleProperty("signingKeyId").orNull
+    val signingKey = providers.gradleProperty("signingKey").orNull
+    val signingPassword = providers.gradleProperty("signingPassword").orNull
 
+    signing {
         if (signingKey != null) {
             useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
             sign(publishing.publications)
@@ -160,14 +160,14 @@ kover {
     }
 }
 
+val sonatypeUsername = providers.gradleProperty("sonatypeUsername").orNull
+val sonatypePassword = providers.gradleProperty("sonatypePassword").orNull
+
 nexusPublishing {
     repositories {
         sonatype {
             nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
             snapshotRepositoryUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
-
-            val sonatypeUsername: String? by project
-            val sonatypePassword: String? by project
 
             username = sonatypeUsername
             password = sonatypePassword


### PR DESCRIPTION
# Motivation

- Gradle 9.6 reports `Project.provideDelegate` as deprecated when the build reads optional signing and Sonatype credentials.
- The deprecated property delegate API is scheduled to become incompatible with Gradle 10.

# Modifications

- **Provider API migration**:
  - Replaced optional signing property delegates with `providers.gradleProperty(...).orNull`.
  - Replaced optional Sonatype credential property delegates with the same Provider API lookup.
  - Preserved the existing behavior: signing remains disabled when no signing key is configured, and absent Sonatype credentials remain `null`.

# Commit Convention Rule

- `fix(build)`: Replace deprecated Gradle property delegates.

# Result

- Kotlin JDSL no longer emits the deprecated `Project.provideDelegate` warning for signing and Sonatype properties.
- The build remains compatible with Gradle 10 migration requirements.

--- korean

# Motivation

- Gradle 9.6에서 선택적 signing 및 Sonatype 자격 증명을 읽을 때 `Project.provideDelegate` deprecation 경고가 발생합니다.
- 해당 property delegate API는 Gradle 10에서 호환되지 않을 예정입니다.

# Modifications

- **Provider API 전환**:
  - 선택적 signing 속성 조회를 `providers.gradleProperty(...).orNull`로 교체했습니다.
  - 선택적 Sonatype 자격 증명 속성 조회도 동일한 Provider API로 교체했습니다.
  - 기존 동작을 유지했습니다. signing key가 없으면 signing은 비활성화되고, Sonatype 자격 증명이 없으면 `null`로 유지됩니다.

# Commit Convention Rule

- `fix(build)`: Deprecated Gradle property delegate를 교체합니다.

# Result

- Kotlin JDSL은 signing 및 Sonatype 속성에 대해 더 이상 deprecated `Project.provideDelegate` 경고를 출력하지 않습니다.
- 빌드는 Gradle 10 마이그레이션 요구사항과 호환됩니다.
