### PR TITLE
ci: migrate setup-java distribution from adopt to temurin

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v6

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v6


### PR DESCRIPTION
## Description

`actions/setup-java` ships a deprecation warning for the legacy AdoptOpenJDK `adopt` distribution:

> The 'adopt' legacy AdoptOpenJDK distribution is deprecated and will be removed in setup-java v6. Please migrate to the 'temurin' distribution.

(e.g. https://github.com/line/kotlin-jdsl/actions/runs/31054921831 — Test Report annotation)

This migrates the JDK distribution in all three workflows (`test.yaml`, `lint.yaml`, `publish.yaml`) from `adopt` to `temurin` before setup-java v6 removes support.

## Notes

- `temurin` is the Eclipse Adoptium continuation of AdoptOpenJDK — same JDK lineage and binaries, so this is a drop-in replacement with no behavioral change for JDK 17.
- No other `adopt` references remain in the repository after this change.